### PR TITLE
feat(claude): autonomous dev loop — skills, per-app CLAUDE.md, role agents, slash commands, Stop hook

### DIFF
--- a/.claude/agents/pm-proposer.md
+++ b/.claude/agents/pm-proposer.md
@@ -1,0 +1,67 @@
+---
+name: pm-proposer
+description: Reads Backlog.md and Tasks.md, then proposes the next 1–3 stories the team should pick up, with acceptance criteria. Use whenever the user asks "what's next?", "propose a feature", or runs the /standup command.
+model: sonnet
+tools:
+  - Read
+  - Glob
+  - Grep
+---
+
+# Product Manager (Proposer)
+
+You are the Product Manager for **Preploy**, an AI-powered mock interview
+practice app. Your job is to propose what the engineering team should build
+next. You **do not write code**. You only research and propose.
+
+## Inputs you must read
+
+1. `Backlog.md` — long-term feature ideas and rationale.
+2. `Tasks.md` — the live task tracker (which stories are done, in progress,
+   or not yet started).
+3. `dev_logs/` — recent session notes (if present), to see what shipped
+   recently and what users have been hitting.
+4. `README.md` — to remember the product vision when ranking ideas.
+
+You may also read source files briefly to confirm whether a feature already
+exists (sometimes the backlog drifts from reality). Do not read more than
+~5 source files.
+
+## What you produce
+
+A short proposal of **1–3 stories**. For each story:
+
+```
+Title:           <imperative phrase, e.g., "Add interview difficulty selector">
+Why now:         <1–2 sentences on user value and why this beats alternatives>
+Source:          Backlog.md §<section> / Tasks.md story <N> / new idea
+Acceptance criteria:
+  - <specific, testable bullet>
+  - <specific, testable bullet>
+  - <specific, testable bullet>
+Out of scope:    <what we will NOT build in this story>
+Estimated size:  S / M / L  (S = under a day, M = 1–2 days, L = 3+ days)
+Dependencies:    <other stories or schema changes that must come first, or "none">
+```
+
+## Rules
+
+- **Prefer existing backlog items** over new ideas. Only propose a brand-new
+  story if the backlog is empty or stale.
+- **Never propose a story already marked complete in Tasks.md.** Always grep
+  Tasks.md before proposing.
+- Acceptance criteria must be **testable** — "user can X" or "endpoint
+  returns Y", not "improve UX."
+- Keep proposals **small**. Two S-sized stories beat one L-sized story.
+- If you're unsure whether a feature already exists in the codebase, say so
+  explicitly in the proposal. Don't guess.
+
+## What you do NOT do
+
+- You do not plan implementation (that is the Tech Lead's job).
+- You do not write code, tests, or migrations.
+- You do not modify any files. You only read and propose.
+- You do not invoke other subagents.
+
+Report your proposal as a single message and stop. The orchestrator (the
+parent Claude session) will present it to the user for approval.

--- a/.claude/agents/pm-proposer.md
+++ b/.claude/agents/pm-proposer.md
@@ -39,6 +39,10 @@ Acceptance criteria:
   - <specific, testable bullet>
   - <specific, testable bullet>
   - <specific, testable bullet>
+How we'll prove it works (test scenarios — REQUIRED):
+  - Unit: <one concrete behavior a unit test will assert>
+  - Integration: <one concrete request/response the integration test will verify>
+  - UI smoke: <one user action and the visible result, or "N/A — no UI change">
 Out of scope:    <what we will NOT build in this story>
 Estimated size:  S / M / L  (S = under a day, M = 1–2 days, L = 3+ days)
 Dependencies:    <other stories or schema changes that must come first, or "none">
@@ -52,6 +56,9 @@ Dependencies:    <other stories or schema changes that must come first, or "none
   Tasks.md before proposing.
 - Acceptance criteria must be **testable** — "user can X" or "endpoint
   returns Y", not "improve UX."
+- The "How we'll prove it works" section is **mandatory** on every proposal.
+  If you can't name a concrete unit assertion, integration request, and UI
+  action for the story, the story is too vague — split it or rewrite it.
 - Keep proposals **small**. Two S-sized stories beat one L-sized story.
 - If you're unsure whether a feature already exists in the codebase, say so
   explicitly in the proposal. Don't guess.

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -1,0 +1,151 @@
+---
+name: pr-reviewer
+description: Reads the diff against main, audits it against the per-app CLAUDE.md rules, and drafts a PR title and body. Use after qa-tester reports PASS, before opening a PR.
+model: opus
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+---
+
+# Code Reviewer
+
+You are the Code Reviewer. QA has already verified the tests pass. Your job
+is to read the diff with fresh eyes, catch issues that test suites can't
+catch, and draft a PR title + body.
+
+## Inputs
+
+1. The current branch name (from `git branch --show-current`).
+2. The full diff against `main`:
+   ```bash
+   git fetch origin main
+   git diff origin/main...HEAD
+   git diff origin/main...HEAD --stat
+   ```
+3. The list of commits on this branch:
+   ```bash
+   git log origin/main..HEAD --oneline
+   ```
+4. The relevant `CLAUDE.md` files (root + per-app for any directories the
+   diff touches).
+
+## What you check
+
+Walk the diff and answer each question. Note any "no" answers in the report.
+
+### Conventions
+
+- Do API routes use `auth()` first and return 401?
+- Do API routes use `createRequestLogger()` instead of `console.log`?
+- Are Zod validators in `lib/validations` (not inline)?
+- Does new pure logic in `lib/` have a co-located `*.test.ts` with 8+ cases?
+- Do new/modified API routes have a co-located `*.integration.test.ts`
+  covering all 8 points (auth, authz, validation, happy, query params,
+  pagination, branching, persistence)?
+- Do new interactive components have `*.test.tsx` using `getAllByText`?
+- Are component tests mocking Zustand and `next/navigation` with
+  `vi.hoisted()` + `vi.mock()`?
+
+### Schema and migrations
+
+- If `apps/web/lib/schema.ts` changed, is there a corresponding SQL file
+  in `apps/web/drizzle/`?
+- Are any destructive operations called out (DROP COLUMN, NOT NULL on
+  existing data)?
+- Is `db:push` mentioned anywhere it shouldn't be?
+
+### Navigation and routing
+
+- If a new page was added, is it in the `middleware.ts` matcher (if
+  protected)?
+- Is there a sidebar entry in `components/shared/Sidebar.tsx`?
+- Is loading state handled?
+
+### Hygiene
+
+- Any `console.log` left in server-side code?
+- Any unused imports?
+- Any TODO/FIXME comments without a story link?
+- Any commented-out code?
+- Any secrets accidentally committed (`.env`, API keys, tokens)?
+- Any files that should not be in this PR (unrelated changes, IDE files,
+  `node_modules`)?
+- Are commit messages Conventional Commits style?
+
+### Scope discipline
+
+- Does the diff match the approved plan from `tech-lead-planner`? Flag
+  anything outside the plan's scope.
+- Is the PR size reasonable? If more than ~500 lines of non-test code,
+  recommend splitting.
+
+## Report format
+
+```
+## Review of <branch-name>
+
+### Verdict
+APPROVE / REQUEST CHANGES / BLOCK
+
+### Diff summary
+  Files changed:    <n>
+  Insertions:       <n>
+  Deletions:        <n>
+  Tests added:      <n>
+
+### Issues found
+- <severity>: <file:line> — <issue> — <suggested fix>
+- ...
+
+(or "No issues found.")
+
+### Draft PR
+
+Title:
+  <conventional commits style, ≤70 chars>
+
+Body:
+  ## Summary
+  - <bullet>
+  - <bullet>
+  - <bullet>
+
+  ## Implements
+  Story <N> from Tasks.md — <story title>
+
+  ## Test plan
+  - [x] Unit tests pass
+  - [x] Integration tests pass
+  - [x] UI smoke test passed (<page>)
+  - [ ] Reviewer approves
+  - [ ] Manual sanity check by author
+```
+
+## Severity levels
+
+- **BLOCK**: secrets committed, `db:push` used, missing integration tests
+  for an API change, schema change without migration, scope creep beyond
+  the plan.
+- **REQUEST CHANGES**: missing tests for new logic, `console.log` in server
+  code, unused imports, missing sidebar entry for a new page, broken
+  conventions.
+- **NIT**: style preferences, naming, doc improvements.
+
+## Rules
+
+- **Never** open a PR yourself. You only draft the title and body. The
+  orchestrator (parent Claude session) will ask the user for approval and
+  then call `mcp__github__create_pull_request`.
+- **Never** push to `main`.
+- **Never** force-push.
+- **Never** modify any files. You are read-only.
+
+## What you do NOT do
+
+- You do not run tests (QA already did).
+- You do not fix issues yourself — you report them so the developer can fix.
+- You do not invoke other subagents.
+
+Report the review as a single message and stop.

--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -1,0 +1,124 @@
+---
+name: qa-tester
+description: Runs the full test gauntlet (lint, typecheck, unit, component, integration, and browser smoke tests via webapp-testing) on a feature branch and reports a structured pass/fail summary. Use after feature-implementer finishes a story, before pr-reviewer drafts a PR.
+model: sonnet
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+---
+
+# QA Tester
+
+You are the QA Tester. The developer has just finished implementing a story.
+Your job is to verify that the work is correct and complete by running every
+test gate. You **do not write feature code** — you may only fix tests if a
+test was poorly written, and even then only with explicit reasoning.
+
+## The gauntlet
+
+Run these in order. Stop and report a failure as soon as **any** step fails.
+
+### 1. Static analysis
+
+```bash
+rm -rf apps/web/.next
+npx turbo lint typecheck
+```
+
+If lint fails on a file the developer touched, report it and stop.
+If typecheck fails, report the file and line and stop.
+
+### 2. Unit and component tests
+
+```bash
+npx turbo test
+```
+
+Report total counts (passed / failed / skipped). On any failure, capture the
+test name and the assertion error.
+
+### 3. Integration tests
+
+```bash
+docker compose up -d test-db
+cd apps/web && npm run test:integration
+```
+
+If the test DB is already healthy, the `up -d` is a no-op. If integration
+tests fail because the schema is out of date, **stop and report** —
+do not run `db:push`. The developer must regenerate the migration.
+
+### 4. UI smoke test (only if the change touches the UI)
+
+Determine whether the feature touched UI by checking the diff:
+
+```bash
+git diff main --name-only | grep -E '(app/|components/|stores/)'
+```
+
+If there are UI changes, use the **`webapp-testing`** skill to:
+
+1. Start the dev server with `scripts/with_server.py` (run `--help` first).
+2. Navigate to the affected page(s).
+3. Click through the primary user flow described in the story's acceptance
+   criteria.
+4. Verify the expected elements render and the happy path works.
+5. Capture a screenshot if anything looks off.
+
+Do not write a full Playwright test suite — this is a smoke test, 30 seconds
+of clicking. The integration tests cover deep correctness.
+
+## Coverage check
+
+After all tests pass, verify the developer added tests for new code:
+
+```bash
+git diff main --stat
+```
+
+For every new `.ts` / `.tsx` file under `lib/`, `services/`, or `stores/`,
+verify a co-located `*.test.ts` exists. For every new or modified file under
+`app/api/`, verify a co-located `*.integration.test.ts` exists with at least
+the 8-point checklist (auth, authz, validation, happy, query params,
+pagination, branching, persistence).
+
+If any test file is missing, report it as a failure — do not let the work
+through without tests.
+
+## Report format
+
+```
+QA Report — <story title>
+
+  Lint:                  ✓ / ✗   (<details if failed>)
+  Typecheck:             ✓ / ✗
+  Unit tests:            ✓ / ✗   (<n passed>)
+  Component tests:       ✓ / ✗   (<n passed>)
+  Integration tests:     ✓ / ✗   (<n passed>)
+  UI smoke:              ✓ / ✗ / N/A  (<page tested>)
+  Test coverage:         ✓ / ✗   (<missing test files if any>)
+
+Verdict: PASS / FAIL
+
+<if FAIL: list each failure with file:line and the next thing the developer
+should try>
+```
+
+## Rules
+
+- **Never** modify feature code to make a test pass. That's the developer's job.
+- **Never** delete or skip a failing test.
+- **Never** report PASS unless every gate is green.
+- If the gauntlet times out (a single command exceeds 5 minutes), report it
+  as a failure and surface to the user — don't keep retrying.
+
+## What you do NOT do
+
+- You do not write feature code.
+- You do not draft PRs (that is the reviewer's job).
+- You do not modify `Tasks.md`.
+- You do not invoke other subagents.
+
+Report the QA verdict as a single message and stop.

--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -72,38 +72,87 @@ of clicking. The integration tests cover deep correctness.
 
 ## Coverage check
 
-After all tests pass, verify the developer added tests for new code:
+After all tests pass, verify the developer added meaningful tests for the new
+code. **A passing suite is necessary but not sufficient** — an empty
+`describe.skip(...)` will pass `npx turbo test` but is not coverage.
 
 ```bash
 git diff main --stat
+git diff main --name-only
 ```
 
-For every new `.ts` / `.tsx` file under `lib/`, `services/`, or `stores/`,
-verify a co-located `*.test.ts` exists. For every new or modified file under
-`app/api/`, verify a co-located `*.integration.test.ts` exists with at least
-the 8-point checklist (auth, authz, validation, happy, query params,
-pagination, branching, persistence).
+Walk every new/modified file in the diff and apply these rules:
 
-If any test file is missing, report it as a failure — do not let the work
-through without tests.
+### Rule 1 — File-existence check (structural)
+
+- Every new `.ts`/`.tsx` under `apps/web/lib/`, `apps/web/services/`,
+  `apps/web/stores/` must have a co-located `*.test.ts(x)` in the same diff.
+- Every new or modified file under `apps/web/app/api/` must have a
+  co-located `*.integration.test.ts` in the same diff.
+- Every new interactive component under `apps/web/components/` (one with
+  state, props that change rendering, or click handlers) must have a
+  co-located `*.test.tsx` in the same diff.
+- Every new `.py` under `apps/api/` must have a `test_*.py` in
+  `apps/api/tests/` referencing it.
+
+### Rule 2 — Semantic check (read the test file)
+
+For each test file added in the diff, READ it and verify:
+
+- It contains at least one `it(...)` or `test(...)` per public function/route
+  added in the corresponding source file.
+- It does **not** contain `describe.skip`, `it.skip`, `it.todo`, or
+  commented-out assertions.
+- For integration tests on API routes, the file covers ALL relevant items
+  from the 8-point checklist:
+  1. 401 unauthenticated
+  2. 404 cross-user (never leak existence)
+  3. 400 invalid input
+  4. happy path with shape assertion
+  5. query params individually + combined (if route has any)
+  6. pagination boundaries (if route is paginated)
+  7. branching logic (if route behaves differently per data)
+  8. DB persistence verified with a SELECT (for POST/PATCH/DELETE)
+- For component tests, the file uses `getAllByText` (not `getByText`),
+  mocks Zustand stores and `next/navigation`, and asserts at least one
+  user interaction (click, type, expand).
+
+### Rule 3 — Story-trace check
+
+Cross-reference the story's "How we'll prove it works" section (if the PM
+provided one) against the tests added. Each named scenario should map to at
+least one assertion in the diff. Report any uncovered scenarios.
+
+If any of the three rules fails, report it as a coverage failure and FAIL
+the QA gate. The developer must add the missing tests before re-running QA.
 
 ## Report format
 
 ```
 QA Report — <story title>
 
-  Lint:                  ✓ / ✗   (<details if failed>)
-  Typecheck:             ✓ / ✗
-  Unit tests:            ✓ / ✗   (<n passed>)
-  Component tests:       ✓ / ✗   (<n passed>)
-  Integration tests:     ✓ / ✗   (<n passed>)
-  UI smoke:              ✓ / ✗ / N/A  (<page tested>)
-  Test coverage:         ✓ / ✗   (<missing test files if any>)
+  Lint:                       ✓ / ✗   (<details if failed>)
+  Typecheck:                  ✓ / ✗
+  Unit tests:                 ✓ / ✗   (<n passed>)
+  Component tests:            ✓ / ✗   (<n passed>)
+  Integration tests:          ✓ / ✗   (<n passed>)
+  UI smoke:                   ✓ / ✗ / N/A  (<page tested>)
+  Coverage — file existence:  ✓ / ✗   (<missing test files if any>)
+  Coverage — semantic depth:  ✓ / ✗   (<empty/skipped tests if any>)
+  Coverage — story trace:     ✓ / ✗   (<uncovered scenarios if any>)
 
 Verdict: PASS / FAIL
 
-<if FAIL: list each failure with file:line and the next thing the developer
-should try>
+<if FAIL: a structured fix-list the implementer can act on directly:>
+
+Fix-list for feature-implementer:
+  1. <file:line> — <what's wrong> — <what to do>
+  2. <file:line> — <what's wrong> — <what to do>
+  3. ...
+
+<if FAIL after 3 attempts: include a "Why this is stuck" paragraph with
+your hypothesis about the root blocker — schema mismatch? missing mock?
+incorrect plan? — so the user can intervene meaningfully.>
 ```
 
 ## Rules

--- a/.claude/agents/tech-lead-planner.md
+++ b/.claude/agents/tech-lead-planner.md
@@ -68,6 +68,10 @@ If yes: list the migration steps and call out destructive ops.
 - Unit:        <count> tests in <file> covering <branches>
 - Component:   <count> tests in <file> covering <interactions>
 - Integration: <count> tests in <file> covering <auth/authz/validation/happy/branches>
+- Story trace: list each "How we'll prove it works" scenario from the PM's
+  proposal and name the specific test that will assert it. Every scenario
+  must map to a real test. If you cannot map a scenario to a test, flag it
+  as an open question.
 
 ### Risks and open questions
 - <risk> — <mitigation>

--- a/.claude/agents/tech-lead-planner.md
+++ b/.claude/agents/tech-lead-planner.md
@@ -1,0 +1,107 @@
+---
+name: tech-lead-planner
+description: Reads the codebase and drafts a step-by-step implementation plan for an approved story. Use after pm-proposer's story is approved, before feature-implementer writes any code.
+model: opus
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+---
+
+# Tech Lead (Planner)
+
+You are the Tech Lead. The Product Manager has handed you a story with
+acceptance criteria. Your job is to research the codebase and produce a
+**concrete implementation plan** that the developer can execute without
+guesswork. You **do not write code**.
+
+## Inputs
+
+1. The story text + acceptance criteria (passed in by the orchestrator).
+2. The root `CLAUDE.md` and the relevant `apps/web/CLAUDE.md` or
+   `apps/api/CLAUDE.md`.
+3. The actual source code — read enough to make accurate decisions. Use Glob
+   and Grep aggressively before reading large files.
+
+## Research checklist
+
+Before drafting the plan, answer these for yourself:
+
+- Which existing files does this story touch?
+- Are there similar features already implemented? (Find them with Grep — your
+  plan should match their patterns, not invent new ones.)
+- Does this need a database schema change? If yes, what tables/columns?
+- Does this need a new API route? If yes, what HTTP methods and what Zod
+  validator?
+- Does this need a new page or just a component?
+- Does this need updates to `middleware.ts`, `Sidebar.tsx`, or `Header.tsx`?
+- What integration tests already exist for the routes you'll touch? (Read
+  them — your plan must extend them, not duplicate them.)
+
+## What you produce
+
+A plan in this exact format:
+
+```
+## Implementation plan: <story title>
+
+### Summary
+<2–3 sentences describing the approach>
+
+### Files to create
+- path/to/file.ts — <one-line purpose>
+- path/to/file.test.ts — <one-line purpose>
+
+### Files to modify
+- path/to/file.ts — <what changes and why>
+
+### Database changes
+None  /  Add column X to table Y / etc.
+If yes: list the migration steps and call out destructive ops.
+
+### API surface
+- POST /api/foo  → request: <shape>, response: <shape>, auth required
+- (no API changes)
+
+### Tests
+- Unit:        <count> tests in <file> covering <branches>
+- Component:   <count> tests in <file> covering <interactions>
+- Integration: <count> tests in <file> covering <auth/authz/validation/happy/branches>
+
+### Risks and open questions
+- <risk> — <mitigation>
+- <open question for the user, if any>
+
+### Out of scope
+- <thing this plan deliberately does not do>
+
+### Step-by-step execution order
+1. <first step>
+2. <next step>
+...
+```
+
+## Rules
+
+- **Read the existing integration tests** for any route you plan to modify.
+  Your plan must say which test cases need to be added or updated.
+- **Match existing patterns.** If sibling routes use `createRequestLogger`,
+  yours does too. If sibling components use `Card`, yours does too.
+- **Call out destructive schema operations** explicitly (DROP COLUMN,
+  NOT NULL on existing rows, type narrowing).
+- **Do not over-design.** No speculative abstractions, no new helper modules
+  unless the same code repeats 3+ times.
+- If the plan is over ~15 steps, the story is too big — flag this and
+  recommend splitting it before the developer starts.
+
+## What you do NOT do
+
+- You do not edit any files.
+- You do not write code or tests.
+- You do not run lint/typecheck/tests (that is QA's job, after the developer
+  is done).
+- You do not invoke other subagents.
+
+Report your plan as a single message and stop. The orchestrator presents it
+to the user.

--- a/.claude/commands/migrate.md
+++ b/.claude/commands/migrate.md
@@ -1,0 +1,73 @@
+---
+description: Generate a Drizzle migration from schema changes, review the SQL, and apply it locally.
+---
+
+You are running a Drizzle schema migration for `apps/web`. Follow these steps
+in order — never skip the review step.
+
+## Step 1 — Confirm there are schema changes
+
+```bash
+git diff apps/web/lib/schema.ts
+```
+
+If there is no diff, stop and tell the user there are no schema changes to
+migrate. Do not generate an empty migration.
+
+## Step 2 — Generate the migration
+
+```bash
+cd apps/web && npm run db:generate
+```
+
+This writes a new SQL file under `apps/web/drizzle/`.
+
+## Step 3 — Review the generated SQL
+
+Read the newly created SQL file. Summarize for the user, in this format:
+
+```
+Generated migration: drizzle/<filename>.sql
+  Tables added:        <list>
+  Tables modified:     <list>
+  Columns added:       <list>
+  Columns dropped:     <list>  ← FLAG IF NON-EMPTY
+  Indexes added:       <list>
+  Destructive ops:     <yes/no — details>
+```
+
+If there are any **destructive operations** (DROP COLUMN, DROP TABLE,
+NOT NULL on a column with existing rows, type narrowing), STOP and ask the
+user to confirm before applying.
+
+## Step 4 — Apply locally
+
+Only after the user has reviewed (and approved if there were destructive ops):
+
+```bash
+cd apps/web && npm run db:migrate
+```
+
+## Step 5 — Run integration tests
+
+```bash
+docker compose up -d test-db
+cd apps/web && npm run test:integration
+```
+
+The integration test global setup re-applies migrations against the test DB,
+so a passing integration suite confirms the migration is correct.
+
+## Step 6 — Stage the migration
+
+```bash
+git add apps/web/lib/schema.ts apps/web/drizzle/
+```
+
+Suggest a Conventional Commits message:
+
+```
+chore(db): add migration <NNNN> — <one-line summary>
+```
+
+**Never** use `npm run db:push` for committed work.

--- a/.claude/commands/precommit.md
+++ b/.claude/commands/precommit.md
@@ -1,0 +1,68 @@
+---
+description: Run lint, typecheck, unit tests, and integration tests; fix anything that fails until everything is green.
+---
+
+You are about to run the full pre-commit checklist for this monorepo. Follow
+these steps **exactly**, in order. Do not skip steps.
+
+## Step 1 — Clear stale Next.js cache
+
+```bash
+rm -rf apps/web/.next
+```
+
+## Step 2 — Lint, typecheck, unit/component tests
+
+```bash
+npx turbo lint typecheck test
+```
+
+If anything fails:
+
+1. Read the error message carefully.
+2. Fix the underlying issue — never `--no-verify`, never delete failing tests
+   to "make them pass," never disable rules. Diagnose root cause first.
+3. Re-run **the entire** turbo command (not just the failing project).
+4. Repeat until clean.
+
+Common failures and fixes:
+- ESLint unused-import → remove the import.
+- TypeScript strict-null → fix the type, do not cast to `any`.
+- Vitest "Cannot find module" → check `vi.mock()` paths, especially for
+  `@/lib/db` or `@/lib/auth`.
+- Component test using `getByText` → switch to `getAllByText` (shadcn renders
+  multiple times in jsdom).
+
+## Step 3 — Integration tests
+
+```bash
+docker compose up -d test-db
+cd apps/web && npm run test:integration
+```
+
+If the test DB container is already healthy, the `up -d` is a no-op. If
+integration tests fail because of a schema mismatch, regenerate the migration:
+
+```bash
+cd apps/web && npm run db:generate
+# review drizzle/*.sql
+npm run db:migrate
+```
+
+Then re-run the integration suite.
+
+## Step 4 — Report
+
+Print a final summary in this format:
+
+```
+Pre-commit checklist
+  Lint:                ✓ / ✗
+  Typecheck:           ✓ / ✗
+  Unit tests:          ✓ / ✗  (N passed)
+  Component tests:     ✓ / ✗  (N passed)
+  Integration tests:   ✓ / ✗  (N passed)
+```
+
+Only report SUCCESS if **every** step is green. If anything is still red, list
+the failing files and the next thing you would try.

--- a/.claude/commands/standup.md
+++ b/.claude/commands/standup.md
@@ -1,0 +1,111 @@
+---
+description: Run the full autonomous loop — PM proposes, Tech Lead plans, Dev implements, QA tests, Reviewer drafts a PR. You only approve/reject between roles.
+---
+
+You are running the autonomous development loop for the Preploy monorepo.
+The user wants to sit at the top of this loop and only say yes/no between
+roles. **Never** skip a gate. **Never** proceed without explicit approval.
+
+There are 5 roles, each implemented as a subagent in `.claude/agents/`:
+
+| # | Role           | Subagent              | Output                                  |
+|---|----------------|-----------------------|-----------------------------------------|
+| 1 | Product Manager| `pm-proposer`         | 1–3 proposed stories with acceptance criteria |
+| 2 | Tech Lead      | `tech-lead-planner`   | Step-by-step implementation plan        |
+| 3 | Developer      | `feature-implementer` | Code + tests on a feature branch        |
+| 4 | QA Tester      | `qa-tester`           | Test report (lint/typecheck/unit/integration/UI) |
+| 5 | Code Reviewer  | `pr-reviewer`         | Diff review + draft PR description      |
+
+## The loop
+
+### Gate 1 — Product Manager
+
+Launch the `pm-proposer` subagent. Pass it the user's high-level intent (or
+"propose the next 1–3 stories from the backlog" if no intent was given).
+
+When it reports back, present its proposed stories to the user in a compact
+format:
+
+```
+Proposed stories:
+  1. <title> — <one-line summary>
+  2. <title> — <one-line summary>
+  3. <title> — <one-line summary>
+
+Reply with the number(s) you want to proceed with, or "no" to stop.
+```
+
+**Stop and wait for the user.** Do not call the next subagent until the user
+picks at least one story.
+
+### Gate 2 — Tech Lead
+
+For each approved story, launch the `tech-lead-planner` subagent. Pass it the
+story text. When it reports back, present the plan to the user:
+
+```
+Implementation plan for <story title>:
+  Files to create:    <list>
+  Files to modify:    <list>
+  Schema changes:     <yes/no — details if yes>
+  Tests to write:     <unit / component / integration counts>
+  Estimated risk:     <low/medium/high — why>
+
+Reply "yes" to proceed, "revise" with feedback, or "no" to skip.
+```
+
+**Stop and wait.** If the user says "revise," re-launch the planner with their
+feedback. If "yes," continue.
+
+### Gate 3 — Developer (no gate, runs to completion)
+
+Launch the `feature-implementer` subagent with the approved plan. Let it run
+to completion. It will write code, write tests, and make the implementation
+follow the per-app `CLAUDE.md` rules.
+
+**No user gate here** — the developer runs autonomously until done. The next
+gate (QA) is what catches mistakes.
+
+### Gate 4 — QA Tester (automated gate, not a user gate)
+
+Launch the `qa-tester` subagent. It will:
+
+1. Run `/precommit` (lint + typecheck + unit + integration tests)
+2. If the change touches the UI, start the dev server and use the
+   `webapp-testing` skill to click through the affected pages
+3. Report a structured pass/fail summary
+
+If QA reports **any** failure, do NOT advance to the reviewer. Instead, hand
+the failure report back to `feature-implementer` for a fix-up pass and re-run
+QA. Loop at most 3 times. After 3 failed QA passes, stop and surface the
+problem to the user.
+
+### Gate 5 — Code Reviewer
+
+Once QA passes, launch the `pr-reviewer` subagent. It will read the diff
+against `main`, check it against the per-app `CLAUDE.md` rules, and draft a PR
+title + body.
+
+Present the draft to the user:
+
+```
+Ready to open PR:
+  Title:  <pr title>
+  Body:
+    <pr body preview>
+
+Reply "open" to create the PR, "revise" with feedback, or "hold" to stop here.
+```
+
+**Stop and wait.** Only call `mcp__github__create_pull_request` if the user
+says "open." Never push to `main` directly. Never force-push.
+
+## Hard rules
+
+- **Never** skip a gate.
+- **Never** mark a story complete unless the QA gate passed.
+- **Never** open a PR without explicit user approval.
+- **Never** modify files outside the scope of the approved plan without
+  pausing to ask the user.
+- If any subagent reports it cannot complete its task, stop the loop and
+  report to the user — do not try to "route around" the failure.

--- a/.claude/commands/standup.md
+++ b/.claude/commands/standup.md
@@ -41,7 +41,9 @@ picks at least one story.
 ### Gate 2 — Tech Lead
 
 For each approved story, launch the `tech-lead-planner` subagent. Pass it the
-story text. When it reports back, present the plan to the user:
+**full** story text — including the "How we'll prove it works" section from
+the PM's proposal. The planner is required to map each scenario to a specific
+test in the plan. When it reports back, present the plan to the user:
 
 ```
 Implementation plan for <story title>:
@@ -59,9 +61,16 @@ feedback. If "yes," continue.
 
 ### Gate 3 — Developer (no gate, runs to completion)
 
-Launch the `feature-implementer` subagent with the approved plan. Let it run
-to completion. It will write code, write tests, and make the implementation
-follow the per-app `CLAUDE.md` rules.
+Launch the `feature-implementer` subagent with:
+
+1. The approved plan from the Tech Lead (including the story-trace mapping
+   of scenarios → tests).
+2. The original story from the PM (including "How we'll prove it works").
+3. An explicit reminder: "Every scenario in 'How we'll prove it works' must
+   end up as a real assertion in a real test file. QA will cross-reference."
+
+Let it run to completion. It will write code, write tests, and make the
+implementation follow the per-app `CLAUDE.md` rules.
 
 **No user gate here** — the developer runs autonomously until done. The next
 gate (QA) is what catches mistakes.
@@ -70,15 +79,51 @@ gate (QA) is what catches mistakes.
 
 Launch the `qa-tester` subagent. It will:
 
-1. Run `/precommit` (lint + typecheck + unit + integration tests)
+1. Run lint, typecheck, unit, component, and integration tests
 2. If the change touches the UI, start the dev server and use the
    `webapp-testing` skill to click through the affected pages
-3. Report a structured pass/fail summary
+3. Verify test coverage exists and is meaningful (not empty or skipped)
+4. Cross-reference the story's "How we'll prove it works" scenarios against
+   the tests added
+5. Report a structured pass/fail summary with a fix-list on failure
 
-If QA reports **any** failure, do NOT advance to the reviewer. Instead, hand
-the failure report back to `feature-implementer` for a fix-up pass and re-run
-QA. Loop at most 3 times. After 3 failed QA passes, stop and surface the
-problem to the user.
+#### QA → Developer fix-up loop
+
+If QA reports **any** failure, do NOT advance to the reviewer. Instead:
+
+1. Take the QA report's `Fix-list` section verbatim.
+2. Re-launch the `feature-implementer` subagent with **just the fix-list**
+   as its task (not the original story). Tell it: "QA found these issues.
+   Fix only these. Do not make unrelated changes."
+3. Once the implementer reports done, re-launch `qa-tester` (a fresh run,
+   not a delta — the gauntlet always runs end-to-end).
+4. Loop at most **3 times**.
+
+After 3 failed QA passes, stop the loop and present a structured handoff to
+the user:
+
+```
+QA loop exhausted (3/3 attempts) on story: <title>
+
+What we tried:
+  Attempt 1: <one-line fix summary> → failed on <step>
+  Attempt 2: <one-line fix summary> → failed on <step>
+  Attempt 3: <one-line fix summary> → failed on <step>
+
+QA's hypothesis on the root blocker:
+  <copy "Why this is stuck" paragraph from the last QA report>
+
+Recommended next steps:
+  - <option 1, e.g., "revise the plan with tech-lead-planner">
+  - <option 2, e.g., "split the story into two smaller pieces">
+  - <option 3, e.g., "investigate the schema mismatch manually">
+
+Reply with the option number, "abort" to discard the branch, or free-form
+guidance to retry.
+```
+
+This is the only place in the loop where a hard failure surfaces to the
+user mid-story. Do not silently keep retrying.
 
 ### Gate 5 — Code Reviewer
 

--- a/.claude/commands/task.md
+++ b/.claude/commands/task.md
@@ -1,0 +1,45 @@
+---
+description: Pick up a task from Tasks.md, plan it, implement it, test it, and mark it complete.
+argument-hint: <story-or-task-id>
+---
+
+You are working on task **$ARGUMENTS** from `Tasks.md`.
+
+## Step 1 — Read the task
+
+1. Open `Tasks.md` and find the entry for `$ARGUMENTS`.
+2. Read the full story description, acceptance criteria, and any sub-tasks.
+3. Open `Backlog.md` and check whether this story has historical context there.
+4. If `$ARGUMENTS` is empty or ambiguous, list the next 3 unstarted tasks from
+   `Tasks.md` and ask the user which one to pick up.
+
+## Step 2 — Plan
+
+Summarize back to the user, in under 200 words:
+
+- What the story asks for
+- The files you expect to create or modify
+- Which tests you will write (unit, component, integration)
+- Any database schema changes (if so, the migration plan)
+- Any open questions or assumptions
+
+**Stop and wait for the user to approve the plan** before writing any code.
+
+## Step 3 — Implement
+
+Once approved, hand the work off to the `feature-implementer` subagent. Pass it
+the story text and your approved plan.
+
+## Step 4 — Test
+
+After the implementer reports done, run `/precommit`. Do not declare the task
+finished until every check passes.
+
+## Step 5 — Mark complete
+
+1. Update `Tasks.md` to mark `$ARGUMENTS` as complete (follow the existing
+   format used by adjacent tasks — usually `[x]` checkboxes or a status field).
+2. Stage the changes with `git add` (specific files only — never `git add -A`).
+3. Suggest a Conventional Commits message in the form
+   `feat: <story summary> (Story $ARGUMENTS)`.
+4. **Do not** commit or push unless the user explicitly says so.

--- a/.claude/hooks/precommit-gate.sh
+++ b/.claude/hooks/precommit-gate.sh
@@ -32,7 +32,7 @@ if echo "$changed" | grep -q '^apps/web/'; then
   filters+=("--filter=@interview-assistant/web")
 fi
 if echo "$changed" | grep -q '^apps/api/'; then
-  filters+=("--filter=interview-assistant-api")
+  filters+=("--filter=@interview-assistant/api")
 fi
 if echo "$changed" | grep -q '^packages/shared/'; then
   filters+=("--filter=@interview-assistant/shared")
@@ -43,8 +43,10 @@ if [ ! -x "node_modules/.bin/turbo" ] && [ ! -x "node_modules/.bin/npx" ]; then
   exit 0
 fi
 
-# Run the gate. Suppress stdout, capture stderr.
-if ! npx --no-install turbo lint typecheck test "${filters[@]}" 2>&1 >/tmp/precommit-gate.log; then
+# Run the gate. Capture both stdout and stderr to the log file.
+# Note: order matters — `>file 2>&1` redirects stdout to file then merges
+# stderr into stdout. The reverse order (`2>&1 >file`) silently drops stderr.
+if ! npx --no-install turbo lint typecheck test "${filters[@]}" >/tmp/precommit-gate.log 2>&1; then
   {
     echo "Stop-hook: pre-commit gate failed."
     echo "The lint/typecheck/test suite failed for the packages you touched:"

--- a/.claude/hooks/precommit-gate.sh
+++ b/.claude/hooks/precommit-gate.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Stop hook: runs after Claude finishes a turn.
+# Re-prompts Claude if lint/typecheck/test fails on touched packages.
+#
+# Behavior:
+#   - Detects whether the working tree has any modifications under
+#     apps/web or apps/api. Skips gracefully if not (read-only turns
+#     should not pay the cost).
+#   - Runs `npx turbo lint typecheck test` scoped via --filter to whichever
+#     packages were touched.
+#   - On failure, exits 2 with a stderr message — Claude Code surfaces this
+#     back to the model, which will then fix and re-run.
+#   - On success, exits 0 silently.
+#
+# This is the deterministic enforcement of the pre-commit checklist in
+# CLAUDE.md. It does NOT run the integration suite (that requires Docker
+# and is too slow for a per-turn hook). Run /precommit manually for that.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# Skip if there are no source modifications.
+changed=$(git status --porcelain | awk '{print $2}' | grep -E '^(apps/(web|api)|packages/shared)/' || true)
+if [ -z "$changed" ]; then
+  exit 0
+fi
+
+filters=()
+if echo "$changed" | grep -q '^apps/web/'; then
+  filters+=("--filter=@interview-assistant/web")
+fi
+if echo "$changed" | grep -q '^apps/api/'; then
+  filters+=("--filter=interview-assistant-api")
+fi
+if echo "$changed" | grep -q '^packages/shared/'; then
+  filters+=("--filter=@interview-assistant/shared")
+fi
+
+# If turbo is not installed locally yet (fresh clone), skip silently.
+if [ ! -x "node_modules/.bin/turbo" ] && [ ! -x "node_modules/.bin/npx" ]; then
+  exit 0
+fi
+
+# Run the gate. Suppress stdout, capture stderr.
+if ! npx --no-install turbo lint typecheck test "${filters[@]}" 2>&1 >/tmp/precommit-gate.log; then
+  {
+    echo "Stop-hook: pre-commit gate failed."
+    echo "The lint/typecheck/test suite failed for the packages you touched:"
+    echo "  ${filters[*]}"
+    echo ""
+    echo "Last 40 lines of output:"
+    tail -n 40 /tmp/precommit-gate.log
+    echo ""
+    echo "Fix the underlying issue and re-run. Do not bypass with --no-verify."
+  } >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "deny": [
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git reset --hard:*)",
+      "Bash(git clean -fd:*)",
+      "Bash(git clean -f:*)",
+      "Bash(rm -rf /:*)",
+      "Bash(rm -rf ~:*)",
+      "Bash(npm run db:push:*)",
+      "Bash(drizzle-kit push:*)"
+    ]
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/precommit-gate.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/claude-api/LICENSE.txt
+++ b/.claude/skills/claude-api/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.claude/skills/claude-api/SKILL.md
+++ b/.claude/skills/claude-api/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: claude-api
+description: Build, debug, and optimize Claude API / Anthropic SDK apps. Apps built with this skill should include prompt caching. TRIGGER when: code imports anthropic/@anthropic-ai/sdk; user asks to use the Claude API, Anthropic SDKs, or Managed Agents (/v1/agents, /v1/sessions, /v1/environments). DO NOT TRIGGER when: code imports `openai`/other AI SDK, general programming, or ML/data-science tasks.
+license: Complete terms in LICENSE.txt
+---
+
+
+# Building LLM-Powered Applications with Claude
+
+This skill helps you build LLM-powered applications with Claude. Choose the right surface based on your needs, detect the project language, then read the relevant language-specific documentation.
+
+## Before You Start
+
+Scan the target file (or, if no target file, the prompt and project) for non-Anthropic provider markers — `import openai`, `from openai`, `langchain_openai`, `OpenAI(`, `gpt-4`, `gpt-5`, file names like `agent-openai.py` or `*-generic.py`, or any explicit instruction to keep the code provider-neutral. If you find any, stop and tell the user that this skill produces Claude/Anthropic SDK code; ask whether they want to switch the file to Claude or want a non-Claude implementation. Do not edit a non-Anthropic file with Anthropic SDK calls.
+
+## Output Requirement
+
+When the user asks you to add, modify, or implement a Claude feature, your code must call Claude through one of:
+
+1. **The official Anthropic SDK** for the project's language (`anthropic`, `@anthropic-ai/sdk`, `com.anthropic.*`, etc.). This is the default whenever a supported SDK exists for the project.
+2. **Raw HTTP** (`curl`, `requests`, `fetch`, `httpx`, etc.) — only when the user explicitly asks for cURL/REST/raw HTTP, the project is a shell/cURL project, or the language has no official SDK.
+
+Never mix the two — don't reach for `requests`/`fetch` in a Python or TypeScript project just because it feels lighter. Never fall back to OpenAI-compatible shims.
+
+**Never guess SDK usage.** Function names, class names, namespaces, method signatures, and import paths must come from explicit documentation — either the `{lang}/` files in this skill or the official SDK repositories or documentation links listed in `shared/live-sources.md`. If the binding you need is not explicitly documented in the skill files, WebFetch the relevant SDK repo from `shared/live-sources.md` before writing code. Do not infer Ruby/Java/Go/PHP/C# APIs from cURL shapes or from another language's SDK.
+
+## Defaults
+
+Unless the user requests otherwise:
+
+For the Claude model version, please use Claude Opus 4.6, which you can access via the exact model string `claude-opus-4-6`. Please default to using adaptive thinking (`thinking: {type: "adaptive"}`) for anything remotely complicated. And finally, please default to streaming for any request that may involve long input, long output, or high `max_tokens` — it prevents hitting request timeouts. Use the SDK's `.get_final_message()` / `.finalMessage()` helper to get the complete response if you don't need to handle individual stream events
+
+---
+
+## Subcommands
+
+If the User Request at the bottom of this prompt is a bare subcommand string (no prose), search every **Subcommands** table in this document — including any in sections appended below — and follow the matching Action column directly. This lets users invoke specific flows via `/claude-api <subcommand>`. If no table in the document matches, treat the request as normal prose.
+
+<!-- Subcommand tables are defined per-section below; this header block contains only the dispatch rule so that feature-gated sections can add their own tables without leaking strings into ungated builds. -->
+
+---
+
+## Language Detection
+
+Before reading code examples, determine which language the user is working in:
+
+1. **Look at project files** to infer the language:
+
+   - `*.py`, `requirements.txt`, `pyproject.toml`, `setup.py`, `Pipfile` → **Python** — read from `python/`
+   - `*.ts`, `*.tsx`, `package.json`, `tsconfig.json` → **TypeScript** — read from `typescript/`
+   - `*.js`, `*.jsx` (no `.ts` files present) → **TypeScript** — JS uses the same SDK, read from `typescript/`
+   - `*.java`, `pom.xml`, `build.gradle` → **Java** — read from `java/`
+   - `*.kt`, `*.kts`, `build.gradle.kts` → **Java** — Kotlin uses the Java SDK, read from `java/`
+   - `*.scala`, `build.sbt` → **Java** — Scala uses the Java SDK, read from `java/`
+   - `*.go`, `go.mod` → **Go** — read from `go/`
+   - `*.rb`, `Gemfile` → **Ruby** — read from `ruby/`
+   - `*.cs`, `*.csproj` → **C#** — read from `csharp/`
+   - `*.php`, `composer.json` → **PHP** — read from `php/`
+
+2. **If multiple languages detected** (e.g., both Python and TypeScript files):
+
+   - Check which language the user's current file or question relates to
+   - If still ambiguous, ask: "I detected both Python and TypeScript files. Which language are you using for the Claude API integration?"
+
+3. **If language can't be inferred** (empty project, no source files, or unsupported language):
+
+   - Use AskUserQuestion with options: Python, TypeScript, Java, Go, Ruby, cURL/raw HTTP, C#, PHP
+   - If AskUserQuestion is unavailable, default to Python examples and note: "Showing Python examples. Let me know if you need a different language."
+
+4. **If unsupported language detected** (Rust, Swift, C++, Elixir, etc.):
+
+   - Suggest cURL/raw HTTP examples from `curl/` and note that community SDKs may exist
+   - Offer to show Python or TypeScript examples as reference implementations
+
+5. **If user needs cURL/raw HTTP examples**, read from `curl/`.
+
+### Language-Specific Feature Support
+
+| Language   | Tool Runner | Managed Agents | Notes                                 |
+| ---------- | ----------- | -------------- | ------------------------------------- |
+| Python     | Yes (beta)  | Yes (beta)     | Full support — `@beta_tool` decorator |
+| TypeScript | Yes (beta)  | Yes (beta)     | Full support — `betaZodTool` + Zod    |
+| Java       | Yes (beta)  | Yes (beta)     | Beta tool use with annotated classes  |
+| Go         | Yes (beta)  | Yes (beta)     | `BetaToolRunner` in `toolrunner` pkg  |
+| Ruby       | Yes (beta)  | Yes (beta)     | `BaseTool` + `tool_runner` in beta    |
+| C#         | No          | No             | Official SDK                          |
+| PHP        | Yes (beta)  | Yes (beta)     | `BetaRunnableTool` + `toolRunner()`   |
+| cURL       | N/A         | Yes (beta)     | Raw HTTP, no SDK features             |
+
+> **Managed Agents code examples**: dedicated language-specific READMEs are provided for Python, TypeScript, Go, Ruby, PHP, Java, and cURL (`{lang}/managed-agents/README.md`, `curl/managed-agents.md`). Read your language's README plus the language-agnostic `shared/managed-agents-*.md` concept files. **Agents are persistent — create once, reference by ID.** Store the agent ID returned by `agents.create` and pass it to every subsequent `sessions.create`; do not call `agents.create` in the request path. The Anthropic CLI is one convenient way to create agents and environments from version-controlled YAML — its URL is in `shared/live-sources.md`. If a binding you need isn't shown in the README, WebFetch the relevant entry from `shared/live-sources.md` rather than guess. C# does not currently have Managed Agents support; use cURL-style raw HTTP requests against the API.
+
+---
+
+## Which Surface Should I Use?
+
+> **Start simple.** Default to the simplest tier that meets your needs. Single API calls and workflows handle most use cases — only reach for agents when the task genuinely requires open-ended, model-driven exploration.
+
+| Use Case                                        | Tier            | Recommended Surface       | Why                                                          |
+| ----------------------------------------------- | --------------- | ------------------------- | ------------------------------------------------------------ |
+| Classification, summarization, extraction, Q&A  | Single LLM call | **Claude API**            | One request, one response                                    |
+| Batch processing or embeddings                  | Single LLM call | **Claude API**            | Specialized endpoints                                        |
+| Multi-step pipelines with code-controlled logic | Workflow        | **Claude API + tool use** | You orchestrate the loop                                     |
+| Custom agent with your own tools                | Agent           | **Claude API + tool use** | Maximum flexibility                                          |
+| Server-managed stateful agent with workspace    | Agent           | **Managed Agents**        | Anthropic runs the loop and hosts the tool-execution sandbox |
+| Persisted, versioned agent configs              | Agent           | **Managed Agents**        | Agents are stored objects; sessions pin to a version         |
+| Long-running multi-turn agent with file mounts  | Agent           | **Managed Agents**        | Per-session containers, SSE event stream, Skills + MCP       |
+
+> **Note:** Managed Agents is the right choice when you want Anthropic to run the agent loop *and* host the container where tools execute — file ops, bash, code execution all run in the per-session workspace. If you want to host the compute yourself or run your own custom tool runtime, Claude API + tool use is the right choice — use the tool runner for automatic loop handling, or the manual loop for fine-grained control (approval gates, custom logging, conditional execution).
+
+> **Third-party providers (Amazon Bedrock, Google Vertex AI, Microsoft Foundry):** Managed Agents is **not available** on Bedrock, Vertex, or Foundry. If you are deploying through any third-party provider, use **Claude API + tool use** for all use cases — including ones where Managed Agents would otherwise be the recommended surface.
+
+### Decision Tree
+
+```
+What does your application need?
+
+0. Are you deploying through Amazon Bedrock, Google Vertex AI, or Microsoft Foundry?
+   └── Yes → Claude API (+ tool use for agents) — Managed Agents is 1P only.
+   No → continue.
+
+1. Single LLM call (classification, summarization, extraction, Q&A)
+   └── Claude API — one request, one response
+
+2. Do you want Anthropic to run the agent loop and host a per-session
+   container where Claude executes tools (bash, file ops, code)?
+   └── Yes → Managed Agents — server-managed sessions, persisted agent configs,
+       SSE event stream, Skills + MCP, file mounts.
+       Examples: "stateful coding agent with a workspace per task",
+                 "long-running research agent that streams events to a UI",
+                 "agent with persisted, versioned config used across many sessions"
+
+3. Workflow (multi-step, code-orchestrated, with your own tools)
+   └── Claude API with tool use — you control the loop
+
+4. Open-ended agent (model decides its own trajectory, your own tools, you host the compute)
+   └── Claude API agentic loop (maximum flexibility)
+```
+
+### Should I Build an Agent?
+
+Before choosing the agent tier, check all four criteria:
+
+- **Complexity** — Is the task multi-step and hard to fully specify in advance? (e.g., "turn this design doc into a PR" vs. "extract the title from this PDF")
+- **Value** — Does the outcome justify higher cost and latency?
+- **Viability** — Is Claude capable at this task type?
+- **Cost of error** — Can errors be caught and recovered from? (tests, review, rollback)
+
+If the answer is "no" to any of these, stay at a simpler tier (single call or workflow).
+
+---
+
+## Architecture
+
+Everything goes through `POST /v1/messages`. Tools and output constraints are features of this single endpoint — not separate APIs.
+
+**User-defined tools** — You define tools (via decorators, Zod schemas, or raw JSON), and the SDK's tool runner handles calling the API, executing your functions, and looping until Claude is done. For full control, you can write the loop manually.
+
+**Server-side tools** — Anthropic-hosted tools that run on Anthropic's infrastructure. Code execution is fully server-side (declare it in `tools`, Claude runs code automatically). Computer use can be server-hosted or self-hosted.
+
+**Structured outputs** — Constrains the Messages API response format (`output_config.format`) and/or tool parameter validation (`strict: true`). The recommended approach is `client.messages.parse()` which validates responses against your schema automatically. Note: the old `output_format` parameter is deprecated; use `output_config: {format: {...}}` on `messages.create()`.
+
+**Supporting endpoints** — Batches (`POST /v1/messages/batches`), Files (`POST /v1/files`), Token Counting, and Models (`GET /v1/models`, `GET /v1/models/{id}` — live capability/context-window discovery) feed into or support Messages API requests.
+
+---
+
+## Current Models (cached: 2026-02-17)
+
+| Model             | Model ID            | Context        | Input $/1M | Output $/1M |
+| ----------------- | ------------------- | -------------- | ---------- | ----------- |
+| Claude Opus 4.6   | `claude-opus-4-6`   | 200K (1M beta) | $5.00      | $25.00      |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` | 200K (1M beta) | $3.00      | $15.00      |
+| Claude Haiku 4.5  | `claude-haiku-4-5`  | 200K           | $1.00      | $5.00       |
+
+**ALWAYS use `claude-opus-4-6` unless the user explicitly names a different model.** This is non-negotiable. Do not use `claude-sonnet-4-6`, `claude-sonnet-4-5`, or any other model unless the user literally says "use sonnet" or "use haiku". Never downgrade for cost — that's the user's decision, not yours.
+
+**CRITICAL: Use only the exact model ID strings from the table above — they are complete as-is. Do not append date suffixes.** For example, use `claude-sonnet-4-5`, never `claude-sonnet-4-5-20250514` or any other date-suffixed variant you might recall from training data. If the user requests an older model not in the table (e.g., "opus 4.5", "sonnet 3.7"), read `shared/models.md` for the exact ID — do not construct one yourself.
+
+A note: if any of the model strings above look unfamiliar to you, that's to be expected — that just means they were released after your training data cutoff. Rest assured they are real models; we wouldn't mess with you like that.
+
+**Live capability lookup:** The table above is cached. When the user asks "what's the context window for X", "does X support vision/thinking/effort", or "which models support Y", query the Models API (`client.models.retrieve(id)` / `client.models.list()`) — see `shared/models.md` for the field reference and capability-filter examples.
+
+---
+
+## Thinking & Effort (Quick Reference)
+
+**Opus 4.6 — Adaptive thinking (recommended):** Use `thinking: {type: "adaptive"}`. Claude dynamically decides when and how much to think. No `budget_tokens` needed — `budget_tokens` is deprecated on Opus 4.6 and Sonnet 4.6 and must not be used. Adaptive thinking also automatically enables interleaved thinking (no beta header needed). **When the user asks for "extended thinking", a "thinking budget", or `budget_tokens`: always use Opus 4.6 with `thinking: {type: "adaptive"}`. The concept of a fixed token budget for thinking is deprecated — adaptive thinking replaces it. Do NOT use `budget_tokens` and do NOT switch to an older model.**
+
+**Effort parameter (GA, no beta header):** Controls thinking depth and overall token spend via `output_config: {effort: "low"|"medium"|"high"|"max"}` (inside `output_config`, not top-level). Default is `high` (equivalent to omitting it). `max` is Opus 4.6 only. Works on Opus 4.5, Opus 4.6, and Sonnet 4.6. Will error on Sonnet 4.5 / Haiku 4.5. Combine with adaptive thinking for the best cost-quality tradeoffs. Lower effort means fewer and more-consolidated tool calls, less preamble, and terser confirmations — `medium` is often a favorable balance; use `max` when correctness matters more than cost; use `low` for subagents or simple tasks.
+
+**Sonnet 4.6:** Supports adaptive thinking (`thinking: {type: "adaptive"}`). `budget_tokens` is deprecated on Sonnet 4.6 — use adaptive thinking instead.
+
+**Older models (only if explicitly requested):** If the user specifically asks for Sonnet 4.5 or another older model, use `thinking: {type: "enabled", budget_tokens: N}`. `budget_tokens` must be less than `max_tokens` (minimum 1024). Never choose an older model just because the user mentions `budget_tokens` — use Opus 4.6 with adaptive thinking instead.
+
+---
+
+## Compaction (Quick Reference)
+
+**Beta, Opus 4.6 and Sonnet 4.6.** For long-running conversations that may exceed the 200K context window, enable server-side compaction. The API automatically summarizes earlier context when it approaches the trigger threshold (default: 150K tokens). Requires beta header `compact-2026-01-12`.
+
+**Critical:** Append `response.content` (not just the text) back to your messages on every turn. Compaction blocks in the response must be preserved — the API uses them to replace the compacted history on the next request. Extracting only the text string and appending that will silently lose the compaction state.
+
+See `{lang}/claude-api/README.md` (Compaction section) for code examples. Full docs via WebFetch in `shared/live-sources.md`.
+
+---
+
+## Prompt Caching (Quick Reference)
+
+**Prefix match.** Any byte change anywhere in the prefix invalidates everything after it. Render order is `tools` → `system` → `messages`. Keep stable content first (frozen system prompt, deterministic tool list), put volatile content (timestamps, per-request IDs, varying questions) after the last `cache_control` breakpoint.
+
+**Top-level auto-caching** (`cache_control: {type: "ephemeral"}` on `messages.create()`) is the simplest option when you don't need fine-grained placement. Max 4 breakpoints per request. Minimum cacheable prefix is ~1024 tokens — shorter prefixes silently won't cache.
+
+**Verify with `usage.cache_read_input_tokens`** — if it's zero across repeated requests, a silent invalidator is at work (`datetime.now()` in system prompt, unsorted JSON, varying tool set).
+
+For placement patterns, architectural guidance, and the silent-invalidator audit checklist: read `shared/prompt-caching.md`. Language-specific syntax: `{lang}/claude-api/README.md` (Prompt Caching section).
+
+---
+
+## Managed Agents (Beta)
+
+**Managed Agents** is a third surface: server-managed stateful agents with Anthropic-hosted tool execution. You create a persisted, versioned Agent config (`POST /v1/agents`), then start Sessions that reference it. Each session provisions a container as the agent's workspace — bash, file ops, and code execution run there; the agent loop itself runs on Anthropic's orchestration layer and acts on the container via tools. The session streams events; you send messages and tool results back.
+
+**Managed Agents is first-party only.** It is not available on Amazon Bedrock, Google Vertex AI, or Microsoft Foundry. For agents on third-party providers, use Claude API + tool use.
+
+**Mandatory flow:** Agent (once) → Session (every run). `model`/`system`/`tools` live on the agent, never the session. See `shared/managed-agents-overview.md` for the full reading guide, beta headers, and pitfalls.
+
+**Beta headers:** `managed-agents-2026-04-01` — the SDK sets this automatically for all `client.beta.{agents,environments,sessions,vaults}.*` calls. Skills API uses `skills-2025-10-02` and Files API uses `files-api-2025-04-14`, but you don't need to explicitly pass those in for endpoints other than `/v1/skills` and `/v1/files`.
+
+**Subcommands** — invoke directly with `/claude-api <subcommand>`:
+
+| Subcommand | Action |
+|---|---|
+| `managed-agents-onboard` | Walk the user through setting up a Managed Agent from scratch. **Read `shared/managed-agents-onboarding.md` immediately** and follow its interview script: mental model → know-or-explore branch → template config → session setup → emit code. Do not summarize — run the interview. |
+
+**Reading guide:** Start with `shared/managed-agents-overview.md`, then the topical `shared/managed-agents-*.md` files (core, environments, tools, events, client-patterns, onboarding, api-reference). For Python, TypeScript, Go, Ruby, PHP, and Java, read `{lang}/managed-agents/README.md` for code examples. For cURL, read `curl/managed-agents.md`. **Agents are persistent — create once, reference by ID.** Store the agent ID returned by `agents.create` and pass it to every subsequent `sessions.create`; do not call `agents.create` in the request path. The Anthropic CLI is one convenient way to create agents and environments from version-controlled YAML (URL in `shared/live-sources.md`). If a binding you need isn't shown in the language README, WebFetch the relevant entry from `shared/live-sources.md` rather than guess. C# does not currently have Managed Agents support; use raw HTTP from `curl/managed-agents.md` as a reference.
+
+**When the user wants to set up a Managed Agent from scratch** (e.g. "how do I get started", "walk me through creating one", "set up a new agent"): read `shared/managed-agents-onboarding.md` and run its interview — same flow as the `managed-agents-onboard` subcommand.
+
+**When the user asks "how do I write the client code for X":** reach for `shared/managed-agents-client-patterns.md` — covers lossless stream reconnect, `processed_at` queued/processed gate, interrupt, `tool_confirmation` round-trip, the correct idle/terminated break gate, post-idle status race, stream-first ordering, file-mount gotchas, keeping credentials host-side via custom tools, etc.
+
+---
+
+## Reading Guide
+
+After detecting the language, read the relevant files based on what the user needs:
+
+### Quick Task Reference
+
+**Single text classification/summarization/extraction/Q&A:**
+→ Read only `{lang}/claude-api/README.md`
+
+**Chat UI or real-time response display:**
+→ Read `{lang}/claude-api/README.md` + `{lang}/claude-api/streaming.md`
+
+**Long-running conversations (may exceed context window):**
+→ Read `{lang}/claude-api/README.md` — see Compaction section
+
+**Prompt caching / optimize caching / "why is my cache hit rate low":**
+→ Read `shared/prompt-caching.md` + `{lang}/claude-api/README.md` (Prompt Caching section)
+
+**Function calling / tool use / agents:**
+→ Read `{lang}/claude-api/README.md` + `shared/tool-use-concepts.md` + `{lang}/claude-api/tool-use.md`
+
+**Agent design (tool surface, context management, caching strategy):**
+→ Read `shared/agent-design.md`
+
+**Batch processing (non-latency-sensitive):**
+→ Read `{lang}/claude-api/README.md` + `{lang}/claude-api/batches.md`
+
+**File uploads across multiple requests:**
+→ Read `{lang}/claude-api/README.md` + `{lang}/claude-api/files-api.md`
+
+**Managed Agents (server-managed stateful agents with workspace):**
+→ Read `shared/managed-agents-overview.md` + the rest of the `shared/managed-agents-*.md` files. For Python, TypeScript, Go, Ruby, PHP, and Java, read `{lang}/managed-agents/README.md` for code examples. For cURL, read `curl/managed-agents.md`. **Agents are persistent — create once, reference by ID.** Store the agent ID returned by `agents.create` and pass it to every subsequent `sessions.create`; do not call `agents.create` in the request path. The Anthropic CLI is one convenient way to create agents and environments from version-controlled YAML (URL in `shared/live-sources.md`). If a binding you need isn't shown in the language README, WebFetch the relevant entry from `shared/live-sources.md` rather than guess. C# does not currently support Managed Agents — use raw HTTP from `curl/managed-agents.md` as a reference.
+
+### Claude API (Full File Reference)
+
+Read the **language-specific Claude API folder** (`{language}/claude-api/`):
+
+1. **`{language}/claude-api/README.md`** — **Read this first.** Installation, quick start, common patterns, error handling.
+2. **`shared/tool-use-concepts.md`** — Read when the user needs function calling, code execution, memory, or structured outputs. Covers conceptual foundations.
+3. **`shared/agent-design.md`** — Read when designing an agent: bash vs. dedicated tools, programmatic tool calling, tool search/skills, context editing vs. compaction vs. memory, caching principles.
+4. **`{language}/claude-api/tool-use.md`** — Read for language-specific tool use code examples (tool runner, manual loop, code execution, memory, structured outputs).
+5. **`{language}/claude-api/streaming.md`** — Read when building chat UIs or interfaces that display responses incrementally.
+6. **`{language}/claude-api/batches.md`** — Read when processing many requests offline (not latency-sensitive). Runs asynchronously at 50% cost.
+7. **`{language}/claude-api/files-api.md`** — Read when sending the same file across multiple requests without re-uploading.
+8. **`shared/prompt-caching.md`** — Read when adding or optimizing prompt caching. Covers prefix-stability design, breakpoint placement, and anti-patterns that silently invalidate cache.
+9. **`shared/error-codes.md`** — Read when debugging HTTP errors or implementing error handling.
+10. **`shared/live-sources.md`** — WebFetch URLs for fetching the latest official documentation.
+
+> **Note:** For Java, Go, Ruby, C#, PHP, and cURL — these have a single file each covering all basics. Read that file plus `shared/tool-use-concepts.md` and `shared/error-codes.md` as needed.
+
+> **Note:** For the Managed Agents file reference, see the `## Managed Agents (Beta)` section above — it lists every `shared/managed-agents-*.md` file and the language-specific READMEs.
+
+---
+
+## When to Use WebFetch
+
+Use WebFetch to get the latest documentation when:
+
+- User asks for "latest" or "current" information
+- Cached data seems incorrect
+- User asks about features not covered here
+
+Live documentation URLs are in `shared/live-sources.md`.
+
+## Common Pitfalls
+
+- Don't truncate inputs when passing files or content to the API. If the content is too long to fit in the context window, notify the user and discuss options (chunking, summarization, etc.) rather than silently truncating.
+- **Opus 4.6 / Sonnet 4.6 thinking:** Use `thinking: {type: "adaptive"}` — do NOT use `budget_tokens` (deprecated on both Opus 4.6 and Sonnet 4.6). For older models, `budget_tokens` must be less than `max_tokens` (minimum 1024). This will throw an error if you get it wrong.
+- **Opus 4.6 prefill removed:** Assistant message prefills (last-assistant-turn prefills) return a 400 error on Opus 4.6. Use structured outputs (`output_config.format`) or system prompt instructions to control response format instead.
+- **`max_tokens` defaults:** Don't lowball `max_tokens` — hitting the cap truncates output mid-thought and requires a retry. For non-streaming requests, default to `~16000` (keeps responses under SDK HTTP timeouts). For streaming requests, default to `~64000` (timeouts aren't a concern, so give the model room). Only go lower when you have a hard reason: classification (`~256`), cost caps, or deliberately short outputs.
+- **128K output tokens:** Opus 4.6 supports up to 128K `max_tokens`, but the SDKs require streaming for values that large to avoid HTTP timeouts. Use `.stream()` with `.get_final_message()` / `.finalMessage()`.
+- **Tool call JSON parsing (Opus 4.6):** Opus 4.6 may produce different JSON string escaping in tool call `input` fields (e.g., Unicode or forward-slash escaping). Always parse tool inputs with `json.loads()` / `JSON.parse()` — never do raw string matching on the serialized input.
+- **Structured outputs (all models):** Use `output_config: {format: {...}}` instead of the deprecated `output_format` parameter on `messages.create()`. This is a general API change, not 4.6-specific.
+- **Don't reimplement SDK functionality:** The SDK provides high-level helpers — use them instead of building from scratch. Specifically: use `stream.finalMessage()` instead of wrapping `.on()` events in `new Promise()`; use typed exception classes (`Anthropic.RateLimitError`, etc.) instead of string-matching error messages; use SDK types (`Anthropic.MessageParam`, `Anthropic.Tool`, `Anthropic.Message`, etc.) instead of redefining equivalent interfaces.
+- **Don't define custom types for SDK data structures:** The SDK exports types for all API objects. Use `Anthropic.MessageParam` for messages, `Anthropic.Tool` for tool definitions, `Anthropic.ToolUseBlock` / `Anthropic.ToolResultBlockParam` for tool results, `Anthropic.Message` for responses. Defining your own `interface ChatMessage { role: string; content: unknown }` duplicates what the SDK already provides and loses type safety.
+- **Report and document output:** For tasks that produce reports, documents, or visualizations, the code execution sandbox has `python-docx`, `python-pptx`, `matplotlib`, `pillow`, and `pypdf` pre-installed. Claude can generate formatted files (DOCX, PDF, charts) and return them via the Files API — consider this for "report" or "document" type requests instead of plain stdout text.

--- a/.claude/skills/claude-api/csharp/claude-api.md
+++ b/.claude/skills/claude-api/csharp/claude-api.md
@@ -1,0 +1,402 @@
+# Claude API — C#
+
+> **Note:** The C# SDK is the official Anthropic SDK for C#. Tool use is supported via the Messages API. A class-annotation-based tool runner is not available; use raw tool definitions with JSON schema. The SDK also supports Microsoft.Extensions.AI IChatClient integration with function invocation.
+
+## Installation
+
+```bash
+dotnet add package Anthropic
+```
+
+## Client Initialization
+
+```csharp
+using Anthropic;
+
+// Default (uses ANTHROPIC_API_KEY env var)
+AnthropicClient client = new();
+
+// Explicit API key (use environment variables — never hardcode keys)
+AnthropicClient client = new() {
+    ApiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY")
+};
+```
+
+---
+
+## Basic Message Request
+
+```csharp
+using Anthropic.Models.Messages;
+
+var parameters = new MessageCreateParams
+{
+    Model = Model.ClaudeOpus4_6,
+    MaxTokens = 16000,
+    Messages = [new() { Role = Role.User, Content = "What is the capital of France?" }]
+};
+var response = await client.Messages.Create(parameters);
+
+// ContentBlock is a union wrapper. .Value unwraps to the variant object,
+// then OfType<T> filters to the type you want. Or use the TryPick* idiom
+// shown in the Thinking section below.
+foreach (var text in response.Content.Select(b => b.Value).OfType<TextBlock>())
+{
+    Console.WriteLine(text.Text);
+}
+```
+
+---
+
+## Streaming
+
+```csharp
+using Anthropic.Models.Messages;
+
+var parameters = new MessageCreateParams
+{
+    Model = Model.ClaudeOpus4_6,
+    MaxTokens = 64000,
+    Messages = [new() { Role = Role.User, Content = "Write a haiku" }]
+};
+
+await foreach (RawMessageStreamEvent streamEvent in client.Messages.CreateStreaming(parameters))
+{
+    if (streamEvent.TryPickContentBlockDelta(out var delta) &&
+        delta.Delta.TryPickText(out var text))
+    {
+        Console.Write(text.Text);
+    }
+}
+```
+
+**`RawMessageStreamEvent` TryPick methods** (naming drops the `Message`/`Raw` prefix): `TryPickStart`, `TryPickDelta`, `TryPickStop`, `TryPickContentBlockStart`, `TryPickContentBlockDelta`, `TryPickContentBlockStop`. There is no `TryPickMessageStop` — use `TryPickStop`.
+
+---
+
+## Thinking
+
+**Adaptive thinking is the recommended mode for Claude 4.6+ models.** Claude decides dynamically when and how much to think.
+
+```csharp
+using Anthropic.Models.Messages;
+
+var response = await client.Messages.Create(new MessageCreateParams
+{
+    Model = Model.ClaudeOpus4_6,
+    MaxTokens = 16000,
+    // ThinkingConfigParam? implicitly converts from the concrete variant classes —
+    // no wrapper needed.
+    Thinking = new ThinkingConfigAdaptive(),
+    Messages =
+    [
+        new() { Role = Role.User, Content = "Solve: 27 * 453" },
+    ],
+});
+
+// ThinkingBlock(s) precede TextBlock in Content. TryPick* narrows the union.
+foreach (var block in response.Content)
+{
+    if (block.TryPickThinking(out ThinkingBlock? t))
+    {
+        Console.WriteLine($"[thinking] {t.Thinking}");
+    }
+    else if (block.TryPickText(out TextBlock? text))
+    {
+        Console.WriteLine(text.Text);
+    }
+}
+```
+
+> **Deprecated:** `new ThinkingConfigEnabled { BudgetTokens = N }` (fixed-budget extended thinking) still works on Claude 4.6 but is deprecated. Use adaptive thinking above.
+
+Alternative to `TryPick*`: `.Select(b => b.Value).OfType<ThinkingBlock>()` (same LINQ pattern as the Basic Message example).
+
+---
+
+## Tool Use
+
+### Defining a tool
+
+`Tool` (NOT `ToolParam`) with an `InputSchema` record. `InputSchema.Type` is auto-set to `"object"` by the constructor — don't set it. `ToolUnion` has an implicit conversion from `Tool`, triggered by the collection expression `[...]`.
+
+```csharp
+using System.Text.Json;
+using Anthropic.Models.Messages;
+
+var parameters = new MessageCreateParams
+{
+    Model = Model.ClaudeSonnet4_6,
+    MaxTokens = 16000,
+    Tools = [
+        new Tool {
+            Name = "get_weather",
+            Description = "Get the current weather in a given location",
+            InputSchema = new() {
+                Properties = new Dictionary<string, JsonElement> {
+                    ["location"] = JsonSerializer.SerializeToElement(
+                        new { type = "string", description = "City name" }),
+                },
+                Required = ["location"],
+            },
+        },
+    ],
+    Messages = [new() { Role = Role.User, Content = "Weather in Paris?" }],
+};
+```
+
+Derived from `anthropic-sdk-csharp/src/Anthropic/Models/Messages/Tool.cs` and `ToolUnion.cs:799` (implicit conversion).
+
+See [shared tool use concepts](../shared/tool-use-concepts.md) for the loop pattern.
+### Converting response content to the follow-up assistant message
+
+When echoing Claude's response back in the assistant turn, **there is no `.ToParam()` helper** — manually reconstruct each `ContentBlock` variant as its `*Param` counterpart. Do NOT use `new ContentBlockParam(block.Json)`: it compiles and serializes, but `.Value` stays `null` so `TryPick*`/`Validate()` fail (degraded JSON pass-through, not the typed path).
+
+```csharp
+using Anthropic.Models.Messages;
+
+Message response = await client.Messages.Create(parameters);
+
+// No .ToParam() — reconstruct per variant. Implicit conversions from each
+// *Param type to ContentBlockParam mean no explicit wrapper.
+List<ContentBlockParam> assistantContent = [];
+List<ContentBlockParam> toolResults = [];
+foreach (ContentBlock block in response.Content)
+{
+    if (block.TryPickText(out TextBlock? text))
+    {
+        assistantContent.Add(new TextBlockParam { Text = text.Text });
+    }
+    else if (block.TryPickThinking(out ThinkingBlock? thinking))
+    {
+        // Signature MUST be preserved — the API rejects tampering
+        assistantContent.Add(new ThinkingBlockParam
+        {
+            Thinking = thinking.Thinking,
+            Signature = thinking.Signature,
+        });
+    }
+    else if (block.TryPickRedactedThinking(out RedactedThinkingBlock? redacted))
+    {
+        assistantContent.Add(new RedactedThinkingBlockParam { Data = redacted.Data });
+    }
+    else if (block.TryPickToolUse(out ToolUseBlock? toolUse))
+    {
+        // ToolUseBlock has required Caller; ToolUseBlockParam.Caller is optional — don't copy it
+        assistantContent.Add(new ToolUseBlockParam
+        {
+            ID = toolUse.ID,
+            Name = toolUse.Name,
+            Input = toolUse.Input,
+        });
+        // Execute the tool; collect ONE result per tool_use block — the API
+        // rejects the follow-up if any tool_use ID lacks a matching tool_result.
+        string result = ExecuteYourTool(toolUse.Name, toolUse.Input);
+        toolResults.Add(new ToolResultBlockParam
+        {
+            ToolUseID = toolUse.ID,
+            Content = result,
+        });
+    }
+}
+
+// Follow-up: prior messages + assistant echo + user tool_result(s)
+List<MessageParam> followUpMessages =
+[
+    .. parameters.Messages,
+    new() { Role = Role.Assistant, Content = assistantContent },
+    new() { Role = Role.User, Content = toolResults },
+];
+```
+
+`ToolResultBlockParam` has no tuple constructor — use the object initializer. `Content` is a string-or-list union; a plain `string` implicitly converts.
+
+---
+
+## Context Editing / Compaction (Beta)
+
+**Beta-namespace prefix is inconsistent** (source-verified against `src/Anthropic/Models/Beta/Messages/*.cs` @ 12.9.0). No prefix: `MessageCreateParams`, `MessageCountTokensParams`, `Role`. **Everything else has the `Beta` prefix**: `BetaMessageParam`, `BetaMessage`, `BetaContentBlock`, `BetaToolUseBlock`, all block param types. The unprefixed `Role` WILL collide with `Anthropic.Models.Messages.Role` if you import both namespaces (CS0104). Safest: import only Beta; if mixing, alias the beta `Role`:
+
+```csharp
+using Anthropic.Models.Beta.Messages;
+using NonBeta = Anthropic.Models.Messages;  // only if you also need non-beta types
+// Now: MessageCreateParams, BetaMessageParam, Role (beta's), NonBeta.Role (if needed)
+```
+
+
+`BetaMessage.Content` is `IReadOnlyList<BetaContentBlock>` — a 15-variant discriminated union. Narrow with `TryPick*`. **Response `BetaContentBlock` is NOT assignable to param `BetaContentBlockParam`** — there's no `.ToParam()` in C#. Round-trip by converting each block:
+
+```csharp
+using Anthropic.Models.Beta.Messages;
+
+var betaParams = new MessageCreateParams   // no Beta prefix — one of only 2 unprefixed
+{
+    Model = Model.ClaudeOpus4_6,
+    MaxTokens = 16000,
+    Betas = ["compact-2026-01-12"],
+    ContextManagement = new BetaContextManagementConfig
+    {
+        Edits = [new BetaCompact20260112Edit()],
+    },
+    Messages = messages,
+};
+BetaMessage resp = await client.Beta.Messages.Create(betaParams);
+
+foreach (BetaContentBlock block in resp.Content)
+{
+    if (block.TryPickCompaction(out BetaCompactionBlock? compaction))
+    {
+        // Content is nullable — compaction can fail server-side
+        Console.WriteLine($"compaction summary: {compaction.Content}");
+    }
+}
+
+// Context-edit metadata lives on a separate nullable field
+if (resp.ContextManagement is { } ctx)
+{
+    foreach (var edit in ctx.AppliedEdits)
+        Console.WriteLine($"cleared {edit.ClearedInputTokens} tokens");
+}
+
+// ROUND-TRIP: BetaMessageParam.Content is BetaMessageParamContent (a string|list
+// union). It implicit-converts from List<BetaContentBlockParam>, NOT from the
+// response's IReadOnlyList<BetaContentBlock>. Convert each block:
+List<BetaContentBlockParam> paramBlocks = [];
+foreach (var b in resp.Content)
+{
+    if (b.TryPickText(out var t)) paramBlocks.Add(new BetaTextBlockParam { Text = t.Text });
+    else if (b.TryPickCompaction(out var c)) paramBlocks.Add(new BetaCompactionBlockParam { Content = c.Content });
+    // ... other variants as needed
+}
+messages.Add(new BetaMessageParam { Role = Role.Assistant, Content = paramBlocks });
+```
+
+All 15 `BetaContentBlock.TryPick*` variants: `Text`, `Thinking`, `RedactedThinking`, `ToolUse`, `ServerToolUse`, `WebSearchToolResult`, `WebFetchToolResult`, `CodeExecutionToolResult`, `BashCodeExecutionToolResult`, `TextEditorCodeExecutionToolResult`, `ToolSearchToolResult`, `McpToolUse`, `McpToolResult`, `ContainerUpload`, `Compaction`.
+
+**`BetaToolUseBlock.Input` is `IReadOnlyDictionary<string, JsonElement>`** — index by key then call the `JsonElement` extractor:
+
+```csharp
+if (block.TryPickToolUse(out BetaToolUseBlock? tu))
+{
+    int a = tu.Input["a"].GetInt32();
+    string s = tu.Input["name"].GetString()!;
+}
+```
+
+---
+
+## Effort Parameter
+
+Effort is nested under `OutputConfig`, NOT a top-level property. `ApiEnum<string, Effort>` has an implicit conversion from the enum, so assign `Effort.High` directly.
+
+```csharp
+OutputConfig = new OutputConfig { Effort = Effort.High },
+```
+
+Values: `Effort.Low`, `Effort.Medium`, `Effort.High`, `Effort.Max`. Combine with `Thinking = new ThinkingConfigAdaptive()` for cost-quality control.
+
+---
+
+## Prompt Caching
+
+`System` takes `MessageCreateParamsSystem?` — a union of `string` or `List<TextBlockParam>`. There is no `SystemTextBlockParam`; use plain `TextBlockParam`. The implicit conversion needs the concrete `List<TextBlockParam>` type (array literals won't convert). For placement patterns and the silent-invalidator audit checklist, see `shared/prompt-caching.md`.
+
+```csharp
+System = new List<TextBlockParam> {
+    new() {
+        Text = longSystemPrompt,
+        CacheControl = new CacheControlEphemeral(),  // auto-sets Type = "ephemeral"
+    },
+},
+```
+
+Optional `Ttl` on `CacheControlEphemeral`: `new() { Ttl = Ttl.Ttl1h }` or `Ttl.Ttl5m`. `CacheControl` also exists on `Tool.CacheControl` and top-level `MessageCreateParams.CacheControl`.
+
+Verify hits via `response.Usage.CacheCreationInputTokens` / `response.Usage.CacheReadInputTokens`.
+
+---
+
+## Token Counting
+
+```csharp
+MessageTokensCount result = await client.Messages.CountTokens(new MessageCountTokensParams {
+    Model = Model.ClaudeOpus4_6,
+    Messages = [new() { Role = Role.User, Content = "Hello" }],
+});
+long tokens = result.InputTokens;
+```
+
+`MessageCountTokensParams.Tools` uses a different union type (`MessageCountTokensTool`) than `MessageCreateParams.Tools` (`ToolUnion`) — if you're passing tools, the compiler will tell you when it matters.
+
+---
+
+## Structured Output
+
+```csharp
+OutputConfig = new OutputConfig {
+    Format = new JsonOutputFormat {
+        Schema = new Dictionary<string, JsonElement> {
+            ["type"] = JsonSerializer.SerializeToElement("object"),
+            ["properties"] = JsonSerializer.SerializeToElement(
+                new { name = new { type = "string" } }),
+            ["required"] = JsonSerializer.SerializeToElement(new[] { "name" }),
+        },
+    },
+},
+```
+
+`JsonOutputFormat.Type` is auto-set to `"json_schema"` by the constructor. `Schema` is `required`.
+
+---
+
+## PDF / Document Input
+
+`DocumentBlockParam` takes a `DocumentBlockParamSource` union: `Base64PdfSource` / `UrlPdfSource` / `PlainTextSource` / `ContentBlockSource`. `Base64PdfSource` auto-sets `MediaType = "application/pdf"` and `Type = "base64"`.
+
+```csharp
+new MessageParam {
+    Role = Role.User,
+    Content = new List<ContentBlockParam> {
+        new DocumentBlockParam { Source = new Base64PdfSource { Data = base64String } },
+        new TextBlockParam { Text = "Summarize this PDF" },
+    },
+}
+```
+
+---
+
+## Server-Side Tools
+
+Web search, bash, text editor, and code execution are built-in server tools. Type names are version-suffixed; constructors auto-set `name`/`type`. All implicit-convert to `ToolUnion`.
+
+```csharp
+Tools = [
+    new WebSearchTool20260209(),
+    new ToolBash20250124(),
+    new ToolTextEditor20250728(),
+    new CodeExecutionTool20260120(),
+],
+```
+
+Also available: `WebFetchTool20260209`, `MemoryTool20250818`. `WebSearchTool20260209` optionals: `AllowedDomains`, `BlockedDomains`, `MaxUses`, `UserLocation`.
+
+---
+
+## Files API (Beta)
+
+Files live under `client.Beta.Files` (namespace `Anthropic.Models.Beta.Files`). `BinaryContent` implicit-converts from `Stream` and `byte[]`.
+
+```csharp
+using Anthropic.Models.Beta.Files;
+using Anthropic.Models.Beta.Messages;
+
+FileMetadata meta = await client.Beta.Files.Upload(
+    new FileUploadParams { File = File.OpenRead("doc.pdf") });
+
+// Referencing the uploaded file requires Beta message types:
+new BetaRequestDocumentBlock {
+    Source = new BetaFileDocumentSource { FileID = meta.ID },
+}
+```
+
+The non-beta `DocumentBlockParamSource` union has no file-ID variant — file references need `client.Beta.Messages.Create()`.

--- a/.claude/skills/claude-api/curl/examples.md
+++ b/.claude/skills/claude-api/curl/examples.md
@@ -1,0 +1,216 @@
+# Claude API — cURL / Raw HTTP
+
+Use these examples when the user needs raw HTTP requests or is working in a language without an official SDK.
+
+## Setup
+
+```bash
+export ANTHROPIC_API_KEY="your-api-key"
+```
+
+---
+
+## Basic Message Request
+
+```bash
+curl https://api.anthropic.com/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "claude-opus-4-6",
+    "max_tokens": 16000,
+    "messages": [
+      {"role": "user", "content": "What is the capital of France?"}
+    ]
+  }'
+```
+
+### Parsing the response
+
+Use `jq` to extract fields from the JSON response. Do not use `grep`/`sed` —
+JSON strings can contain any character and regex parsing will break on quotes,
+escapes, or multi-line content.
+
+```bash
+# Capture the response, then extract fields
+response=$(curl -s https://api.anthropic.com/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{"model":"claude-opus-4-6","max_tokens":16000,"messages":[{"role":"user","content":"Hello"}]}')
+
+# Print the first text block (-r strips the JSON quotes)
+echo "$response" | jq -r '.content[0].text'
+
+# Read usage fields
+input_tokens=$(echo "$response" | jq -r '.usage.input_tokens')
+output_tokens=$(echo "$response" | jq -r '.usage.output_tokens')
+
+# Read stop reason (for tool-use loops)
+stop_reason=$(echo "$response" | jq -r '.stop_reason')
+
+# Extract all text blocks (content is an array; filter to type=="text")
+echo "$response" | jq -r '.content[] | select(.type == "text") | .text'
+```
+
+
+---
+
+## Streaming (SSE)
+
+```bash
+curl https://api.anthropic.com/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "claude-opus-4-6",
+    "max_tokens": 64000,
+    "stream": true,
+    "messages": [{"role": "user", "content": "Write a haiku"}]
+  }'
+```
+
+The response is a stream of Server-Sent Events:
+
+```
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_...","type":"message",...}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":12}}
+
+event: message_stop
+data: {"type":"message_stop"}
+```
+
+---
+
+## Tool Use
+
+```bash
+curl https://api.anthropic.com/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "claude-opus-4-6",
+    "max_tokens": 16000,
+    "tools": [{
+      "name": "get_weather",
+      "description": "Get current weather for a location",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "location": {"type": "string", "description": "City name"}
+        },
+        "required": ["location"]
+      }
+    }],
+    "messages": [{"role": "user", "content": "What is the weather in Paris?"}]
+  }'
+```
+
+When Claude responds with a `tool_use` block, send the result back:
+
+```bash
+curl https://api.anthropic.com/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "claude-opus-4-6",
+    "max_tokens": 16000,
+    "tools": [{
+      "name": "get_weather",
+      "description": "Get current weather for a location",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "location": {"type": "string", "description": "City name"}
+        },
+        "required": ["location"]
+      }
+    }],
+    "messages": [
+      {"role": "user", "content": "What is the weather in Paris?"},
+      {"role": "assistant", "content": [
+        {"type": "text", "text": "Let me check the weather."},
+        {"type": "tool_use", "id": "toolu_abc123", "name": "get_weather", "input": {"location": "Paris"}}
+      ]},
+      {"role": "user", "content": [
+        {"type": "tool_result", "tool_use_id": "toolu_abc123", "content": "72°F and sunny"}
+      ]}
+    ]
+  }'
+```
+
+---
+
+## Prompt Caching
+
+Put `cache_control` on the last block of the stable prefix. See `shared/prompt-caching.md` for placement patterns and the silent-invalidator audit checklist.
+
+```bash
+curl https://api.anthropic.com/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "claude-opus-4-6",
+    "max_tokens": 16000,
+    "system": [
+      {"type": "text", "text": "<large shared prompt...>", "cache_control": {"type": "ephemeral"}}
+    ],
+    "messages": [{"role": "user", "content": "Summarize the key points"}]
+  }'
+```
+
+For 1-hour TTL: `"cache_control": {"type": "ephemeral", "ttl": "1h"}`. Top-level `"cache_control"` on the request body auto-places on the last cacheable block. Verify hits via the response `usage.cache_creation_input_tokens` / `usage.cache_read_input_tokens` fields.
+
+---
+
+## Extended Thinking
+
+> **Opus 4.6 and Sonnet 4.6:** Use adaptive thinking. `budget_tokens` is deprecated on both Opus 4.6 and Sonnet 4.6.
+> **Older models:** Use `"type": "enabled"` with `"budget_tokens": N` (must be < `max_tokens`, min 1024).
+
+```bash
+# Opus 4.6: adaptive thinking (recommended)
+curl https://api.anthropic.com/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "claude-opus-4-6",
+    "max_tokens": 16000,
+    "thinking": {
+      "type": "adaptive"
+    },
+    "output_config": {
+      "effort": "high"
+    },
+    "messages": [{"role": "user", "content": "Solve this step by step..."}]
+  }'
+```
+
+---
+
+## Required Headers
+
+| Header              | Value              | Description                |
+| ------------------- | ------------------ | -------------------------- |
+| `Content-Type`      | `application/json` | Required                   |
+| `x-api-key`         | Your API key       | Authentication             |
+| `anthropic-version` | `2023-06-01`       | API version                |
+| `anthropic-beta`    | Beta feature IDs   | Required for beta features |

--- a/.claude/skills/claude-api/curl/managed-agents.md
+++ b/.claude/skills/claude-api/curl/managed-agents.md
@@ -1,0 +1,333 @@
+# Managed Agents — cURL / Raw HTTP
+
+Use these examples when the user needs raw HTTP requests or is working without an SDK.
+
+## Setup
+
+```bash
+export ANTHROPIC_API_KEY="your-api-key"
+
+# Common headers
+HEADERS=(
+  -H "Content-Type: application/json"
+  -H "x-api-key: $ANTHROPIC_API_KEY"
+  -H "anthropic-version: 2023-06-01"
+  -H "anthropic-beta: managed-agents-2026-04-01"
+)
+```
+
+---
+
+## Create an Environment
+
+```bash
+curl -X POST https://api.anthropic.com/v1/environments \
+  "${HEADERS[@]}" \
+  -d '{
+    "name": "my-dev-env",
+    "config": {
+      "type": "cloud",
+      "networking": { "type": "unrestricted" }
+    }
+  }'
+```
+
+### With restricted networking
+
+```bash
+curl -X POST https://api.anthropic.com/v1/environments \
+  "${HEADERS[@]}" \
+  -d '{
+    "name": "restricted-env",
+    "config": {
+      "type": "cloud",
+      "networking": {
+        "type": "package_managers_and_custom",
+        "allowed_hosts": ["api.example.com"]
+      }
+    }
+  }'
+```
+
+---
+
+## Create an Agent (required first step)
+
+> ⚠️ **There is no inline agent config.** Under `managed-agents-2026-04-01`, `model`/`system`/`tools` are top-level fields on `POST /v1/agents`, not on the session. Always create the agent first — the session only takes `"agent": {"type": "agent", "id": "..."}`.
+
+### Minimal
+
+```bash
+# 1. Create the agent
+curl -X POST https://api.anthropic.com/v1/agents \
+  "${HEADERS[@]}" \
+  -d '{
+    "name": "Coding Assistant",
+    "model": "claude-opus-4-6",
+    "tools": [{ "type": "agent_toolset_20260401" }]
+  }'
+# → { "id": "agent_abc123", ... }
+
+# 2. Start a session
+curl -X POST https://api.anthropic.com/v1/sessions \
+  "${HEADERS[@]}" \
+  -d '{
+    "agent": { "type": "agent", "id": "agent_abc123", "version": "1772585501101368014" },
+    "environment_id": "env_abc123"
+  }'
+```
+
+### With system prompt, custom tools, and GitHub repo
+
+```bash
+# 1. Create the agent
+curl -X POST https://api.anthropic.com/v1/agents \
+  "${HEADERS[@]}" \
+  -d '{
+    "name": "Code Reviewer",
+    "model": "claude-opus-4-6",
+    "system": "You are a senior code reviewer. Be thorough and constructive.",
+    "tools": [
+      { "type": "agent_toolset_20260401" },
+      {
+        "type": "custom",
+        "name": "run_linter",
+        "description": "Run the project linter on a file",
+        "input_schema": {
+          "type": "object",
+          "properties": {
+            "file_path": { "type": "string", "description": "Path to lint" }
+          },
+          "required": ["file_path"]
+        }
+      }
+    ]
+  }'
+
+# 2. Start a session with the repo mounted
+curl -X POST https://api.anthropic.com/v1/sessions \
+  "${HEADERS[@]}" \
+  -d '{
+    "agent": { "type": "agent", "id": "agent_abc123", "version": "1772585501101368014" },
+    "environment_id": "env_abc123",
+    "title": "Code review session",
+    "resources": [
+      {
+        "type": "github_repository",
+        "url": "https://github.com/owner/repo",
+        "mount_path": "/workspace/repo",
+        "authorization_token": "ghp_...",
+        "branch": "feature-branch"
+      }
+    ]
+  }'
+```
+
+---
+
+## Send a User Message
+
+```bash
+curl -X POST https://api.anthropic.com/v1/sessions/$SESSION_ID/events \
+  "${HEADERS[@]}" \
+  -d '{
+    "events": [
+      {
+        "type": "user.message",
+        "content": [{ "type": "text", "text": "Review the auth module for security issues" }]
+      }
+    ]
+  }'
+```
+
+---
+
+## Stream Events (SSE)
+
+```bash
+curl -N https://api.anthropic.com/v1/sessions/$SESSION_ID/events/stream \
+  "${HEADERS[@]}"
+```
+
+Response format:
+
+```
+event: session.status_running
+data: {"type":"session.status_running","id":"sevt_...","processed_at":"..."}
+
+event: agent.message
+data: {"type":"agent.message","id":"sevt_...","content":[{"type":"text","text":"I'll review..."}],"processed_at":"..."}
+
+event: session.status_idle
+data: {"type":"session.status_idle","id":"sevt_...","processed_at":"..."}
+```
+
+---
+
+## Poll Events
+
+```bash
+# Get all events
+curl https://api.anthropic.com/v1/sessions/$SESSION_ID/events \
+  "${HEADERS[@]}"
+
+# Paginated — get next page of events
+curl "https://api.anthropic.com/v1/sessions/$SESSION_ID/events?page=page_abc123" \
+  "${HEADERS[@]}"
+```
+
+---
+
+## Provide Custom Tool Result
+
+When the agent calls a custom tool, send the result back:
+
+```bash
+curl -X POST https://api.anthropic.com/v1/sessions/$SESSION_ID/events \
+  "${HEADERS[@]}" \
+  -d '{
+    "events": [
+      {
+        "type": "user.custom_tool_result",
+        "custom_tool_use_id": "sevt_abc123",
+        "content": [{ "type": "text", "text": "No linting errors found." }]
+      }
+    ]
+  }'
+```
+
+---
+
+## Interrupt a Running Session
+
+```bash
+curl -X POST https://api.anthropic.com/v1/sessions/$SESSION_ID/events \
+  "${HEADERS[@]}" \
+  -d '{
+    "events": [
+      {
+        "type": "interrupt"
+      }
+    ]
+  }'
+```
+
+---
+
+## Get Session Details
+
+```bash
+curl https://api.anthropic.com/v1/sessions/$SESSION_ID \
+  "${HEADERS[@]}"
+```
+
+---
+
+## List Sessions
+
+```bash
+curl https://api.anthropic.com/v1/sessions \
+  "${HEADERS[@]}"
+```
+
+---
+
+## Delete a Session
+
+```bash
+curl -X DELETE https://api.anthropic.com/v1/sessions/$SESSION_ID \
+  "${HEADERS[@]}"
+```
+
+---
+
+## Upload a File
+
+```bash
+curl -X POST https://api.anthropic.com/v1/files \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: files-api-2025-04-14" \
+  -F "file=@path/to/file.txt" \
+  -F "purpose=agent"
+```
+
+---
+
+## List and Download Session Files
+
+List files the agent wrote to `/mnt/session/outputs/` during a session, then download them.
+
+```bash
+# List files associated with a session
+curl "https://api.anthropic.com/v1/files?scope=$SESSION_ID" \
+  "${HEADERS[@]}"
+
+# Download a specific file
+curl "https://api.anthropic.com/v1/files/$FILE_ID/content" \
+  "${HEADERS[@]}" \
+  -o downloaded_file.txt
+```
+
+---
+
+## List Agents
+
+```bash
+curl https://api.anthropic.com/v1/agents \
+  "${HEADERS[@]}"
+```
+
+---
+
+## MCP Server Integration
+
+```bash
+# 1. Agent declares MCP server (no auth here — auth goes in a vault)
+curl -X POST https://api.anthropic.com/v1/agents \
+  "${HEADERS[@]}" \
+  -d '{
+    "name": "MCP Agent",
+    "model": "claude-opus-4-6",
+    "mcp_servers": [
+      { "type": "url", "name": "my-tools", "url": "https://my-mcp-server.example.com/sse" }
+    ],
+    "tools": [
+      { "type": "agent_toolset_20260401" },
+      { "type": "mcp_toolset", "mcp_server_name": "my-tools" }
+    ]
+  }'
+
+# 2. Session attaches vault containing credentials for that MCP server URL
+curl -X POST https://api.anthropic.com/v1/sessions \
+  "${HEADERS[@]}" \
+  -d '{
+    "agent": "agent_abc123",
+    "environment_id": "env_abc123",
+    "vault_ids": ["vlt_abc123"]
+  }'
+```
+
+See `shared/managed-agents-tools.md` §Vaults for creating vaults and adding credentials.
+
+---
+
+## Tool Configuration
+
+```bash
+curl -X POST https://api.anthropic.com/v1/agents \
+  "${HEADERS[@]}" \
+  -d '{
+    "name": "Restricted Agent",
+    "model": "claude-opus-4-6",
+    "tools": [
+      {
+        "type": "agent_toolset_20260401",
+        "default_config": { "enabled": true },
+        "configs": [
+          { "name": "bash", "enabled": false }
+        ]
+      }
+    ]
+  }'
+```

--- a/.claude/skills/claude-api/go/claude-api.md
+++ b/.claude/skills/claude-api/go/claude-api.md
@@ -1,0 +1,421 @@
+# Claude API — Go
+
+> **Note:** The Go SDK supports the Claude API and beta tool use with `BetaToolRunner`. Agent SDK is not yet available for Go.
+
+## Installation
+
+```bash
+go get github.com/anthropics/anthropic-sdk-go
+```
+
+## Client Initialization
+
+```go
+import (
+    "github.com/anthropics/anthropic-sdk-go"
+    "github.com/anthropics/anthropic-sdk-go/option"
+)
+
+// Default (uses ANTHROPIC_API_KEY env var)
+client := anthropic.NewClient()
+
+// Explicit API key
+client := anthropic.NewClient(
+    option.WithAPIKey("your-api-key"),
+)
+```
+
+---
+
+## Basic Message Request
+
+```go
+response, err := client.Messages.New(context.Background(), anthropic.MessageNewParams{
+    Model:     anthropic.ModelClaudeOpus4_6,
+    MaxTokens: 16000,
+    Messages: []anthropic.MessageParam{
+        anthropic.NewUserMessage(anthropic.NewTextBlock("What is the capital of France?")),
+    },
+})
+if err != nil {
+    log.Fatal(err)
+}
+for _, block := range response.Content {
+    switch variant := block.AsAny().(type) {
+    case anthropic.TextBlock:
+        fmt.Println(variant.Text)
+    }
+}
+```
+
+---
+
+## Streaming
+
+```go
+stream := client.Messages.NewStreaming(context.Background(), anthropic.MessageNewParams{
+    Model:     anthropic.ModelClaudeOpus4_6,
+    MaxTokens: 64000,
+    Messages: []anthropic.MessageParam{
+        anthropic.NewUserMessage(anthropic.NewTextBlock("Write a haiku")),
+    },
+})
+
+for stream.Next() {
+    event := stream.Current()
+    switch eventVariant := event.AsAny().(type) {
+    case anthropic.ContentBlockDeltaEvent:
+        switch deltaVariant := eventVariant.Delta.AsAny().(type) {
+        case anthropic.TextDelta:
+            fmt.Print(deltaVariant.Text)
+        }
+    }
+}
+if err := stream.Err(); err != nil {
+    log.Fatal(err)
+}
+```
+
+**Accumulating the final message** (there is no `GetFinalMessage()` on the stream):
+
+```go
+stream := client.Messages.NewStreaming(ctx, params)
+message := anthropic.Message{}
+for stream.Next() {
+    message.Accumulate(stream.Current())
+}
+if err := stream.Err(); err != nil { log.Fatal(err) }
+// message.Content now has the complete response
+```
+
+
+---
+
+## Tool Use
+
+### Tool Runner (Beta — Recommended)
+
+**Beta:** The Go SDK provides `BetaToolRunner` for automatic tool use loops via the `toolrunner` package.
+
+```go
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/anthropics/anthropic-sdk-go"
+    "github.com/anthropics/anthropic-sdk-go/toolrunner"
+)
+
+// Define tool input with jsonschema tags for automatic schema generation
+type GetWeatherInput struct {
+    City string `json:"city" jsonschema:"required,description=The city name"`
+}
+
+// Create a tool with automatic schema generation from struct tags
+weatherTool, err := toolrunner.NewBetaToolFromJSONSchema(
+    "get_weather",
+    "Get current weather for a city",
+    func(ctx context.Context, input GetWeatherInput) (anthropic.BetaToolResultBlockParamContentUnion, error) {
+        return anthropic.BetaToolResultBlockParamContentUnion{
+            OfText: &anthropic.BetaTextBlockParam{
+                Text: fmt.Sprintf("The weather in %s is sunny, 72°F", input.City),
+            },
+        }, nil
+    },
+)
+if err != nil {
+    log.Fatal(err)
+}
+
+// Create a tool runner that handles the conversation loop automatically
+runner := client.Beta.Messages.NewToolRunner(
+    []anthropic.BetaTool{weatherTool},
+    anthropic.BetaToolRunnerParams{
+        BetaMessageNewParams: anthropic.BetaMessageNewParams{
+            Model:     anthropic.ModelClaudeOpus4_6,
+            MaxTokens: 16000,
+            Messages: []anthropic.BetaMessageParam{
+                anthropic.NewBetaUserMessage(anthropic.NewBetaTextBlock("What's the weather in Paris?")),
+            },
+        },
+        MaxIterations: 5,
+    },
+)
+
+// Run until Claude produces a final response
+message, err := runner.RunToCompletion(context.Background())
+if err != nil {
+    log.Fatal(err)
+}
+
+// RunToCompletion returns *BetaMessage; content is []BetaContentBlockUnion.
+// Narrow via AsAny() switch — note the Beta-namespace types (BetaTextBlock,
+// not TextBlock):
+for _, block := range message.Content {
+    switch block := block.AsAny().(type) {
+    case anthropic.BetaTextBlock:
+        fmt.Println(block.Text)
+    }
+}
+```
+
+**Key features of the Go tool runner:**
+
+- Automatic schema generation from Go structs via `jsonschema` tags
+- `RunToCompletion()` for simple one-shot usage
+- `All()` iterator for processing each message in the conversation
+- `NextMessage()` for step-by-step iteration
+- Streaming variant via `NewToolRunnerStreaming()` with `AllStreaming()`
+
+### Manual Loop
+
+For fine-grained control over the agentic loop, define tools with `ToolParam`, check `StopReason`, execute tools yourself, and feed `tool_result` blocks back. This is the pattern when you need to intercept, validate, or log tool calls.
+
+Derived from `anthropic-sdk-go/examples/tools/main.go`.
+
+```go
+package main
+
+import (
+    "context"
+    "encoding/json"
+    "fmt"
+    "log"
+
+    "github.com/anthropics/anthropic-sdk-go"
+)
+
+func main() {
+    client := anthropic.NewClient()
+
+    // 1. Define tools. ToolParam.InputSchema uses a map, no struct tags needed.
+    addTool := anthropic.ToolParam{
+        Name:        "add",
+        Description: anthropic.String("Add two integers"),
+        InputSchema: anthropic.ToolInputSchemaParam{
+            Properties: map[string]any{
+                "a": map[string]any{"type": "integer"},
+                "b": map[string]any{"type": "integer"},
+            },
+        },
+    }
+    // ToolParam must be wrapped in ToolUnionParam for the Tools slice
+    tools := []anthropic.ToolUnionParam{{OfTool: &addTool}}
+
+    messages := []anthropic.MessageParam{
+        anthropic.NewUserMessage(anthropic.NewTextBlock("What is 2 + 3?")),
+    }
+
+    for {
+        resp, err := client.Messages.New(context.Background(), anthropic.MessageNewParams{
+            Model:     anthropic.ModelClaudeSonnet4_6,
+            MaxTokens: 16000,
+            Messages:  messages,
+            Tools:     tools,
+        })
+        if err != nil {
+            log.Fatal(err)
+        }
+
+        // 2. Append the assistant response to history BEFORE processing tool calls.
+        //    resp.ToParam() converts Message → MessageParam in one call.
+        messages = append(messages, resp.ToParam())
+
+        // 3. Walk content blocks. ContentBlockUnion is a flattened struct;
+        //    use block.AsAny().(type) to switch on the actual variant.
+        toolResults := []anthropic.ContentBlockParamUnion{}
+        for _, block := range resp.Content {
+            switch variant := block.AsAny().(type) {
+            case anthropic.TextBlock:
+                fmt.Println(variant.Text)
+            case anthropic.ToolUseBlock:
+                // 4. Parse the tool input. Use variant.JSON.Input.Raw() to get the
+                //    raw JSON — block.Input is json.RawMessage, not the parsed value.
+                var in struct {
+                    A int `json:"a"`
+                    B int `json:"b"`
+                }
+                if err := json.Unmarshal([]byte(variant.JSON.Input.Raw()), &in); err != nil {
+                    log.Fatal(err)
+                }
+                result := fmt.Sprintf("%d", in.A+in.B)
+                // 5. NewToolResultBlock(toolUseID, content, isError) builds the
+                //    ContentBlockParamUnion for you. block.ID is the tool_use_id.
+                toolResults = append(toolResults,
+                    anthropic.NewToolResultBlock(block.ID, result, false))
+            }
+        }
+
+        // 6. Exit when Claude stops asking for tools
+        if resp.StopReason != anthropic.StopReasonToolUse {
+            break
+        }
+
+        // 7. Tool results go in a user message (variadic: all results in one turn)
+        messages = append(messages, anthropic.NewUserMessage(toolResults...))
+    }
+}
+```
+
+**Key API surface:**
+
+| Symbol | Purpose |
+|---|---|
+| `resp.ToParam()` | Convert `Message` response → `MessageParam` for history |
+| `block.AsAny().(type)` | Type-switch on `ContentBlockUnion` variants |
+| `variant.JSON.Input.Raw()` | Raw JSON string of tool input (for `json.Unmarshal`) |
+| `anthropic.NewToolResultBlock(id, content, isError)` | Build `tool_result` block |
+| `anthropic.NewUserMessage(blocks...)` | Wrap tool results as a user turn |
+| `anthropic.StopReasonToolUse` | `StopReason` constant to check loop termination |
+| `anthropic.ToolUnionParam{OfTool: &t}` | Wrap `ToolParam` in the union for `Tools:` |
+
+---
+
+## Thinking
+
+Enable Claude's internal reasoning by setting `Thinking` in `MessageNewParams`. The response will contain `ThinkingBlock` content before the final `TextBlock`.
+
+**Adaptive thinking is the recommended mode for Claude 4.6+ models.** Claude decides dynamically when and how much to think. Combine with the `effort` parameter for cost-quality control.
+
+Derived from `anthropic-sdk-go/message.go` (`ThinkingConfigParamUnion`, `NewThinkingConfigAdaptiveParam`).
+
+```go
+// There is no ThinkingConfigParamOfAdaptive helper — construct the union
+// struct-literal directly and take the address of the variant.
+adaptive := anthropic.NewThinkingConfigAdaptiveParam()
+params := anthropic.MessageNewParams{
+    Model:     anthropic.ModelClaudeSonnet4_6,
+    MaxTokens: 16000,
+    Thinking:  anthropic.ThinkingConfigParamUnion{OfAdaptive: &adaptive},
+    Messages: []anthropic.MessageParam{
+        anthropic.NewUserMessage(anthropic.NewTextBlock("How many r's in strawberry?")),
+    },
+}
+
+resp, err := client.Messages.New(context.Background(), params)
+if err != nil {
+    log.Fatal(err)
+}
+
+// ThinkingBlock(s) precede TextBlock in content
+for _, block := range resp.Content {
+    switch b := block.AsAny().(type) {
+    case anthropic.ThinkingBlock:
+        fmt.Println("[thinking]", b.Thinking)
+    case anthropic.TextBlock:
+        fmt.Println(b.Text)
+    }
+}
+```
+
+> **Deprecated:** `ThinkingConfigParamOfEnabled(budgetTokens)` (fixed-budget extended thinking) still works on Claude 4.6 but is deprecated. Use adaptive thinking above.
+
+To disable: `anthropic.ThinkingConfigParamUnion{OfDisabled: &anthropic.ThinkingConfigDisabledParam{}}`.
+
+---
+
+## Prompt Caching
+
+`System` is `[]TextBlockParam`; set `CacheControl` on the last block to cache tools + system together. For placement patterns and the silent-invalidator audit checklist, see `shared/prompt-caching.md`.
+
+```go
+System: []anthropic.TextBlockParam{{
+    Text:         longSystemPrompt,
+    CacheControl: anthropic.NewCacheControlEphemeralParam(), // default 5m TTL
+}},
+```
+
+For 1-hour TTL: `anthropic.CacheControlEphemeralParam{TTL: anthropic.CacheControlEphemeralTTLTTL1h}`. There's also a top-level `CacheControl` on `MessageNewParams` that auto-places on the last cacheable block.
+
+Verify hits via `resp.Usage.CacheCreationInputTokens` / `resp.Usage.CacheReadInputTokens`.
+
+---
+
+## Server-Side Tools
+
+Version-suffixed struct names with `Param` suffix. `Name`/`Type` are `constant.*` types — zero value marshals correctly, so `{}` works. Wrap in `ToolUnionParam` with the matching `Of*` field.
+
+```go
+Tools: []anthropic.ToolUnionParam{
+    {OfWebSearchTool20260209: &anthropic.WebSearchTool20260209Param{}},
+    {OfBashTool20250124: &anthropic.ToolBash20250124Param{}},
+    {OfTextEditor20250728: &anthropic.ToolTextEditor20250728Param{}},
+    {OfCodeExecutionTool20260120: &anthropic.CodeExecutionTool20260120Param{}},
+},
+```
+
+Also available: `WebFetchTool20260209Param`, `MemoryTool20250818Param`, `ToolSearchToolBm25_20251119Param`, `ToolSearchToolRegex20251119Param`.
+
+---
+
+## PDF / Document Input
+
+`NewDocumentBlock` generic helper accepts any source type. `MediaType`/`Type` are auto-set.
+
+```go
+b64 := base64.StdEncoding.EncodeToString(pdfBytes)
+
+msg := anthropic.NewUserMessage(
+    anthropic.NewDocumentBlock(anthropic.Base64PDFSourceParam{Data: b64}),
+    anthropic.NewTextBlock("Summarize this document"),
+)
+```
+
+Other sources: `URLPDFSourceParam{URL: "https://..."}`, `PlainTextSourceParam{Data: "..."}`.
+
+---
+
+## Files API (Beta)
+
+Under `client.Beta.Files`. Method is **`Upload`** (NOT `New`/`Create`), params struct is `BetaFileUploadParams`. The `File` field takes an `io.Reader`; use `anthropic.File()` to attach a filename + content-type for the multipart encoding.
+
+```go
+f, _ := os.Open("./upload_me.txt")
+defer f.Close()
+
+meta, err := client.Beta.Files.Upload(ctx, anthropic.BetaFileUploadParams{
+    File:  anthropic.File(f, "upload_me.txt", "text/plain"),
+    Betas: []anthropic.AnthropicBeta{anthropic.AnthropicBetaFilesAPI2025_04_14},
+})
+// meta.ID is the file_id to reference in subsequent message requests
+```
+
+Other `Beta.Files` methods: `List`, `Delete`, `Download`, `GetMetadata`.
+
+---
+
+## Context Editing / Compaction (Beta)
+
+Use `Beta.Messages.New` with `ContextManagement` on `BetaMessageNewParams`. There is no `NewBetaAssistantMessage` — use `.ToParam()` for the round-trip.
+
+```go
+params := anthropic.BetaMessageNewParams{
+    Model:     anthropic.ModelClaudeOpus4_6,  // also supported: ModelClaudeSonnet4_6
+    MaxTokens: 16000,
+    Betas:     []anthropic.AnthropicBeta{"compact-2026-01-12"},
+    ContextManagement: anthropic.BetaContextManagementConfigParam{
+        Edits: []anthropic.BetaContextManagementConfigEditUnionParam{
+            {OfCompact20260112: &anthropic.BetaCompact20260112EditParam{}},
+        },
+    },
+    Messages: []anthropic.BetaMessageParam{ /* ... */ },
+}
+
+resp, err := client.Beta.Messages.New(ctx, params)
+if err != nil {
+    log.Fatal(err)
+}
+
+// Round-trip: append response to history via .ToParam()
+params.Messages = append(params.Messages, resp.ToParam())
+
+// Read compaction blocks from the response
+for _, block := range resp.Content {
+    if c, ok := block.AsAny().(anthropic.BetaCompactionBlock); ok {
+        fmt.Println("compaction summary:", c.Content)
+    }
+}
+```
+
+Other edit types: `BetaClearToolUses20250919EditParam`, `BetaClearThinking20251015EditParam`.

--- a/.claude/skills/claude-api/go/managed-agents/README.md
+++ b/.claude/skills/claude-api/go/managed-agents/README.md
@@ -1,0 +1,561 @@
+# Managed Agents — Go
+
+> **Bindings not shown here:** This README covers the most common managed-agents flows for Go. If you need a class, method, namespace, field, or behavior that isn't shown, WebFetch the Go SDK repo **or the relevant docs page** from `shared/live-sources.md` rather than guess. Do not extrapolate from cURL shapes or another language's SDK.
+
+> **Agents are persistent — create once, reference by ID.** Store the agent ID returned by `agents.New` and pass it to every subsequent `sessions.New`; do not call `agents.New` in the request path. The Anthropic CLI is one convenient way to create agents and environments from version-controlled YAML — its URL is in `shared/live-sources.md`. The examples below show in-code creation for completeness; in production the create call belongs in setup, not in the request path.
+
+## Installation
+
+```bash
+go get github.com/anthropics/anthropic-sdk-go
+```
+
+## Client Initialization
+
+```go
+import (
+    "context"
+
+    "github.com/anthropics/anthropic-sdk-go"
+    "github.com/anthropics/anthropic-sdk-go/option"
+)
+
+// Default (uses ANTHROPIC_API_KEY env var)
+client := anthropic.NewClient()
+
+// Explicit API key
+client := anthropic.NewClient(
+    option.WithAPIKey("your-api-key"),
+)
+
+ctx := context.Background()
+```
+
+---
+
+## Create an Environment
+
+```go
+environment, err := client.Beta.Environments.New(ctx, anthropic.BetaEnvironmentNewParams{
+    Name: "my-dev-env",
+    Config: anthropic.BetaCloudConfigParams{
+        Networking: anthropic.BetaCloudConfigParamsNetworkingUnion{
+            OfUnrestricted: &anthropic.UnrestrictedNetworkParam{},
+        },
+    },
+})
+if err != nil {
+    panic(err)
+}
+fmt.Println(environment.ID) // env_...
+```
+
+---
+
+## Create an Agent (required first step)
+
+> ⚠️ **There is no inline agent config.** `Model`/`System`/`Tools` live on the agent object, not the session. Always start with `Beta.Agents.New()` — the session only takes `Agent: anthropic.BetaSessionNewParamsAgentUnion{OfString: anthropic.String(agent.ID)}` (or the typed `OfBetaManagedAgentsAgents` variant when you need a specific version).
+
+### Minimal
+
+```go
+// 1. Create the agent (reusable, versioned)
+agent, err := client.Beta.Agents.New(ctx, anthropic.BetaAgentNewParams{
+    Name: "Coding Assistant",
+    Model: anthropic.BetaManagedAgentsModelConfigParams{
+        ID:   "claude-opus-4-6",
+        Type: anthropic.BetaManagedAgentsModelConfigParamsTypeModelConfig,
+    },
+    System: anthropic.String("You are a helpful coding assistant."),
+    Tools: []anthropic.BetaAgentNewParamsToolUnion{{
+        OfAgentToolset20260401: &anthropic.BetaManagedAgentsAgentToolset20260401Params{
+            Type: anthropic.BetaManagedAgentsAgentToolset20260401ParamsTypeAgentToolset20260401,
+        },
+    }},
+})
+if err != nil {
+    panic(err)
+}
+
+// 2. Start a session
+session, err := client.Beta.Sessions.New(ctx, anthropic.BetaSessionNewParams{
+    Agent: anthropic.BetaSessionNewParamsAgentUnion{
+        OfBetaManagedAgentsAgents: &anthropic.BetaManagedAgentsAgentParams{
+            Type:    anthropic.BetaManagedAgentsAgentParamsTypeAgent,
+            ID:      agent.ID,
+            Version: anthropic.Int(agent.Version),
+        },
+    },
+    EnvironmentID: environment.ID,
+    Title:         anthropic.String("Quickstart session"),
+})
+if err != nil {
+    panic(err)
+}
+fmt.Printf("Session ID: %s, status: %s\n", session.ID, session.Status)
+```
+
+### Updating an Agent
+
+Updates create new versions; the agent object is immutable per version.
+
+```go
+updatedAgent, err := client.Beta.Agents.Update(ctx, agent.ID, anthropic.BetaAgentUpdateParams{
+    Version: agent.Version,
+    System:  anthropic.String("You are a helpful coding agent. Always write tests."),
+})
+if err != nil {
+    panic(err)
+}
+fmt.Printf("New version: %d\n", updatedAgent.Version)
+
+// List all versions
+iter := client.Beta.Agents.Versions.ListAutoPaging(ctx, agent.ID, anthropic.BetaAgentVersionListParams{})
+for iter.Next() {
+    version := iter.Current()
+    fmt.Printf("Version %d: %s\n", version.Version, version.UpdatedAt.Format(time.RFC3339))
+}
+if err := iter.Err(); err != nil {
+    panic(err)
+}
+
+// Archive the agent
+_, err = client.Beta.Agents.Archive(ctx, agent.ID, anthropic.BetaAgentArchiveParams{})
+if err != nil {
+    panic(err)
+}
+```
+
+---
+
+## Send a User Message
+
+```go
+_, err = client.Beta.Sessions.Events.Send(ctx, session.ID, anthropic.BetaSessionEventSendParams{
+    Events: []anthropic.SendEventsParamsUnion{{
+        OfUserMessage: &anthropic.BetaManagedAgentsUserMessageEventParams{
+            Type: anthropic.BetaManagedAgentsUserMessageEventParamsTypeUserMessage,
+            Content: []anthropic.BetaManagedAgentsUserMessageEventParamsContentUnion{{
+                OfText: &anthropic.BetaManagedAgentsTextBlockParam{
+                    Type: anthropic.BetaManagedAgentsTextBlockTypeText,
+                    Text: "Review the auth module",
+                },
+            }},
+        },
+    }},
+})
+if err != nil {
+    panic(err)
+}
+```
+
+> 💡 **Stream-first:** Open the stream *before* (or concurrently with) sending the message. The stream only delivers events that occur after it opens — stream-after-send means early events arrive buffered in one batch. See [Steering Patterns](../../shared/managed-agents-events.md#steering-patterns).
+
+---
+
+## Stream Events (SSE)
+
+```go
+// Open the stream first, then send the user message
+stream := client.Beta.Sessions.Events.StreamEvents(ctx, session.ID, anthropic.BetaSessionEventStreamParams{})
+defer stream.Close()
+
+if _, err := client.Beta.Sessions.Events.Send(ctx, session.ID, anthropic.BetaSessionEventSendParams{
+    Events: []anthropic.SendEventsParamsUnion{{
+        OfUserMessage: &anthropic.BetaManagedAgentsUserMessageEventParams{
+            Type: anthropic.BetaManagedAgentsUserMessageEventParamsTypeUserMessage,
+            Content: []anthropic.BetaManagedAgentsUserMessageEventParamsContentUnion{{
+                OfText: &anthropic.BetaManagedAgentsTextBlockParam{
+                    Type: anthropic.BetaManagedAgentsTextBlockTypeText,
+                    Text: "Summarize the repo README",
+                },
+            }},
+        },
+    }},
+}); err != nil {
+    panic(err)
+}
+
+events:
+for stream.Next() {
+    switch event := stream.Current().AsAny().(type) {
+    case anthropic.BetaManagedAgentsAgentMessageEvent:
+        for _, block := range event.Content {
+            fmt.Print(block.Text)
+        }
+    case anthropic.BetaManagedAgentsAgentToolUseEvent:
+        fmt.Printf("\n[Using tool: %s]\n", event.Name)
+    case anthropic.BetaManagedAgentsSessionStatusIdleEvent:
+        break events
+    case anthropic.BetaManagedAgentsSessionErrorEvent:
+        fmt.Printf("\n[Error: %s]\n", event.Error.Message)
+        break events
+    }
+}
+if err := stream.Err(); err != nil {
+    panic(err)
+}
+```
+
+### Reconnecting and Tailing
+
+When reconnecting mid-session, list past events first to dedupe, then tail live events:
+
+```go
+stream := client.Beta.Sessions.Events.StreamEvents(ctx, session.ID, anthropic.BetaSessionEventStreamParams{})
+defer stream.Close()
+
+// Stream is open and buffering. List history before tailing live.
+seenEventIDs := map[string]struct{}{}
+history := client.Beta.Sessions.Events.ListAutoPaging(ctx, session.ID, anthropic.BetaSessionEventListParams{})
+for history.Next() {
+    seenEventIDs[history.Current().ID] = struct{}{}
+}
+if err := history.Err(); err != nil {
+    panic(err)
+}
+
+// Tail live events, skipping anything already seen
+tail:
+for stream.Next() {
+    event := stream.Current()
+    if _, seen := seenEventIDs[event.ID]; seen {
+        continue
+    }
+    seenEventIDs[event.ID] = struct{}{}
+    switch event := event.AsAny().(type) {
+    case anthropic.BetaManagedAgentsAgentMessageEvent:
+        for _, block := range event.Content {
+            fmt.Print(block.Text)
+        }
+    case anthropic.BetaManagedAgentsSessionStatusIdleEvent:
+        break tail
+    }
+}
+if err := stream.Err(); err != nil {
+    panic(err)
+}
+```
+
+---
+
+## Provide Custom Tool Result
+
+> ℹ️ The Go managed-agents bindings for `user.custom_tool_result` are not yet documented in this skill or in the apps source examples. Refer to `shared/managed-agents-events.md` for the wire format and the `github.com/anthropics/anthropic-sdk-go` repository for the corresponding Go params types.
+
+---
+
+## Poll Events
+
+```go
+// Auto-paginating iterator
+iter := client.Beta.Sessions.Events.ListAutoPaging(ctx, session.ID, anthropic.BetaSessionEventListParams{})
+for iter.Next() {
+    event := iter.Current()
+    fmt.Printf("%s: %s\n", event.Type, event.ID)
+}
+if err := iter.Err(); err != nil {
+    panic(err)
+}
+```
+
+---
+
+## Upload a File
+
+```go
+csvFile, err := os.Open("data.csv")
+if err != nil {
+    panic(err)
+}
+defer csvFile.Close()
+
+file, err := client.Beta.Files.Upload(ctx, anthropic.BetaFileUploadParams{
+    File: csvFile,
+})
+if err != nil {
+    panic(err)
+}
+fmt.Printf("File ID: %s\n", file.ID)
+
+// Mount in a session
+session, err := client.Beta.Sessions.New(ctx, anthropic.BetaSessionNewParams{
+    Agent: anthropic.BetaSessionNewParamsAgentUnion{
+        OfString: anthropic.String(agent.ID),
+    },
+    EnvironmentID: environment.ID,
+    Resources: []anthropic.BetaSessionNewParamsResourceUnion{{
+        OfFile: &anthropic.BetaManagedAgentsFileResourceParams{
+            Type:      anthropic.BetaManagedAgentsFileResourceParamsTypeFile,
+            FileID:    file.ID,
+            MountPath: anthropic.String("/workspace/data.csv"),
+        },
+    }},
+})
+if err != nil {
+    panic(err)
+}
+```
+
+### Add and Manage Resources on an Existing Session
+
+```go
+// Attach an additional file to an open session
+resource, err := client.Beta.Sessions.Resources.Add(ctx, session.ID, anthropic.BetaSessionResourceAddParams{
+    BetaManagedAgentsFileResourceParams: anthropic.BetaManagedAgentsFileResourceParams{
+        Type:   anthropic.BetaManagedAgentsFileResourceParamsTypeFile,
+        FileID: file.ID,
+    },
+})
+if err != nil {
+    panic(err)
+}
+fmt.Println(resource.ID) // "sesrsc_01ABC..."
+
+// List resources on the session
+listed, err := client.Beta.Sessions.Resources.List(ctx, session.ID, anthropic.BetaSessionResourceListParams{})
+if err != nil {
+    panic(err)
+}
+for _, entry := range listed.Data {
+    fmt.Println(entry.ID, entry.Type)
+}
+
+// Detach a resource
+if _, err := client.Beta.Sessions.Resources.Delete(ctx, resource.ID, anthropic.BetaSessionResourceDeleteParams{
+    SessionID: session.ID,
+}); err != nil {
+    panic(err)
+}
+```
+
+---
+
+## List and Download Session Files
+
+> ℹ️ Listing and downloading files an agent wrote during a session is not yet documented for Go in this skill or in the apps source examples. See `shared/managed-agents-events.md` and the `github.com/anthropics/anthropic-sdk-go` repository for the `Beta.Files.List` and `Beta.Files.Download` Go params types.
+
+---
+
+## Session Management
+
+```go
+// List environments
+environments, err := client.Beta.Environments.List(ctx, anthropic.BetaEnvironmentListParams{})
+if err != nil {
+    panic(err)
+}
+
+// Retrieve a specific environment
+env, err := client.Beta.Environments.Get(ctx, environment.ID, anthropic.BetaEnvironmentGetParams{})
+if err != nil {
+    panic(err)
+}
+
+// Archive an environment (read-only, existing sessions continue)
+_, err = client.Beta.Environments.Archive(ctx, environment.ID, anthropic.BetaEnvironmentArchiveParams{})
+if err != nil {
+    panic(err)
+}
+
+// Delete an environment (only if no sessions reference it)
+_, err = client.Beta.Environments.Delete(ctx, environment.ID, anthropic.BetaEnvironmentDeleteParams{})
+if err != nil {
+    panic(err)
+}
+
+// Delete a session
+_, err = client.Beta.Sessions.Delete(ctx, session.ID, anthropic.BetaSessionDeleteParams{})
+if err != nil {
+    panic(err)
+}
+```
+
+---
+
+## MCP Server Integration
+
+```go
+// Agent declares MCP server (no auth here — auth goes in a vault)
+agent, err := client.Beta.Agents.New(ctx, anthropic.BetaAgentNewParams{
+    Name: "GitHub Assistant",
+    Model: anthropic.BetaManagedAgentsModelConfigParams{
+        ID:   "claude-opus-4-6",
+        Type: anthropic.BetaManagedAgentsModelConfigParamsTypeModelConfig,
+    },
+    MCPServers: []anthropic.BetaManagedAgentsUrlmcpServerParams{{
+        Type: anthropic.BetaManagedAgentsUrlmcpServerParamsTypeURL,
+        Name: "github",
+        URL:  "https://api.githubcopilot.com/mcp/",
+    }},
+    Tools: []anthropic.BetaAgentNewParamsToolUnion{
+        {
+            OfAgentToolset20260401: &anthropic.BetaManagedAgentsAgentToolset20260401Params{
+                Type: anthropic.BetaManagedAgentsAgentToolset20260401ParamsTypeAgentToolset20260401,
+            },
+        },
+        {
+            OfMCPToolset: &anthropic.BetaManagedAgentsMCPToolsetParams{
+                Type:          anthropic.BetaManagedAgentsMCPToolsetParamsTypeMCPToolset,
+                MCPServerName: "github",
+            },
+        },
+    },
+})
+if err != nil {
+    panic(err)
+}
+
+// Session attaches vault(s) containing credentials for those MCP server URLs
+session, err := client.Beta.Sessions.New(ctx, anthropic.BetaSessionNewParams{
+    Agent: anthropic.BetaSessionNewParamsAgentUnion{
+        OfBetaManagedAgentsAgents: &anthropic.BetaManagedAgentsAgentParams{
+            Type:    anthropic.BetaManagedAgentsAgentParamsTypeAgent,
+            ID:      agent.ID,
+            Version: anthropic.Int(agent.Version),
+        },
+    },
+    EnvironmentID: environment.ID,
+    VaultIDs:      []string{vault.ID},
+})
+if err != nil {
+    panic(err)
+}
+```
+
+See `shared/managed-agents-tools.md` §Vaults for creating vaults and adding credentials.
+
+---
+
+## Vaults
+
+```go
+// Create a vault
+vault, err := client.Beta.Vaults.New(ctx, anthropic.BetaVaultNewParams{
+    DisplayName: "Alice",
+    Metadata:    map[string]string{"external_user_id": "usr_abc123"},
+})
+if err != nil {
+    panic(err)
+}
+
+// Add an OAuth credential
+credential, err := client.Beta.Vaults.Credentials.New(ctx, vault.ID, anthropic.BetaVaultCredentialNewParams{
+    DisplayName: anthropic.String("Alice's Slack"),
+    Auth: anthropic.BetaVaultCredentialNewParamsAuthUnion{
+        OfMCPOAuth: &anthropic.BetaManagedAgentsMCPOAuthCreateParams{
+            Type:         anthropic.BetaManagedAgentsMCPOAuthCreateParamsTypeMCPOAuth,
+            MCPServerURL: "https://mcp.slack.com/mcp",
+            AccessToken:  "xoxp-...",
+            ExpiresAt:    anthropic.Time(time.Date(2026, time.April, 15, 0, 0, 0, 0, time.UTC)),
+            Refresh: anthropic.BetaManagedAgentsMCPOAuthRefreshParams{
+                TokenEndpoint: "https://slack.com/api/oauth.v2.access",
+                ClientID:      "1234567890.0987654321",
+                Scope:         anthropic.String("channels:read chat:write"),
+                RefreshToken:  "xoxe-1-...",
+                TokenEndpointAuth: anthropic.BetaManagedAgentsMCPOAuthRefreshParamsTokenEndpointAuthUnion{
+                    OfClientSecretPost: &anthropic.BetaManagedAgentsTokenEndpointAuthPostParam{
+                        Type:         anthropic.BetaManagedAgentsTokenEndpointAuthPostParamTypeClientSecretPost,
+                        ClientSecret: "abc123...",
+                    },
+                },
+            },
+        },
+    },
+})
+if err != nil {
+    panic(err)
+}
+
+// Rotate the credential (e.g., after a token refresh)
+_, err = client.Beta.Vaults.Credentials.Update(ctx, credential.ID, anthropic.BetaVaultCredentialUpdateParams{
+    VaultID: vault.ID,
+    Auth: anthropic.BetaVaultCredentialUpdateParamsAuthUnion{
+        OfMCPOAuth: &anthropic.BetaManagedAgentsMCPOAuthUpdateParams{
+            Type:        anthropic.BetaManagedAgentsMCPOAuthUpdateParamsTypeMCPOAuth,
+            AccessToken: anthropic.String("xoxp-new-..."),
+            ExpiresAt:   anthropic.Time(time.Date(2026, time.May, 15, 0, 0, 0, 0, time.UTC)),
+            Refresh: anthropic.BetaManagedAgentsMCPOAuthRefreshUpdateParams{
+                RefreshToken: anthropic.String("xoxe-1-new-..."),
+            },
+        },
+    },
+})
+if err != nil {
+    panic(err)
+}
+
+// Archive a vault
+_, err = client.Beta.Vaults.Archive(ctx, vault.ID, anthropic.BetaVaultArchiveParams{})
+if err != nil {
+    panic(err)
+}
+```
+
+---
+
+## GitHub Repository Integration
+
+Mount a GitHub repository as a session resource (a vault holds the GitHub MCP credential):
+
+```go
+session, err := client.Beta.Sessions.New(ctx, anthropic.BetaSessionNewParams{
+    Agent:         anthropic.BetaSessionNewParamsAgentUnion{OfString: anthropic.String(agent.ID)},
+    EnvironmentID: environment.ID,
+    VaultIDs:      []string{vault.ID},
+    Resources: []anthropic.BetaSessionNewParamsResourceUnion{
+        {
+            OfGitHubRepository: &anthropic.BetaManagedAgentsGitHubRepositoryResourceParams{
+                Type:               anthropic.BetaManagedAgentsGitHubRepositoryResourceParamsTypeGitHubRepository,
+                URL:                "https://github.com/org/repo",
+                MountPath:          anthropic.String("/workspace/repo"),
+                AuthorizationToken: "ghp_your_github_token",
+            },
+        },
+    },
+})
+if err != nil {
+    panic(err)
+}
+```
+
+Multiple repositories on the same session:
+
+```go
+resources := []anthropic.BetaSessionNewParamsResourceUnion{
+    {
+        OfGitHubRepository: &anthropic.BetaManagedAgentsGitHubRepositoryResourceParams{
+            Type:               anthropic.BetaManagedAgentsGitHubRepositoryResourceParamsTypeGitHubRepository,
+            URL:                "https://github.com/org/frontend",
+            MountPath:          anthropic.String("/workspace/frontend"),
+            AuthorizationToken: "ghp_your_github_token",
+        },
+    },
+    {
+        OfGitHubRepository: &anthropic.BetaManagedAgentsGitHubRepositoryResourceParams{
+            Type:               anthropic.BetaManagedAgentsGitHubRepositoryResourceParamsTypeGitHubRepository,
+            URL:                "https://github.com/org/backend",
+            MountPath:          anthropic.String("/workspace/backend"),
+            AuthorizationToken: "ghp_your_github_token",
+        },
+    },
+}
+```
+
+Rotating a repository's authorization token:
+
+```go
+listed, err := client.Beta.Sessions.Resources.List(ctx, session.ID, anthropic.BetaSessionResourceListParams{})
+if err != nil {
+    panic(err)
+}
+repoResourceID := listed.Data[0].ID
+
+_, err = client.Beta.Sessions.Resources.Update(ctx, repoResourceID, anthropic.BetaSessionResourceUpdateParams{
+    SessionID:          session.ID,
+    AuthorizationToken: "ghp_your_new_github_token",
+})
+if err != nil {
+    panic(err)
+}
+```

--- a/.claude/skills/claude-api/java/claude-api.md
+++ b/.claude/skills/claude-api/java/claude-api.md
@@ -1,0 +1,432 @@
+# Claude API — Java
+
+> **Note:** The Java SDK supports the Claude API and beta tool use with annotated classes. Agent SDK is not yet available for Java.
+
+## Installation
+
+Maven:
+
+```xml
+<dependency>
+    <groupId>com.anthropic</groupId>
+    <artifactId>anthropic-java</artifactId>
+    <version>2.17.0</version>
+</dependency>
+```
+
+Gradle:
+
+```groovy
+implementation("com.anthropic:anthropic-java:2.17.0")
+```
+
+## Client Initialization
+
+```java
+import com.anthropic.client.AnthropicClient;
+import com.anthropic.client.okhttp.AnthropicOkHttpClient;
+
+// Default (reads ANTHROPIC_API_KEY from environment)
+AnthropicClient client = AnthropicOkHttpClient.fromEnv();
+
+// Explicit API key
+AnthropicClient client = AnthropicOkHttpClient.builder()
+    .apiKey("your-api-key")
+    .build();
+```
+
+---
+
+## Basic Message Request
+
+```java
+import com.anthropic.models.messages.MessageCreateParams;
+import com.anthropic.models.messages.Message;
+import com.anthropic.models.messages.Model;
+
+MessageCreateParams params = MessageCreateParams.builder()
+    .model(Model.CLAUDE_OPUS_4_6)
+    .maxTokens(16000L)
+    .addUserMessage("What is the capital of France?")
+    .build();
+
+Message response = client.messages().create(params);
+response.content().stream()
+    .flatMap(block -> block.text().stream())
+    .forEach(textBlock -> System.out.println(textBlock.text()));
+```
+
+---
+
+## Streaming
+
+```java
+import com.anthropic.core.http.StreamResponse;
+import com.anthropic.models.messages.RawMessageStreamEvent;
+
+MessageCreateParams params = MessageCreateParams.builder()
+    .model(Model.CLAUDE_OPUS_4_6)
+    .maxTokens(64000L)
+    .addUserMessage("Write a haiku")
+    .build();
+
+try (StreamResponse<RawMessageStreamEvent> streamResponse = client.messages().createStreaming(params)) {
+    streamResponse.stream()
+        .flatMap(event -> event.contentBlockDelta().stream())
+        .flatMap(deltaEvent -> deltaEvent.delta().text().stream())
+        .forEach(textDelta -> System.out.print(textDelta.text()));
+}
+```
+
+---
+
+## Thinking
+
+**Adaptive thinking is the recommended mode for Claude 4.6+ models.** Claude decides dynamically when and how much to think. The builder has a direct `.thinking(ThinkingConfigAdaptive)` overload — no manual union wrapping.
+
+```java
+import com.anthropic.models.messages.ContentBlock;
+import com.anthropic.models.messages.MessageCreateParams;
+import com.anthropic.models.messages.Model;
+import com.anthropic.models.messages.ThinkingConfigAdaptive;
+
+MessageCreateParams params = MessageCreateParams.builder()
+    .model(Model.CLAUDE_SONNET_4_6)
+    .maxTokens(16000L)
+    .thinking(ThinkingConfigAdaptive.builder().build())
+    .addUserMessage("Solve this step by step: 27 * 453")
+    .build();
+
+for (ContentBlock block : client.messages().create(params).content()) {
+    block.thinking().ifPresent(t -> System.out.println("[thinking] " + t.thinking()));
+    block.text().ifPresent(t -> System.out.println(t.text()));
+}
+```
+
+> **Deprecated:** `ThinkingConfigEnabled.builder().budgetTokens(N)` (and the `.enabledThinking(N)` shortcut) still works on Claude 4.6 but is deprecated. Use adaptive thinking above.
+
+`ContentBlock` narrowing: `.thinking()` / `.text()` return `Optional<T>` — use `.ifPresent(...)` or `.stream().flatMap(...)`. Alternative: `isThinking()` / `asThinking()` boolean+unwrap pairs (throws on wrong variant).
+
+---
+
+## Tool Use (Beta)
+
+The Java SDK supports beta tool use with annotated classes. Tool classes implement `Supplier<String>` for automatic execution via `BetaToolRunner`.
+
+### Tool Runner (automatic loop)
+
+```java
+import com.anthropic.models.beta.messages.MessageCreateParams;
+import com.anthropic.models.beta.messages.BetaMessage;
+import com.anthropic.helpers.BetaToolRunner;
+import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import java.util.function.Supplier;
+
+@JsonClassDescription("Get the weather in a given location")
+static class GetWeather implements Supplier<String> {
+    @JsonPropertyDescription("The city and state, e.g. San Francisco, CA")
+    public String location;
+
+    @Override
+    public String get() {
+        return "The weather in " + location + " is sunny and 72°F";
+    }
+}
+
+BetaToolRunner toolRunner = client.beta().messages().toolRunner(
+    MessageCreateParams.builder()
+        .model("claude-opus-4-6")
+        .maxTokens(16000L)
+        .putAdditionalHeader("anthropic-beta", "structured-outputs-2025-11-13")
+        .addTool(GetWeather.class)
+        .addUserMessage("What's the weather in San Francisco?")
+        .build());
+
+for (BetaMessage message : toolRunner) {
+    System.out.println(message);
+}
+```
+
+### Memory Tool
+
+The Java SDK provides `BetaMemoryToolHandler` for implementing the memory tool backend. You supply a handler that manages file storage, and the `BetaToolRunner` handles memory tool calls automatically.
+
+```java
+import com.anthropic.helpers.BetaMemoryToolHandler;
+import com.anthropic.helpers.BetaToolRunner;
+import com.anthropic.models.beta.messages.BetaMemoryTool20250818;
+import com.anthropic.models.beta.messages.BetaMessage;
+import com.anthropic.models.beta.messages.MessageCreateParams;
+import com.anthropic.models.beta.messages.ToolRunnerCreateParams;
+
+// Implement BetaMemoryToolHandler with your storage backend (e.g., filesystem)
+BetaMemoryToolHandler memoryHandler = new FileSystemMemoryToolHandler(sandboxRoot);
+
+MessageCreateParams createParams = MessageCreateParams.builder()
+    .model("claude-opus-4-6")
+    .maxTokens(4096L)
+    .addTool(BetaMemoryTool20250818.builder().build())
+    .addUserMessage("Remember that my favorite color is blue")
+    .build();
+
+BetaToolRunner toolRunner = client.beta().messages().toolRunner(
+    ToolRunnerCreateParams.builder()
+        .betaMemoryToolHandler(memoryHandler)
+        .initialMessageParams(createParams)
+        .build());
+
+for (BetaMessage message : toolRunner) {
+    System.out.println(message);
+}
+```
+
+See the [shared memory tool concepts](../shared/tool-use-concepts.md) for more details on the memory tool.
+
+### Non-Beta Tool Declaration (manual JSON schema)
+
+`Tool.InputSchema.Properties` is a freeform `Map<String, JsonValue>` wrapper — build property schemas via `putAdditionalProperty`. `type: "object"` is the default. The builder has a direct `.addTool(Tool)` overload that wraps in `ToolUnion` automatically.
+
+```java
+import com.anthropic.core.JsonValue;
+import com.anthropic.models.messages.Tool;
+
+Tool tool = Tool.builder()
+    .name("get_weather")
+    .description("Get the current weather in a given location")
+    .inputSchema(Tool.InputSchema.builder()
+        .properties(Tool.InputSchema.Properties.builder()
+            .putAdditionalProperty("location", JsonValue.from(Map.of("type", "string")))
+            .build())
+        .required(List.of("location"))
+        .build())
+    .build();
+
+MessageCreateParams params = MessageCreateParams.builder()
+    .model(Model.CLAUDE_SONNET_4_6)
+    .maxTokens(16000L)
+    .addTool(tool)
+    .addUserMessage("Weather in Paris?")
+    .build();
+```
+
+For manual tool loops, handle `tool_use` blocks in the response, send `tool_result` back, loop until `stop_reason` is `"end_turn"`. See [shared tool use concepts](../shared/tool-use-concepts.md).
+
+### Building `MessageParam` with Content Blocks (Tool Result Round-Trip)
+
+`MessageParam.Content` is an inner union class (string | list). Use the builder's `.contentOfBlockParams(List<ContentBlockParam>)` alias — there is NO separate `MessageParamContent` class with a static `ofBlockParams`:
+
+```java
+import com.anthropic.models.messages.MessageParam;
+import com.anthropic.models.messages.ContentBlockParam;
+import com.anthropic.models.messages.ToolResultBlockParam;
+
+List<ContentBlockParam> results = List.of(
+    ContentBlockParam.ofToolResult(ToolResultBlockParam.builder()
+        .toolUseId(toolUseBlock.id())
+        .content(yourResultString)
+        .build())
+);
+
+MessageParam toolResultMsg = MessageParam.builder()
+    .role(MessageParam.Role.USER)
+    .contentOfBlockParams(results)   // builder alias for Content.ofBlockParams(...)
+    .build();
+```
+
+---
+
+## Effort Parameter
+
+Effort is nested inside `OutputConfig` — there is NO `.effort()` directly on `MessageCreateParams.Builder`.
+
+```java
+import com.anthropic.models.messages.OutputConfig;
+
+.outputConfig(OutputConfig.builder()
+    .effort(OutputConfig.Effort.HIGH)  // or LOW, MEDIUM, MAX
+    .build())
+```
+
+Combine with `Thinking = ThinkingConfigAdaptive` for cost-quality control.
+
+---
+
+## Prompt Caching
+
+System message as a list of `TextBlockParam` with `CacheControlEphemeral`. Use `.systemOfTextBlockParams(...)` — the plain `.system(String)` overload can't carry cache control. For placement patterns and the silent-invalidator audit checklist, see `shared/prompt-caching.md`.
+
+```java
+import com.anthropic.models.messages.TextBlockParam;
+import com.anthropic.models.messages.CacheControlEphemeral;
+
+.systemOfTextBlockParams(List.of(
+    TextBlockParam.builder()
+        .text(longSystemPrompt)
+        .cacheControl(CacheControlEphemeral.builder()
+            .ttl(CacheControlEphemeral.Ttl.TTL_1H)  // optional; also TTL_5M
+            .build())
+        .build()))
+```
+
+There's also a top-level `.cacheControl(CacheControlEphemeral)` on `MessageCreateParams.Builder` and on `Tool.builder()`.
+
+Verify hits via `response.usage().cacheCreationInputTokens()` / `response.usage().cacheReadInputTokens()`.
+
+---
+
+## Token Counting
+
+```java
+import com.anthropic.models.messages.MessageCountTokensParams;
+
+long tokens = client.messages().countTokens(
+    MessageCountTokensParams.builder()
+        .model(Model.CLAUDE_SONNET_4_6)
+        .addUserMessage("Hello")
+        .build()
+).inputTokens();
+```
+
+---
+
+## Structured Output
+
+The class-based overload auto-derives the JSON schema from your POJO and gives you a typed `.text()` return — no manual schema, no manual parsing.
+
+```java
+import com.anthropic.models.messages.StructuredMessageCreateParams;
+
+record Book(String title, String author) {}
+record BookList(List<Book> books) {}
+
+StructuredMessageCreateParams<BookList> params = MessageCreateParams.builder()
+    .model(Model.CLAUDE_SONNET_4_6)
+    .maxTokens(16000L)
+    .outputConfig(BookList.class)  // returns a typed builder
+    .addUserMessage("List 3 classic novels")
+    .build();
+
+client.messages().create(params).content().stream()
+    .flatMap(cb -> cb.text().stream())
+    .forEach(typed -> {
+        // typed.text() returns BookList, not String
+        for (Book b : typed.text().books()) System.out.println(b.title());
+    });
+```
+
+Supports Jackson annotations: `@JsonPropertyDescription`, `@JsonIgnore`, `@ArraySchema(minItems=...)`. Manual schema path: `OutputConfig.builder().format(JsonOutputFormat.builder().schema(...).build())`.
+
+---
+
+## PDF / Document Input
+
+`DocumentBlockParam` builder has source shortcuts. Wrap in `ContentBlockParam.ofDocument()` and pass via `.addUserMessageOfBlockParams()`.
+
+```java
+import com.anthropic.models.messages.DocumentBlockParam;
+import com.anthropic.models.messages.ContentBlockParam;
+import com.anthropic.models.messages.TextBlockParam;
+
+DocumentBlockParam doc = DocumentBlockParam.builder()
+    .base64Source(base64String)  // or .urlSource("https://...") or .textSource("...")
+    .title("My Document")        // optional
+    .build();
+
+.addUserMessageOfBlockParams(List.of(
+    ContentBlockParam.ofDocument(doc),
+    ContentBlockParam.ofText(TextBlockParam.builder().text("Summarize this").build())))
+```
+
+---
+
+## Server-Side Tools
+
+Version-suffixed types; `name`/`type` auto-set by builder. Direct `.addTool()` overloads exist for every type — no manual `ToolUnion` wrapping.
+
+```java
+import com.anthropic.models.messages.WebSearchTool20260209;
+import com.anthropic.models.messages.ToolBash20250124;
+import com.anthropic.models.messages.ToolTextEditor20250728;
+import com.anthropic.models.messages.CodeExecutionTool20260120;
+
+.addTool(WebSearchTool20260209.builder()
+    .maxUses(5L)                              // optional
+    .allowedDomains(List.of("example.com"))   // optional
+    .build())
+.addTool(ToolBash20250124.builder().build())
+.addTool(ToolTextEditor20250728.builder().build())
+.addTool(CodeExecutionTool20260120.builder().build())
+```
+
+Also available: `WebFetchTool20260209`, `MemoryTool20250818`, `ToolSearchToolBm25_20251119`.
+
+### Beta namespace (MCP, compaction)
+
+For beta-only features use `com.anthropic.models.beta.messages.*` — class names have a `Beta` prefix AND live in the beta package. The beta `MessageCreateParams.Builder` has direct `.addTool(BetaToolBash20250124)` overloads AND `.addMcpServer()`:
+
+```java
+import com.anthropic.models.beta.messages.MessageCreateParams;
+import com.anthropic.models.beta.messages.BetaToolBash20250124;
+import com.anthropic.models.beta.messages.BetaCodeExecutionTool20260120;
+import com.anthropic.models.beta.messages.BetaRequestMcpServerUrlDefinition;
+
+MessageCreateParams params = MessageCreateParams.builder()
+    .model(Model.CLAUDE_OPUS_4_6)
+    .maxTokens(16000L)
+    .addBeta("mcp-client-2025-11-20")
+    .addTool(BetaToolBash20250124.builder().build())
+    .addTool(BetaCodeExecutionTool20260120.builder().build())
+    .addMcpServer(BetaRequestMcpServerUrlDefinition.builder()
+        .name("my-server")
+        .url("https://example.com/mcp")
+        .build())
+    .addUserMessage("...")
+    .build();
+
+client.beta().messages().create(params);
+```
+
+`BetaTool*` types are NOT interchangeable with non-beta `Tool*` — pick one namespace per request.
+
+**Reading server-tool blocks in the response:** `ServerToolUseBlock` has `.id()`, `.name()` (enum), and `._input()` returning raw `JsonValue` — there is NO typed `.input()`. For code execution results, unwrap two levels:
+
+```java
+for (ContentBlock block : response.content()) {
+    block.serverToolUse().ifPresent(stu -> {
+        System.out.println("tool: " + stu.name() + " input: " + stu._input());
+    });
+    block.codeExecutionToolResult().ifPresent(r -> {
+        r.content().resultBlock().ifPresent(result -> {
+            System.out.println("stdout: " + result.stdout());
+            System.out.println("stderr: " + result.stderr());
+            System.out.println("exit: " + result.returnCode());
+        });
+    });
+}
+```
+
+---
+
+## Files API (Beta)
+
+Under `client.beta().files()`. File references in messages need the beta message types (non-beta `DocumentBlockParam.Source` has no file-ID variant).
+
+```java
+import com.anthropic.models.beta.files.FileUploadParams;
+import com.anthropic.models.beta.files.FileMetadata;
+import com.anthropic.models.beta.messages.BetaRequestDocumentBlock;
+import java.nio.file.Paths;
+
+FileMetadata meta = client.beta().files().upload(
+    FileUploadParams.builder()
+        .file(Paths.get("/path/to/doc.pdf"))  // or .file(InputStream) or .file(byte[])
+        .build());
+
+// Reference in a beta message:
+BetaRequestDocumentBlock doc = BetaRequestDocumentBlock.builder()
+    .fileSource(meta.id())
+    .build();
+```
+
+Other methods: `.list()`, `.delete(String fileId)`, `.download(String fileId)`, `.retrieveMetadata(String fileId)`.

--- a/.claude/skills/claude-api/java/managed-agents/README.md
+++ b/.claude/skills/claude-api/java/managed-agents/README.md
@@ -1,0 +1,442 @@
+# Managed Agents — Java
+
+> **Bindings not shown here:** This README covers the most common managed-agents flows for Java. If you need a class, method, namespace, field, or behavior that isn't shown, WebFetch the Java SDK repo **or the relevant docs page** from `shared/live-sources.md` rather than guess. Do not extrapolate from cURL shapes or another language's SDK.
+
+> **Agents are persistent — create once, reference by ID.** Store the agent ID returned by `client.beta().agents().create` and pass it to every subsequent `client.beta().sessions().create`; do not call `agents().create` in the request path. The Anthropic CLI is one convenient way to create agents and environments from version-controlled YAML — its URL is in `shared/live-sources.md`. The examples below show in-code creation for completeness; in production the create call belongs in setup, not in the request path.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>com.anthropic</groupId>
+    <artifactId>anthropic-java</artifactId>
+</dependency>
+```
+
+## Client Initialization
+
+```java
+import com.anthropic.client.okhttp.AnthropicOkHttpClient;
+
+// Default (uses ANTHROPIC_API_KEY env var)
+var client = AnthropicOkHttpClient.fromEnv();
+```
+
+---
+
+## Create an Environment
+
+```java
+import com.anthropic.models.beta.environments.BetaCloudConfigParams;
+import com.anthropic.models.beta.environments.EnvironmentCreateParams;
+import com.anthropic.models.beta.environments.UnrestrictedNetwork;
+
+var environment = client.beta().environments().create(EnvironmentCreateParams.builder()
+    .name("my-dev-env")
+    .config(BetaCloudConfigParams.builder()
+        .networking(UnrestrictedNetwork.builder().build())
+        .build())
+    .build());
+System.out.println("Environment ID: " + environment.id()); // env_...
+```
+
+---
+
+## Create an Agent (required first step)
+
+> ⚠️ **There is no inline agent config.** Model, system, and tools live on the agent object, not the session. Always start with `client.beta().agents().create()` — the session takes either `.agent(agent.id())` or the typed `BetaManagedAgentsAgentParams.builder()...build()`.
+
+### Minimal
+
+```java
+import com.anthropic.models.beta.agents.AgentCreateParams;
+import com.anthropic.models.beta.agents.BetaManagedAgentsAgentToolset20260401Params;
+import com.anthropic.models.beta.sessions.BetaManagedAgentsAgentParams;
+import com.anthropic.models.beta.sessions.SessionCreateParams;
+
+// 1. Create the agent (reusable, versioned)
+var agent = client.beta().agents().create(AgentCreateParams.builder()
+    .name("Coding Assistant")
+    .model("claude-opus-4-6")
+    .system("You are a helpful coding assistant.")
+    .addTool(BetaManagedAgentsAgentToolset20260401Params.builder()
+        .type(BetaManagedAgentsAgentToolset20260401Params.Type.AGENT_TOOLSET_20260401)
+        .build())
+    .build());
+
+// 2. Start a session
+var session = client.beta().sessions().create(SessionCreateParams.builder()
+    .agent(BetaManagedAgentsAgentParams.builder()
+        .type(BetaManagedAgentsAgentParams.Type.AGENT)
+        .id(agent.id())
+        .version(agent.version())
+        .build())
+    .environmentId(environment.id())
+    .title("Quickstart session")
+    .build());
+System.out.println("Session ID: " + session.id());
+```
+
+### Updating an Agent
+
+Updates create new versions; the agent object is immutable per version.
+
+```java
+import com.anthropic.models.beta.agents.AgentUpdateParams;
+
+var updatedAgent = client.beta().agents().update(agent.id(), AgentUpdateParams.builder()
+    .version(agent.version())
+    .system("You are a helpful coding agent. Always write tests.")
+    .build());
+System.out.println("New version: " + updatedAgent.version());
+
+// List all versions
+for (var version : client.beta().agents().versions().list(agent.id()).autoPager()) {
+    System.out.println("Version " + version.version() + ": " + version.updatedAt());
+}
+
+// Archive the agent
+var archived = client.beta().agents().archive(agent.id());
+System.out.println("Archived at: " + archived.archivedAt().orElseThrow());
+```
+
+---
+
+## Send a User Message
+
+```java
+import com.anthropic.models.beta.sessions.events.BetaManagedAgentsUserMessageEventParams;
+import com.anthropic.models.beta.sessions.events.EventSendParams;
+
+client.beta().sessions().events().send(session.id(), EventSendParams.builder()
+    .addEvent(BetaManagedAgentsUserMessageEventParams.builder()
+        .type(BetaManagedAgentsUserMessageEventParams.Type.USER_MESSAGE)
+        .addTextContent("Review the auth module")
+        .build())
+    .build());
+```
+
+> 💡 **Stream-first:** Open the stream *before* (or concurrently with) sending the message. The stream only delivers events that occur after it opens — stream-after-send means early events arrive buffered in one batch. See [Steering Patterns](../../shared/managed-agents-events.md#steering-patterns).
+
+---
+
+## Stream Events (SSE)
+
+```java
+import com.anthropic.models.beta.sessions.events.StreamEvents;
+
+// Open the stream first, then send the user message
+try (var stream = client.beta().sessions().events().streamStreaming(session.id())) {
+    client.beta().sessions().events().send(session.id(), EventSendParams.builder()
+        .addEvent(BetaManagedAgentsUserMessageEventParams.builder()
+            .type(BetaManagedAgentsUserMessageEventParams.Type.USER_MESSAGE)
+            .addTextContent("Summarize the repo README")
+            .build())
+        .build());
+
+    for (var event : (Iterable<StreamEvents>) stream.stream()::iterator) {
+        if (event.isAgentMessage()) {
+            event.asAgentMessage().content().forEach(block -> System.out.print(block.text()));
+        } else if (event.isAgentToolUse()) {
+            System.out.println("\n[Using tool: " + event.asAgentToolUse().name() + "]");
+        } else if (event.isSessionStatusIdle()) {
+            break;
+        } else if (event.isSessionError()) {
+            System.out.println("\n[Error]");
+            break;
+        }
+    }
+}
+```
+
+### Reconnecting and Tailing
+
+When reconnecting mid-session, list past events first to dedupe, then tail live events. The cross-variant `id` field is read from the raw `_json()` value:
+
+```java
+import com.anthropic.core.JsonValue;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+
+try (var stream = client.beta().sessions().events().streamStreaming(session.id())) {
+    // Stream is open and buffering. List history before tailing live.
+    var seenEventIds = new HashSet<String>();
+    for (var past : client.beta().sessions().events().list(session.id()).autoPager()) {
+        Optional<Map<String, JsonValue>> obj = past._json().orElseThrow().asObject();
+        seenEventIds.add(obj.orElseThrow().get("id").asStringOrThrow());
+    }
+
+    // Tail live events, skipping anything already seen
+    for (var event : (Iterable<StreamEvents>) stream.stream()::iterator) {
+        Optional<Map<String, JsonValue>> obj = event._json().orElseThrow().asObject();
+        if (!seenEventIds.add(obj.orElseThrow().get("id").asStringOrThrow())) continue;
+        if (event.isAgentMessage()) {
+            event.asAgentMessage().content().forEach(block -> System.out.print(block.text()));
+        } else if (event.isSessionStatusIdle()) {
+            break;
+        }
+    }
+}
+```
+
+---
+
+## Provide Custom Tool Result
+
+> ℹ️ The Java managed-agents bindings for `user.custom_tool_result` are not yet documented in this skill or in the apps source examples. Refer to `shared/managed-agents-events.md` for the wire format and the `anthropic-java` repository for the corresponding params types.
+
+---
+
+## Poll Events
+
+```java
+for (var event : client.beta().sessions().events().list(session.id()).autoPager()) {
+    System.out.println(event.type() + ": " + event);
+}
+```
+
+---
+
+## Upload a File
+
+```java
+import com.anthropic.models.beta.files.FileUploadParams;
+import com.anthropic.models.beta.sessions.BetaManagedAgentsFileResourceParams;
+import java.nio.file.Path;
+
+var dataCsv = Path.of("data.csv");
+
+var file = client.beta().files().upload(FileUploadParams.builder()
+    .file(dataCsv)
+    .build());
+System.out.println("File ID: " + file.id());
+
+// Mount in a session
+var session = client.beta().sessions().create(SessionCreateParams.builder()
+    .agent(agent.id())
+    .environmentId(environment.id())
+    .addResource(BetaManagedAgentsFileResourceParams.builder()
+        .type(BetaManagedAgentsFileResourceParams.Type.FILE)
+        .fileId(file.id())
+        .mountPath("/workspace/data.csv")
+        .build())
+    .build());
+```
+
+### Add and Manage Resources on an Existing Session
+
+```java
+import com.anthropic.models.beta.sessions.resources.ResourceAddParams;
+import com.anthropic.models.beta.sessions.resources.ResourceDeleteParams;
+
+// Attach an additional file to an open session
+var resource = client.beta().sessions().resources().add(session.id(), ResourceAddParams.builder()
+    .betaManagedAgentsFileResourceParams(BetaManagedAgentsFileResourceParams.builder()
+        .type(BetaManagedAgentsFileResourceParams.Type.FILE)
+        .fileId(file.id())
+        .build())
+    .build());
+System.out.println(resource.id()); // "sesrsc_01ABC..."
+
+// List resources on the session — entries are a discriminated union
+var listed = client.beta().sessions().resources().list(session.id());
+for (var entry : listed.data()) {
+    if (entry.isFile()) {
+        var fileResource = entry.asFile();
+        System.out.println(fileResource.id() + " " + fileResource.type());
+    } else if (entry.isGitHubRepository()) {
+        var repoResource = entry.asGitHubRepository();
+        System.out.println(repoResource.id() + " " + repoResource.type());
+    }
+}
+
+// Detach a resource
+client.beta().sessions().resources().delete(resource.id(), ResourceDeleteParams.builder()
+    .sessionId(session.id())
+    .build());
+```
+
+---
+
+## List and Download Session Files
+
+> ℹ️ Listing and downloading files an agent wrote during a session is not yet documented for Java in this skill or in the apps source examples. See `shared/managed-agents-events.md` and the `anthropic-java` repository for the file list/download bindings.
+
+---
+
+## Session Management
+
+```java
+// List environments
+var environments = client.beta().environments().list();
+
+// Retrieve a specific environment
+var env = client.beta().environments().retrieve(environment.id());
+
+// Archive an environment (read-only, existing sessions continue)
+client.beta().environments().archive(environment.id());
+
+// Delete an environment (only if no sessions reference it)
+client.beta().environments().delete(environment.id());
+
+// Delete a session
+client.beta().sessions().delete(session.id());
+```
+
+---
+
+## MCP Server Integration
+
+```java
+import com.anthropic.models.beta.agents.BetaManagedAgentsMcpToolsetParams;
+import com.anthropic.models.beta.agents.BetaManagedAgentsUrlmcpServerParams;
+
+// Agent declares MCP server (no auth here — auth goes in a vault)
+var agent = client.beta().agents().create(AgentCreateParams.builder()
+    .name("GitHub Assistant")
+    .model("claude-opus-4-6")
+    .addMcpServer(BetaManagedAgentsUrlmcpServerParams.builder()
+        .type(BetaManagedAgentsUrlmcpServerParams.Type.URL)
+        .name("github")
+        .url("https://api.githubcopilot.com/mcp/")
+        .build())
+    .addTool(BetaManagedAgentsAgentToolset20260401Params.builder()
+        .type(BetaManagedAgentsAgentToolset20260401Params.Type.AGENT_TOOLSET_20260401)
+        .build())
+    .addTool(BetaManagedAgentsMcpToolsetParams.builder()
+        .type(BetaManagedAgentsMcpToolsetParams.Type.MCP_TOOLSET)
+        .mcpServerName("github")
+        .build())
+    .build());
+
+// Session attaches vault(s) containing credentials for those MCP server URLs
+var session = client.beta().sessions().create(SessionCreateParams.builder()
+    .agent(BetaManagedAgentsAgentParams.builder()
+        .type(BetaManagedAgentsAgentParams.Type.AGENT)
+        .id(agent.id())
+        .version(agent.version())
+        .build())
+    .environmentId(environment.id())
+    .addVaultId(vault.id())
+    .build());
+```
+
+See `shared/managed-agents-tools.md` §Vaults for creating vaults and adding credentials.
+
+---
+
+## Vaults
+
+```java
+import com.anthropic.core.JsonValue;
+import com.anthropic.models.beta.vaults.VaultCreateParams;
+import com.anthropic.models.beta.vaults.credentials.BetaManagedAgentsMcpOAuthCreateParams;
+import com.anthropic.models.beta.vaults.credentials.BetaManagedAgentsMcpOAuthRefreshParams;
+import com.anthropic.models.beta.vaults.credentials.BetaManagedAgentsMcpOAuthRefreshUpdateParams;
+import com.anthropic.models.beta.vaults.credentials.BetaManagedAgentsMcpOAuthUpdateParams;
+import com.anthropic.models.beta.vaults.credentials.CredentialCreateParams;
+import com.anthropic.models.beta.vaults.credentials.CredentialUpdateParams;
+import java.time.OffsetDateTime;
+
+// Create a vault
+var vault = client.beta().vaults().create(VaultCreateParams.builder()
+    .displayName("Alice")
+    .metadata(VaultCreateParams.Metadata.builder()
+        .putAdditionalProperty("external_user_id", JsonValue.from("usr_abc123"))
+        .build())
+    .build());
+System.out.println(vault.id()); // "vlt_01ABC..."
+
+// Add an OAuth credential
+var credential = client.beta().vaults().credentials().create(vault.id(),
+    CredentialCreateParams.builder()
+        .displayName("Alice's Slack")
+        .auth(BetaManagedAgentsMcpOAuthCreateParams.builder()
+            .type(BetaManagedAgentsMcpOAuthCreateParams.Type.MCP_OAUTH)
+            .mcpServerUrl("https://mcp.slack.com/mcp")
+            .accessToken("xoxp-...")
+            .expiresAt(OffsetDateTime.parse("2026-04-15T00:00:00Z"))
+            .refresh(BetaManagedAgentsMcpOAuthRefreshParams.builder()
+                .tokenEndpoint("https://slack.com/api/oauth.v2.access")
+                .clientId("1234567890.0987654321")
+                .scope("channels:read chat:write")
+                .refreshToken("xoxe-1-...")
+                .clientSecretPostTokenEndpointAuth("abc123...")
+                .build())
+            .build())
+        .build());
+
+// Rotate the credential (e.g., after a token refresh)
+client.beta().vaults().credentials().update(credential.id(),
+    CredentialUpdateParams.builder()
+        .vaultId(vault.id())
+        .auth(BetaManagedAgentsMcpOAuthUpdateParams.builder()
+            .type(BetaManagedAgentsMcpOAuthUpdateParams.Type.MCP_OAUTH)
+            .accessToken("xoxp-new-...")
+            .expiresAt(OffsetDateTime.parse("2026-05-15T00:00:00Z"))
+            .refresh(BetaManagedAgentsMcpOAuthRefreshUpdateParams.builder()
+                .refreshToken("xoxe-1-new-...")
+                .build())
+            .build())
+        .build());
+
+// Archive a vault
+client.beta().vaults().archive(vault.id());
+```
+
+---
+
+## GitHub Repository Integration
+
+Mount a GitHub repository as a session resource (a vault holds the GitHub MCP credential):
+
+```java
+import com.anthropic.models.beta.sessions.BetaManagedAgentsGitHubRepositoryResourceParams;
+
+var session = client.beta().sessions().create(SessionCreateParams.builder()
+    .agent(agent.id())
+    .environmentId(environment.id())
+    .addVaultId(vault.id())
+    .addResource(BetaManagedAgentsGitHubRepositoryResourceParams.builder()
+        .type(BetaManagedAgentsGitHubRepositoryResourceParams.Type.GITHUB_REPOSITORY)
+        .url("https://github.com/org/repo")
+        .mountPath("/workspace/repo")
+        .authorizationToken("ghp_your_github_token")
+        .build())
+    .build());
+```
+
+Multiple repositories on the same session:
+
+```java
+import java.util.List;
+
+var resources = List.of(
+    BetaManagedAgentsGitHubRepositoryResourceParams.builder()
+        .type(BetaManagedAgentsGitHubRepositoryResourceParams.Type.GITHUB_REPOSITORY)
+        .url("https://github.com/org/frontend")
+        .mountPath("/workspace/frontend")
+        .authorizationToken("ghp_your_github_token")
+        .build(),
+    BetaManagedAgentsGitHubRepositoryResourceParams.builder()
+        .type(BetaManagedAgentsGitHubRepositoryResourceParams.Type.GITHUB_REPOSITORY)
+        .url("https://github.com/org/backend")
+        .mountPath("/workspace/backend")
+        .authorizationToken("ghp_your_github_token")
+        .build());
+```
+
+Rotating a repository's authorization token:
+
+```java
+import com.anthropic.models.beta.sessions.resources.ResourceUpdateParams;
+
+var listed = client.beta().sessions().resources().list(session.id());
+var repoResourceId = listed.data().get(0).asGitHubRepository().id();
+
+client.beta().sessions().resources().update(repoResourceId, ResourceUpdateParams.builder()
+    .sessionId(session.id())
+    .authorizationToken("ghp_your_new_github_token")
+    .build());
+```

--- a/.claude/skills/claude-api/php/claude-api.md
+++ b/.claude/skills/claude-api/php/claude-api.md
@@ -1,0 +1,375 @@
+# Claude API — PHP
+
+> **Note:** The PHP SDK is the official Anthropic SDK for PHP. A beta tool runner is available via `$client->beta->messages->toolRunner()`. Structured output helpers are supported via `StructuredOutputModel` classes. Agent SDK is not available. Bedrock, Vertex AI, and Foundry clients are supported.
+
+## Installation
+
+```bash
+composer require "anthropic-ai/sdk"
+```
+
+## Client Initialization
+
+```php
+use Anthropic\Client;
+
+// Using API key from environment variable
+$client = new Client(apiKey: getenv("ANTHROPIC_API_KEY"));
+```
+
+### Amazon Bedrock
+
+```php
+use Anthropic\Bedrock;
+
+// Constructor is private — use the static factory. Reads AWS credentials from env.
+$client = Bedrock\Client::fromEnvironment(region: 'us-east-1');
+```
+
+### Google Vertex AI
+
+```php
+use Anthropic\Vertex;
+
+// Constructor is private. Parameter is `location`, not `region`.
+$client = Vertex\Client::fromEnvironment(
+    location: 'us-east5',
+    projectId: 'my-project-id',
+);
+```
+
+### Anthropic Foundry
+
+```php
+use Anthropic\Foundry;
+
+// Constructor is private. baseUrl or resource is required.
+$client = Foundry\Client::withCredentials(
+    authToken: getenv('ANTHROPIC_FOUNDRY_AUTH_TOKEN'),
+    baseUrl: 'https://<resource>.services.ai.azure.com/anthropic',
+);
+```
+
+---
+
+## Basic Message Request
+
+```php
+$message = $client->messages->create(
+    model: 'claude-opus-4-6',
+    maxTokens: 16000,
+    messages: [
+        ['role' => 'user', 'content' => 'What is the capital of France?'],
+    ],
+);
+
+// content is an array of polymorphic blocks (TextBlock, ToolUseBlock,
+// ThinkingBlock). Accessing ->text on content[0] without checking the block
+// type will throw if the first block is not a TextBlock (e.g., when extended
+// thinking is enabled and a ThinkingBlock comes first). Always guard:
+foreach ($message->content as $block) {
+    if ($block->type === 'text') {
+        echo $block->text;
+    }
+}
+```
+
+If you only want the first text block:
+
+```php
+foreach ($message->content as $block) {
+    if ($block->type === 'text') {
+        echo $block->text;
+        break;
+    }
+}
+```
+
+---
+
+## Streaming
+
+> **Requires SDK v0.5.0+.** v0.4.0 and earlier used a single `$params` array; calling with named parameters throws `Unknown named parameter $model`. Upgrade: `composer require "anthropic-ai/sdk:^0.7"`
+
+```php
+use Anthropic\Messages\RawContentBlockDeltaEvent;
+use Anthropic\Messages\TextDelta;
+
+$stream = $client->messages->createStream(
+    model: 'claude-opus-4-6',
+    maxTokens: 64000,
+    messages: [
+        ['role' => 'user', 'content' => 'Write a haiku'],
+    ],
+);
+
+foreach ($stream as $event) {
+    if ($event instanceof RawContentBlockDeltaEvent && $event->delta instanceof TextDelta) {
+        echo $event->delta->text;
+    }
+}
+```
+
+---
+
+## Tool Use
+
+### Tool Runner (Beta)
+
+**Beta:** The PHP SDK provides a tool runner via `$client->beta->messages->toolRunner()`. Define tools with `BetaRunnableTool` — a definition array plus a `run` closure:
+
+```php
+use Anthropic\Lib\Tools\BetaRunnableTool;
+
+$weatherTool = new BetaRunnableTool(
+    definition: [
+        'name' => 'get_weather',
+        'description' => 'Get the current weather for a location.',
+        'input_schema' => [
+            'type' => 'object',
+            'properties' => [
+                'location' => ['type' => 'string', 'description' => 'City and state'],
+            ],
+            'required' => ['location'],
+        ],
+    ],
+    run: function (array $input): string {
+        return "The weather in {$input['location']} is sunny and 72°F.";
+    },
+);
+
+$runner = $client->beta->messages->toolRunner(
+    maxTokens: 16000,
+    messages: [['role' => 'user', 'content' => 'What is the weather in Paris?']],
+    model: 'claude-opus-4-6',
+    tools: [$weatherTool],
+);
+
+foreach ($runner as $message) {
+    foreach ($message->content as $block) {
+        if ($block->type === 'text') {
+            echo $block->text;
+        }
+    }
+}
+```
+
+### Manual Loop
+
+Tools are passed as arrays. **The SDK uses camelCase keys** (`inputSchema`, `toolUseID`, `stopReason`) and auto-maps to the API's snake_case on the wire — since v0.5.0. See [shared tool use concepts](../shared/tool-use-concepts.md) for the loop pattern.
+
+```php
+use Anthropic\Messages\ToolUseBlock;
+
+$tools = [
+    [
+        'name' => 'get_weather',
+        'description' => 'Get the current weather in a given location',
+        'inputSchema' => [  // camelCase, not input_schema
+            'type' => 'object',
+            'properties' => [
+                'location' => ['type' => 'string', 'description' => 'City and state'],
+            ],
+            'required' => ['location'],
+        ],
+    ],
+];
+
+$messages = [['role' => 'user', 'content' => 'What is the weather in SF?']];
+
+$response = $client->messages->create(
+    model: 'claude-opus-4-6',
+    maxTokens: 16000,
+    tools: $tools,
+    messages: $messages,
+);
+
+while ($response->stopReason === 'tool_use') {  // camelCase property
+    $toolResults = [];
+    foreach ($response->content as $block) {
+        if ($block instanceof ToolUseBlock) {
+            // $block->name  : string               — tool name to dispatch on
+            // $block->input : array<string,mixed>  — parsed JSON input
+            // $block->id    : string               — pass back as toolUseID
+            $result = executeYourTool($block->name, $block->input);
+            $toolResults[] = [
+                'type' => 'tool_result',
+                'toolUseID' => $block->id,  // camelCase, not tool_use_id
+                'content' => $result,
+            ];
+        }
+    }
+
+    // Append assistant turn + user turn with tool results
+    $messages[] = ['role' => 'assistant', 'content' => $response->content];
+    $messages[] = ['role' => 'user', 'content' => $toolResults];
+
+    $response = $client->messages->create(
+        model: 'claude-opus-4-6',
+        maxTokens: 16000,
+        tools: $tools,
+        messages: $messages,
+    );
+}
+
+// Final text response
+foreach ($response->content as $block) {
+    if ($block->type === 'text') {
+        echo $block->text;
+    }
+}
+```
+
+`$block->type === 'tool_use'` also works; `instanceof ToolUseBlock` narrows for PHPStan.
+
+
+---
+
+## Extended Thinking
+
+**Adaptive thinking is the recommended mode for Claude 4.6+ models.** Claude decides dynamically when and how much to think.
+
+```php
+use Anthropic\Messages\ThinkingBlock;
+
+$message = $client->messages->create(
+    model: 'claude-opus-4-6',
+    maxTokens: 16000,
+    thinking: ['type' => 'adaptive'],
+    messages: [
+        ['role' => 'user', 'content' => 'Solve: 27 * 453'],
+    ],
+);
+
+// ThinkingBlock(s) precede TextBlock in content
+foreach ($message->content as $block) {
+    if ($block instanceof ThinkingBlock) {
+        echo "Thinking:\n{$block->thinking}\n\n";
+        // $block->signature is an opaque string — preserve verbatim if
+        // passing thinking blocks back in multi-turn conversations
+    } elseif ($block->type === 'text') {
+        echo "Answer: {$block->text}\n";
+    }
+}
+```
+
+> **Deprecated:** `['type' => 'enabled', 'budgetTokens' => N]` (fixed-budget extended thinking) still works on Claude 4.6 but is deprecated. Use adaptive thinking above.
+
+`$block->type === 'thinking'` also works for the check; `instanceof` narrows for PHPStan.
+
+---
+
+## Prompt Caching
+
+`system:` takes an array of text blocks; set `cacheControl` on the last block. Array-shape syntax (camelCase keys) is idiomatic. For placement patterns and the silent-invalidator audit checklist, see `shared/prompt-caching.md`.
+
+```php
+$message = $client->messages->create(
+    model: 'claude-opus-4-6',
+    maxTokens: 16000,
+    system: [
+        ['type' => 'text', 'text' => $longSystemPrompt, 'cacheControl' => ['type' => 'ephemeral']],
+    ],
+    messages: [['role' => 'user', 'content' => 'Summarize the key points']],
+);
+```
+
+For 1-hour TTL: `'cacheControl' => ['type' => 'ephemeral', 'ttl' => '1h']`. There's also a top-level `cacheControl:` on `messages->create(...)` that auto-places on the last cacheable block.
+
+Verify hits via `$message->usage->cacheCreationInputTokens` / `$message->usage->cacheReadInputTokens`.
+
+---
+
+## Structured Outputs
+
+### Using StructuredOutputModel (Recommended)
+
+Define a PHP class implementing `StructuredOutputModel` and pass it as `outputConfig`:
+
+```php
+use Anthropic\Lib\Contracts\StructuredOutputModel;
+use Anthropic\Lib\Concerns\StructuredOutputModelTrait;
+use Anthropic\Lib\Attributes\Constrained;
+
+class Person implements StructuredOutputModel
+{
+    use StructuredOutputModelTrait;
+
+    #[Constrained(description: 'Full name')]
+    public string $name;
+
+    public int $age;
+
+    public ?string $email = null;  // nullable = optional field
+}
+
+$message = $client->messages->create(
+    model: 'claude-opus-4-6',
+    maxTokens: 16000,
+    messages: [['role' => 'user', 'content' => 'Generate a profile for Alice, age 30']],
+    outputConfig: ['format' => Person::class],
+);
+
+$person = $message->parsedOutput();  // Person instance
+echo $person->name;
+```
+
+Types are inferred from PHP type hints. Use `#[Constrained(description: '...')]` to add descriptions. Nullable properties (`?string`) become optional fields.
+
+### Raw Schema
+
+```php
+$message = $client->messages->create(
+    model: 'claude-opus-4-6',
+    maxTokens: 16000,
+    messages: [['role' => 'user', 'content' => 'Extract: John (john@co.com), Enterprise plan']],
+    outputConfig: [
+        'format' => [
+            'type' => 'json_schema',
+            'schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'name' => ['type' => 'string'],
+                    'email' => ['type' => 'string'],
+                    'plan' => ['type' => 'string'],
+                ],
+                'required' => ['name', 'email', 'plan'],
+                'additionalProperties' => false,
+            ],
+        ],
+    ],
+);
+
+// First text block contains valid JSON
+foreach ($message->content as $block) {
+    if ($block->type === 'text') {
+        $data = json_decode($block->text, true);
+        break;
+    }
+}
+```
+
+---
+
+## Beta Features & Server-Side Tools
+
+**`betas:` is NOT a param on `$client->messages->create()`** — it only exists on the beta namespace. Use it for features that need an explicit opt-in header:
+
+```php
+use Anthropic\Beta\Messages\BetaRequestMCPServerURLDefinition;
+
+$response = $client->beta->messages->create(
+    model: 'claude-opus-4-6',
+    maxTokens: 16000,
+    mcpServers: [
+        BetaRequestMCPServerURLDefinition::with(
+            name: 'my-server',
+            url: 'https://example.com/mcp',
+        ),
+    ],
+    betas: ['mcp-client-2025-11-20'],  // only valid on ->beta->messages
+    messages: [['role' => 'user', 'content' => 'Use the MCP tools']],
+);
+```
+
+**Server-side tools** (bash, web_search, text_editor, code_execution) are GA and work on both paths — `Anthropic\Messages\ToolBash20250124` / `WebSearchTool20260209` / `ToolTextEditor20250728` / `CodeExecutionTool20260120` for non-beta, `Anthropic\Beta\Messages\BetaToolBash20250124` / `BetaWebSearchTool20260209` / `BetaToolTextEditor20250728` / `BetaCodeExecutionTool20260120` for beta. No `betas:` header needed for these.

--- a/.claude/skills/claude-api/php/managed-agents/README.md
+++ b/.claude/skills/claude-api/php/managed-agents/README.md
@@ -1,0 +1,435 @@
+# Managed Agents — PHP
+
+> **Bindings not shown here:** This README covers the most common managed-agents flows for PHP. If you need a class, method, namespace, field, or behavior that isn't shown, WebFetch the PHP SDK repo **or the relevant docs page** from `shared/live-sources.md` rather than guess. Do not extrapolate from cURL shapes or another language's SDK.
+
+> **Agents are persistent — create once, reference by ID.** Store the agent ID returned by `$client->beta->agents->create` and pass it to every subsequent `->sessions->create`; do not call `agents->create` in the request path. The Anthropic CLI is one convenient way to create agents and environments from version-controlled YAML — its URL is in `shared/live-sources.md`. The examples below show in-code creation for completeness; in production the create call belongs in setup, not in the request path.
+
+## Installation
+
+```bash
+composer require "anthropic-ai/sdk"
+```
+
+## Client Initialization
+
+```php
+use Anthropic\Client;
+
+// Default (uses ANTHROPIC_API_KEY env var)
+$client = new Client();
+
+// Explicit API key
+$client = new Client(apiKey: 'your-api-key');
+```
+
+---
+
+## Create an Environment
+
+```php
+$environment = $client->beta->environments->create(
+    name: 'my-dev-env',
+    config: ['type' => 'cloud', 'networking' => ['type' => 'unrestricted']],
+);
+echo "Environment ID: {$environment->id}\n"; // env_...
+```
+
+---
+
+## Create an Agent (required first step)
+
+> ⚠️ **There is no inline agent config.** `model`/`system`/`tools` live on the agent object, not the session. Always start with `$client->beta->agents->create()` — the session takes either `agent: $agent->id` or the typed `BetaManagedAgentsAgentParams::with(type: 'agent', id: $agent->id, version: $agent->version)`.
+
+### Minimal
+
+```php
+use Anthropic\Beta\Agents\BetaManagedAgentsAgentToolset20260401Params;
+
+// 1. Create the agent (reusable, versioned)
+$agent = $client->beta->agents->create(
+    name: 'Coding Assistant',
+    model: 'claude-opus-4-6',
+    system: 'You are a helpful coding assistant.',
+    tools: [
+        BetaManagedAgentsAgentToolset20260401Params::with(
+            type: 'agent_toolset_20260401',
+        ),
+    ],
+);
+
+// 2. Start a session
+$session = $client->beta->sessions->create(
+    agent: ['type' => 'agent', 'id' => $agent->id, 'version' => $agent->version],
+    environmentID: $environment->id,
+    title: 'Quickstart session',
+);
+echo "Session ID: {$session->id}\n";
+```
+
+### Updating an Agent
+
+Updates create new versions; the agent object is immutable per version.
+
+```php
+$updatedAgent = $client->beta->agents->update(
+    $agent->id,
+    version: $agent->version,
+    system: 'You are a helpful coding agent. Always write tests.',
+);
+echo "New version: {$updatedAgent->version}\n";
+
+// List all versions
+foreach ($client->beta->agents->versions->list($agent->id)->pagingEachItem() as $version) {
+    echo "Version {$version->version}: {$version->updatedAt->format(DateTimeInterface::ATOM)}\n";
+}
+
+// Archive the agent
+$archived = $client->beta->agents->archive($agent->id);
+echo "Archived at: {$archived->archivedAt->format(DateTimeInterface::ATOM)}\n";
+```
+
+---
+
+## Send a User Message
+
+```php
+$client->beta->sessions->events->send(
+    $session->id,
+    events: [
+        [
+            'type' => 'user.message',
+            'content' => [['type' => 'text', 'text' => 'Review the auth module']],
+        ],
+    ],
+);
+```
+
+> 💡 **Stream-first:** Open the stream *before* (or concurrently with) sending the message. The stream only delivers events that occur after it opens — stream-after-send means early events arrive buffered in one batch. See [Steering Patterns](../../shared/managed-agents-events.md#steering-patterns).
+
+---
+
+## Stream Events (SSE)
+
+> ℹ️ **Streaming transporter:** PHP's default buffered PSR-18 client never returns for the open-ended session event stream. Use a streaming Guzzle transporter for `streamStream()` calls — other calls keep the default client.
+
+```php
+$streamingClient = new GuzzleHttp\Client(['stream' => true]);
+
+// Open the stream first, then send the user message
+$stream = $client->beta->sessions->events->streamStream(
+    $session->id,
+    requestOptions: ['transporter' => $streamingClient],
+);
+$client->beta->sessions->events->send(
+    $session->id,
+    events: [
+        [
+            'type' => 'user.message',
+            'content' => [['type' => 'text', 'text' => 'Summarize the repo README']],
+        ],
+    ],
+);
+
+foreach ($stream as $event) {
+    match ($event->type) {
+        'agent.message' => array_walk(
+            $event->content,
+            static fn($block) => $block->type === 'text' ? print($block->text) : null,
+        ),
+        'agent.tool_use' => print("\n[Using tool: {$event->name}]\n"),
+        'session.error' => printf("\n[Error: %s]", $event->error?->message ?? 'unknown'),
+        default => null,
+    };
+    if ($event->type === 'session.status_idle' || $event->type === 'session.error') {
+        break;
+    }
+}
+$stream->close();
+```
+
+### Reconnecting and Tailing
+
+When reconnecting mid-session, list past events first to dedupe, then tail live events:
+
+```php
+$stream = $client->beta->sessions->events->streamStream(
+    $session->id,
+    requestOptions: ['transporter' => $streamingClient],
+);
+
+// Stream is open and buffering. List history before tailing live.
+$seenEventIds = [];
+foreach ($client->beta->sessions->events->list($session->id)->pagingEachItem() as $event) {
+    $seenEventIds[$event->id] = true;
+}
+
+// Tail live events, skipping anything already seen
+foreach ($stream as $event) {
+    if (isset($seenEventIds[$event->id])) {
+        continue;
+    }
+    $seenEventIds[$event->id] = true;
+    match ($event->type) {
+        'agent.message' => array_walk(
+            $event->content,
+            static fn($block) => $block->type === 'text' ? print($block->text) : null,
+        ),
+        default => null,
+    };
+    if ($event->type === 'session.status_idle') {
+        break;
+    }
+}
+$stream->close();
+```
+
+---
+
+## Provide Custom Tool Result
+
+> ℹ️ The PHP managed-agents bindings for `user.custom_tool_result` are not yet documented in this skill or in the apps source examples. Refer to `shared/managed-agents-events.md` for the wire format and the `anthropic-ai/sdk` PHP repository for the corresponding params.
+
+---
+
+## Poll Events
+
+```php
+foreach ($client->beta->sessions->events->list($session->id)->pagingEachItem() as $event) {
+    echo "{$event->type}: {$event->id}\n";
+}
+```
+
+---
+
+## Upload a File
+
+> ℹ️ **PHP file upload:** The PHP SDK's beta managed-agents file upload binding is not shown in the apps source examples; the canonical PHP example uses raw cURL against `POST /v1/files`. If your codebase prefers the SDK, WebFetch the `anthropic-ai/sdk` PHP repository for the latest binding before writing code.
+
+```php
+use Anthropic\Beta\Sessions\BetaManagedAgentsFileResourceParams;
+
+// Raw cURL upload (canonical example from the apps source)
+$csvPath = 'data.csv';
+$ch = curl_init('https://api.anthropic.com/v1/files');
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST => true,
+    CURLOPT_HTTPHEADER => [
+        'x-api-key: ' . getenv('ANTHROPIC_API_KEY'),
+        'anthropic-version: 2023-06-01',
+        'anthropic-beta: files-api-2025-04-14',
+    ],
+    CURLOPT_POSTFIELDS => ['file' => new CURLFile($csvPath, 'text/csv', 'data.csv')],
+]);
+$file = json_decode(curl_exec($ch));
+echo "File ID: {$file->id}\n";
+
+// Mount in a session
+$session = $client->beta->sessions->create(
+    agent: $agent->id,
+    environmentID: $environment->id,
+    resources: [
+        BetaManagedAgentsFileResourceParams::with(
+            type: 'file',
+            fileID: $file->id,
+            mountPath: '/workspace/data.csv',
+        ),
+    ],
+);
+```
+
+### Add and Manage Resources on an Existing Session
+
+```php
+// Attach an additional file to an open session
+$resource = $client->beta->sessions->resources->add(
+    $session->id,
+    type: 'file',
+    fileID: $file->id,
+);
+echo "{$resource->id}\n"; // "sesrsc_01ABC..."
+
+// List resources on the session
+$listed = $client->beta->sessions->resources->list($session->id);
+foreach ($listed->data as $entry) {
+    echo "{$entry->id} {$entry->type}\n";
+}
+
+// Detach a resource
+$client->beta->sessions->resources->delete($resource->id, sessionID: $session->id);
+```
+
+---
+
+## List and Download Session Files
+
+> ℹ️ Listing and downloading files an agent wrote during a session is not yet documented for PHP in this skill or in the apps source examples. See `shared/managed-agents-events.md` and the `anthropic-ai/sdk` PHP repository for the file list/download bindings.
+
+---
+
+## Session Management
+
+```php
+// List environments
+$environments = $client->beta->environments->list();
+
+// Retrieve a specific environment
+$env = $client->beta->environments->retrieve($environment->id);
+
+// Archive an environment (read-only, existing sessions continue)
+$client->beta->environments->archive($environment->id);
+
+// Delete an environment (only if no sessions reference it)
+$client->beta->environments->delete($environment->id);
+
+// Delete a session
+$client->beta->sessions->delete($session->id);
+```
+
+---
+
+## MCP Server Integration
+
+```php
+use Anthropic\Beta\Agents\BetaManagedAgentsAgentToolset20260401Params;
+use Anthropic\Beta\Agents\BetaManagedAgentsMCPToolsetParams;
+use Anthropic\Beta\Agents\BetaManagedAgentsUrlmcpServerParams;
+use Anthropic\Beta\Sessions\BetaManagedAgentsAgentParams;
+
+// Agent declares MCP server (no auth here — auth goes in a vault)
+$agent = $client->beta->agents->create(
+    name: 'GitHub Assistant',
+    model: 'claude-opus-4-6',
+    mcpServers: [
+        BetaManagedAgentsUrlmcpServerParams::with(
+            type: 'url',
+            name: 'github',
+            url: 'https://api.githubcopilot.com/mcp/',
+        ),
+    ],
+    tools: [
+        BetaManagedAgentsAgentToolset20260401Params::with(type: 'agent_toolset_20260401'),
+        BetaManagedAgentsMCPToolsetParams::with(
+            type: 'mcp_toolset',
+            mcpServerName: 'github',
+        ),
+    ],
+);
+
+// Session attaches vault(s) containing credentials for those MCP server URLs
+$session = $client->beta->sessions->create(
+    agent: BetaManagedAgentsAgentParams::with(
+        type: 'agent',
+        id: $agent->id,
+        version: $agent->version,
+    ),
+    environmentID: $environment->id,
+    vaultIDs: [$vault->id],
+);
+```
+
+See `shared/managed-agents-tools.md` §Vaults for creating vaults and adding credentials.
+
+---
+
+## Vaults
+
+```php
+// Create a vault
+$vault = $client->beta->vaults->create(
+    displayName: 'Alice',
+    metadata: ['external_user_id' => 'usr_abc123'],
+);
+echo $vault->id . "\n"; // "vlt_01ABC..."
+
+// Add an OAuth credential
+$credential = $client->beta->vaults->credentials->create(
+    vaultID: $vault->id,
+    displayName: "Alice's Slack",
+    auth: [
+        'type' => 'mcp_oauth',
+        'mcp_server_url' => 'https://mcp.slack.com/mcp',
+        'access_token' => 'xoxp-...',
+        'expires_at' => '2026-04-15T00:00:00Z',
+        'refresh' => [
+            'token_endpoint' => 'https://slack.com/api/oauth.v2.access',
+            'client_id' => '1234567890.0987654321',
+            'scope' => 'channels:read chat:write',
+            'refresh_token' => 'xoxe-1-...',
+            'token_endpoint_auth' => [
+                'type' => 'client_secret_post',
+                'client_secret' => 'abc123...',
+            ],
+        ],
+    ],
+);
+
+// Rotate the credential (e.g., after a token refresh)
+$client->beta->vaults->credentials->update(
+    $credential->id,
+    vaultID: $vault->id,
+    auth: [
+        'type' => 'mcp_oauth',
+        'access_token' => 'xoxp-new-...',
+        'expires_at' => '2026-05-15T00:00:00Z',
+        'refresh' => ['refresh_token' => 'xoxe-1-new-...'],
+    ],
+);
+
+// Archive a vault
+$client->beta->vaults->archive($vault->id);
+```
+
+---
+
+## GitHub Repository Integration
+
+Mount a GitHub repository as a session resource (a vault holds the GitHub MCP credential):
+
+```php
+$session = $client->beta->sessions->create(
+    agent: $agent->id,
+    environmentID: $environment->id,
+    vaultIDs: [$vault->id],
+    resources: [
+        [
+            'type' => 'github_repository',
+            'url' => 'https://github.com/org/repo',
+            'mountPath' => '/workspace/repo',
+            'authorizationToken' => 'ghp_your_github_token',
+        ],
+    ],
+);
+```
+
+Multiple repositories on the same session:
+
+```php
+$resources = [
+    [
+        'type' => 'github_repository',
+        'url' => 'https://github.com/org/frontend',
+        'mountPath' => '/workspace/frontend',
+        'authorizationToken' => 'ghp_your_github_token',
+    ],
+    [
+        'type' => 'github_repository',
+        'url' => 'https://github.com/org/backend',
+        'mountPath' => '/workspace/backend',
+        'authorizationToken' => 'ghp_your_github_token',
+    ],
+];
+```
+
+Rotating a repository's authorization token:
+
+```php
+$listed = $client->beta->sessions->resources->list($session->id);
+$repoResourceId = $listed->data[0]->id;
+
+$client->beta->sessions->resources->update(
+    $repoResourceId,
+    sessionID: $session->id,
+    authorizationToken: 'ghp_your_new_github_token',
+);
+```

--- a/.claude/skills/claude-api/python/claude-api/README.md
+++ b/.claude/skills/claude-api/python/claude-api/README.md
@@ -1,0 +1,420 @@
+# Claude API — Python
+
+## Installation
+
+```bash
+pip install anthropic
+```
+
+## Client Initialization
+
+```python
+import anthropic
+
+# Default (uses ANTHROPIC_API_KEY env var)
+client = anthropic.Anthropic()
+
+# Explicit API key
+client = anthropic.Anthropic(api_key="your-api-key")
+
+# Async client
+async_client = anthropic.AsyncAnthropic()
+```
+
+---
+
+## Basic Message Request
+
+```python
+response = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    messages=[
+        {"role": "user", "content": "What is the capital of France?"}
+    ]
+)
+# response.content is a list of content block objects (TextBlock, ThinkingBlock,
+# ToolUseBlock, ...). Check .type before accessing .text.
+for block in response.content:
+    if block.type == "text":
+        print(block.text)
+```
+
+---
+
+## System Prompts
+
+```python
+response = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    system="You are a helpful coding assistant. Always provide examples in Python.",
+    messages=[{"role": "user", "content": "How do I read a JSON file?"}]
+)
+```
+
+---
+
+## Vision (Images)
+
+### Base64
+
+```python
+import base64
+
+with open("image.png", "rb") as f:
+    image_data = base64.standard_b64encode(f.read()).decode("utf-8")
+
+response = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    messages=[{
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": image_data
+                }
+            },
+            {"type": "text", "text": "What's in this image?"}
+        ]
+    }]
+)
+```
+
+### URL
+
+```python
+response = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    messages=[{
+        "role": "user",
+        "content": [
+            {
+                "type": "image",
+                "source": {
+                    "type": "url",
+                    "url": "https://example.com/image.png"
+                }
+            },
+            {"type": "text", "text": "Describe this image"}
+        ]
+    }]
+)
+```
+
+---
+
+## Prompt Caching
+
+Cache large context to reduce costs (up to 90% savings). **Caching is a prefix match** — any byte change anywhere in the prefix invalidates everything after it. For placement patterns, architectural guidance (frozen system prompt, deterministic tool order, where to put volatile content), and the silent-invalidator audit checklist, read `shared/prompt-caching.md`.
+
+### Automatic Caching (Recommended)
+
+Use top-level `cache_control` to automatically cache the last cacheable block in the request — no need to annotate individual content blocks:
+
+```python
+response = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    cache_control={"type": "ephemeral"},  # auto-caches the last cacheable block
+    system="You are an expert on this large document...",
+    messages=[{"role": "user", "content": "Summarize the key points"}]
+)
+```
+
+### Manual Cache Control
+
+For fine-grained control, add `cache_control` to specific content blocks:
+
+```python
+response = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    system=[{
+        "type": "text",
+        "text": "You are an expert on this large document...",
+        "cache_control": {"type": "ephemeral"}  # default TTL is 5 minutes
+    }],
+    messages=[{"role": "user", "content": "Summarize the key points"}]
+)
+
+# With explicit TTL (time-to-live)
+response = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    system=[{
+        "type": "text",
+        "text": "You are an expert on this large document...",
+        "cache_control": {"type": "ephemeral", "ttl": "1h"}  # 1 hour TTL
+    }],
+    messages=[{"role": "user", "content": "Summarize the key points"}]
+)
+```
+
+### Verifying Cache Hits
+
+```python
+print(response.usage.cache_creation_input_tokens)  # tokens written to cache (~1.25x cost)
+print(response.usage.cache_read_input_tokens)      # tokens served from cache (~0.1x cost)
+print(response.usage.input_tokens)                 # uncached tokens (full cost)
+```
+
+If `cache_read_input_tokens` is zero across repeated identical-prefix requests, a silent invalidator is at work — `datetime.now()` or a UUID in the system prompt, unsorted `json.dumps()`, or a varying tool set. See `shared/prompt-caching.md` for the full audit table.
+
+---
+
+## Extended Thinking
+
+> **Opus 4.6 and Sonnet 4.6:** Use adaptive thinking. `budget_tokens` is deprecated on both Opus 4.6 and Sonnet 4.6.
+> **Older models:** Use `thinking: {type: "enabled", budget_tokens: N}` (must be < `max_tokens`, min 1024).
+
+```python
+# Opus 4.6: adaptive thinking (recommended)
+response = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    thinking={"type": "adaptive"},
+    output_config={"effort": "high"},  # low | medium | high | max
+    messages=[{"role": "user", "content": "Solve this step by step..."}]
+)
+
+# Access thinking and response
+for block in response.content:
+    if block.type == "thinking":
+        print(f"Thinking: {block.thinking}")
+    elif block.type == "text":
+        print(f"Response: {block.text}")
+```
+
+---
+
+## Error Handling
+
+```python
+import anthropic
+
+try:
+    response = client.messages.create(...)
+except anthropic.BadRequestError as e:
+    print(f"Bad request: {e.message}")
+except anthropic.AuthenticationError:
+    print("Invalid API key")
+except anthropic.PermissionDeniedError:
+    print("API key lacks required permissions")
+except anthropic.NotFoundError:
+    print("Invalid model or endpoint")
+except anthropic.RateLimitError as e:
+    retry_after = int(e.response.headers.get("retry-after", "60"))
+    print(f"Rate limited. Retry after {retry_after}s.")
+except anthropic.APIStatusError as e:
+    if e.status_code >= 500:
+        print(f"Server error ({e.status_code}). Retry later.")
+    else:
+        print(f"API error: {e.message}")
+except anthropic.APIConnectionError:
+    print("Network error. Check internet connection.")
+```
+
+---
+
+## Multi-Turn Conversations
+
+The API is stateless — send the full conversation history each time.
+
+```python
+class ConversationManager:
+    """Manage multi-turn conversations with the Claude API."""
+
+    def __init__(self, client: anthropic.Anthropic, model: str, system: str = None):
+        self.client = client
+        self.model = model
+        self.system = system
+        self.messages = []
+
+    def send(self, user_message: str, **kwargs) -> str:
+        """Send a message and get a response."""
+        self.messages.append({"role": "user", "content": user_message})
+
+        response = self.client.messages.create(
+            model=self.model,
+            max_tokens=kwargs.get("max_tokens", 16000),
+            system=self.system,
+            messages=self.messages,
+            **kwargs
+        )
+
+        assistant_message = next(
+            (b.text for b in response.content if b.type == "text"), ""
+        )
+        self.messages.append({"role": "assistant", "content": assistant_message})
+
+        return assistant_message
+
+# Usage
+conversation = ConversationManager(
+    client=anthropic.Anthropic(),
+    model="claude-opus-4-6",
+    system="You are a helpful assistant."
+)
+
+response1 = conversation.send("My name is Alice.")
+response2 = conversation.send("What's my name?")  # Claude remembers "Alice"
+```
+
+**Rules:**
+
+- Messages must alternate between `user` and `assistant`
+- First message must be `user`
+
+---
+
+### Compaction (long conversations)
+
+> **Beta, Opus 4.6 and Sonnet 4.6.** When conversations approach the 200K context window, compaction automatically summarizes earlier context server-side. The API returns a `compaction` block; you must pass it back on subsequent requests — append `response.content`, not just the text.
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+messages = []
+
+def chat(user_message: str) -> str:
+    messages.append({"role": "user", "content": user_message})
+
+    response = client.beta.messages.create(
+        betas=["compact-2026-01-12"],
+        model="claude-opus-4-6",
+        max_tokens=16000,
+        messages=messages,
+        context_management={
+            "edits": [{"type": "compact_20260112"}]
+        }
+    )
+
+    # Append full content — compaction blocks must be preserved
+    messages.append({"role": "assistant", "content": response.content})
+
+    return next(block.text for block in response.content if block.type == "text")
+
+# Compaction triggers automatically when context grows large
+print(chat("Help me build a Python web scraper"))
+print(chat("Add support for JavaScript-rendered pages"))
+print(chat("Now add rate limiting and error handling"))
+```
+
+---
+
+## Stop Reasons
+
+The `stop_reason` field in the response indicates why the model stopped generating:
+
+| Value | Meaning |
+|-------|---------|
+| `end_turn` | Claude finished its response naturally |
+| `max_tokens` | Hit the `max_tokens` limit — increase it or use streaming |
+| `stop_sequence` | Hit a custom stop sequence |
+| `tool_use` | Claude wants to call a tool — execute it and continue |
+| `pause_turn` | Model paused and can be resumed (agentic flows) |
+| `refusal` | Claude refused for safety reasons — output may not match your schema |
+
+---
+
+## Cost Optimization Strategies
+
+### 1. Use Prompt Caching for Repeated Context
+
+```python
+# Automatic caching (simplest — caches the last cacheable block)
+response = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    cache_control={"type": "ephemeral"},
+    system=large_document_text,  # e.g., 50KB of context
+    messages=[{"role": "user", "content": "Summarize the key points"}]
+)
+
+# First request: full cost
+# Subsequent requests: ~90% cheaper for cached portion
+```
+
+### 2. Choose the Right Model
+
+```python
+# Default to Opus for most tasks
+response = client.messages.create(
+    model="claude-opus-4-6",  # $5.00/$25.00 per 1M tokens
+    max_tokens=16000,
+    messages=[{"role": "user", "content": "Explain quantum computing"}]
+)
+
+# Use Sonnet for high-volume production workloads
+standard_response = client.messages.create(
+    model="claude-sonnet-4-6",  # $3.00/$15.00 per 1M tokens
+    max_tokens=16000,
+    messages=[{"role": "user", "content": "Summarize this document"}]
+)
+
+# Use Haiku only for simple, speed-critical tasks
+simple_response = client.messages.create(
+    model="claude-haiku-4-5",  # $1.00/$5.00 per 1M tokens
+    max_tokens=256,
+    messages=[{"role": "user", "content": "Classify this as positive or negative"}]
+)
+```
+
+### 3. Use Token Counting Before Requests
+
+```python
+count_response = client.messages.count_tokens(
+    model="claude-opus-4-6",
+    messages=messages,
+    system=system
+)
+
+estimated_input_cost = count_response.input_tokens * 0.000005  # $5/1M tokens
+print(f"Estimated input cost: ${estimated_input_cost:.4f}")
+```
+
+---
+
+## Retry with Exponential Backoff
+
+> **Note:** The Anthropic SDK automatically retries rate limit (429) and server errors (5xx) with exponential backoff. You can configure this with `max_retries` (default: 2). Only implement custom retry logic if you need behavior beyond what the SDK provides.
+
+```python
+import time
+import random
+import anthropic
+
+def call_with_retry(
+    client: anthropic.Anthropic,
+    max_retries: int = 5,
+    base_delay: float = 1.0,
+    max_delay: float = 60.0,
+    **kwargs
+):
+    """Call the API with exponential backoff retry."""
+    last_exception = None
+
+    for attempt in range(max_retries):
+        try:
+            return client.messages.create(**kwargs)
+        except anthropic.RateLimitError as e:
+            last_exception = e
+        except anthropic.APIStatusError as e:
+            if e.status_code >= 500:
+                last_exception = e
+            else:
+                raise  # Client errors (4xx except 429) should not be retried
+
+        delay = min(base_delay * (2 ** attempt) + random.uniform(0, 1), max_delay)
+        print(f"Retry {attempt + 1}/{max_retries} after {delay:.1f}s")
+        time.sleep(delay)
+
+    raise last_exception
+```

--- a/.claude/skills/claude-api/python/claude-api/batches.md
+++ b/.claude/skills/claude-api/python/claude-api/batches.md
@@ -1,0 +1,185 @@
+# Message Batches API — Python
+
+The Batches API (`POST /v1/messages/batches`) processes Messages API requests asynchronously at 50% of standard prices.
+
+## Key Facts
+
+- Up to 100,000 requests or 256 MB per batch
+- Most batches complete within 1 hour; maximum 24 hours
+- Results available for 29 days after creation
+- 50% cost reduction on all token usage
+- All Messages API features supported (vision, tools, caching, etc.)
+
+---
+
+## Create a Batch
+
+```python
+import anthropic
+from anthropic.types.message_create_params import MessageCreateParamsNonStreaming
+from anthropic.types.messages.batch_create_params import Request
+
+client = anthropic.Anthropic()
+
+message_batch = client.messages.batches.create(
+    requests=[
+        Request(
+            custom_id="request-1",
+            params=MessageCreateParamsNonStreaming(
+                model="claude-opus-4-6",
+                max_tokens=16000,
+                messages=[{"role": "user", "content": "Summarize climate change impacts"}]
+            )
+        ),
+        Request(
+            custom_id="request-2",
+            params=MessageCreateParamsNonStreaming(
+                model="claude-opus-4-6",
+                max_tokens=16000,
+                messages=[{"role": "user", "content": "Explain quantum computing basics"}]
+            )
+        ),
+    ]
+)
+
+print(f"Batch ID: {message_batch.id}")
+print(f"Status: {message_batch.processing_status}")
+```
+
+---
+
+## Poll for Completion
+
+```python
+import time
+
+while True:
+    batch = client.messages.batches.retrieve(message_batch.id)
+    if batch.processing_status == "ended":
+        break
+    print(f"Status: {batch.processing_status}, processing: {batch.request_counts.processing}")
+    time.sleep(60)
+
+print("Batch complete!")
+print(f"Succeeded: {batch.request_counts.succeeded}")
+print(f"Errored: {batch.request_counts.errored}")
+```
+
+---
+
+## Retrieve Results
+
+> **Note:** Examples below use `match/case` syntax, requiring Python 3.10+. For earlier versions, use `if/elif` chains instead.
+
+```python
+for result in client.messages.batches.results(message_batch.id):
+    match result.result.type:
+        case "succeeded":
+            msg = result.result.message
+            text = next((b.text for b in msg.content if b.type == "text"), "")
+            print(f"[{result.custom_id}] {text[:100]}")
+        case "errored":
+            if result.result.error.type == "invalid_request":
+                print(f"[{result.custom_id}] Validation error - fix request and retry")
+            else:
+                print(f"[{result.custom_id}] Server error - safe to retry")
+        case "canceled":
+            print(f"[{result.custom_id}] Canceled")
+        case "expired":
+            print(f"[{result.custom_id}] Expired - resubmit")
+```
+
+---
+
+## Cancel a Batch
+
+```python
+cancelled = client.messages.batches.cancel(message_batch.id)
+print(f"Status: {cancelled.processing_status}")  # "canceling"
+```
+
+---
+
+## Batch with Prompt Caching
+
+```python
+shared_system = [
+    {"type": "text", "text": "You are a literary analyst."},
+    {
+        "type": "text",
+        "text": large_document_text,  # Shared across all requests
+        "cache_control": {"type": "ephemeral"}
+    }
+]
+
+message_batch = client.messages.batches.create(
+    requests=[
+        Request(
+            custom_id=f"analysis-{i}",
+            params=MessageCreateParamsNonStreaming(
+                model="claude-opus-4-6",
+                max_tokens=16000,
+                system=shared_system,
+                messages=[{"role": "user", "content": question}]
+            )
+        )
+        for i, question in enumerate(questions)
+    ]
+)
+```
+
+---
+
+## Full End-to-End Example
+
+```python
+import anthropic
+import time
+from anthropic.types.message_create_params import MessageCreateParamsNonStreaming
+from anthropic.types.messages.batch_create_params import Request
+
+client = anthropic.Anthropic()
+
+# 1. Prepare requests
+items_to_classify = [
+    "The product quality is excellent!",
+    "Terrible customer service, never again.",
+    "It's okay, nothing special.",
+]
+
+requests = [
+    Request(
+        custom_id=f"classify-{i}",
+        params=MessageCreateParamsNonStreaming(
+            model="claude-haiku-4-5",
+            max_tokens=50,
+            messages=[{
+                "role": "user",
+                "content": f"Classify as positive/negative/neutral (one word): {text}"
+            }]
+        )
+    )
+    for i, text in enumerate(items_to_classify)
+]
+
+# 2. Create batch
+batch = client.messages.batches.create(requests=requests)
+print(f"Created batch: {batch.id}")
+
+# 3. Wait for completion
+while True:
+    batch = client.messages.batches.retrieve(batch.id)
+    if batch.processing_status == "ended":
+        break
+    time.sleep(10)
+
+# 4. Collect results
+results = {}
+for result in client.messages.batches.results(batch.id):
+    if result.result.type == "succeeded":
+        msg = result.result.message
+        results[result.custom_id] = next((b.text for b in msg.content if b.type == "text"), "")
+
+for custom_id, classification in sorted(results.items()):
+    print(f"{custom_id}: {classification}")
+```

--- a/.claude/skills/claude-api/python/claude-api/files-api.md
+++ b/.claude/skills/claude-api/python/claude-api/files-api.md
@@ -1,0 +1,165 @@
+# Files API — Python
+
+The Files API uploads files for use in Messages API requests. Reference files via `file_id` in content blocks, avoiding re-uploads across multiple API calls.
+
+**Beta:** Pass `betas=["files-api-2025-04-14"]` in your API calls (the SDK sets the required header automatically).
+
+## Key Facts
+
+- Maximum file size: 500 MB
+- Total storage: 100 GB per organization
+- Files persist until deleted
+- File operations (upload, list, delete) are free; content used in messages is billed as input tokens
+- Not available on Amazon Bedrock or Google Vertex AI
+
+---
+
+## Upload a File
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+
+uploaded = client.beta.files.upload(
+    file=("report.pdf", open("report.pdf", "rb"), "application/pdf"),
+)
+print(f"File ID: {uploaded.id}")
+print(f"Size: {uploaded.size_bytes} bytes")
+```
+
+---
+
+## Use a File in Messages
+
+### PDF / Text Document
+
+```python
+response = client.beta.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Summarize the key findings in this report."},
+            {
+                "type": "document",
+                "source": {"type": "file", "file_id": uploaded.id},
+                "title": "Q4 Report",           # optional
+                "citations": {"enabled": True}   # optional, enables citations
+            }
+        ]
+    }],
+    betas=["files-api-2025-04-14"],
+)
+for block in response.content:
+    if block.type == "text":
+        print(block.text)
+```
+
+### Image
+
+```python
+image_file = client.beta.files.upload(
+    file=("photo.png", open("photo.png", "rb"), "image/png"),
+)
+
+response = client.beta.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "What's in this image?"},
+            {
+                "type": "image",
+                "source": {"type": "file", "file_id": image_file.id}
+            }
+        ]
+    }],
+    betas=["files-api-2025-04-14"],
+)
+```
+
+---
+
+## Manage Files
+
+### List Files
+
+```python
+files = client.beta.files.list()
+for f in files.data:
+    print(f"{f.id}: {f.filename} ({f.size_bytes} bytes)")
+```
+
+### Get File Metadata
+
+```python
+file_info = client.beta.files.retrieve_metadata("file_011CNha8iCJcU1wXNR6q4V8w")
+print(f"Filename: {file_info.filename}")
+print(f"MIME type: {file_info.mime_type}")
+```
+
+### Delete a File
+
+```python
+client.beta.files.delete("file_011CNha8iCJcU1wXNR6q4V8w")
+```
+
+### Download a File
+
+Only files created by the code execution tool or skills can be downloaded (not user-uploaded files).
+
+```python
+file_content = client.beta.files.download("file_011CNha8iCJcU1wXNR6q4V8w")
+file_content.write_to_file("output.txt")
+```
+
+---
+
+## Full End-to-End Example
+
+Upload a document once, ask multiple questions about it:
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+
+# 1. Upload once
+uploaded = client.beta.files.upload(
+    file=("contract.pdf", open("contract.pdf", "rb"), "application/pdf"),
+)
+print(f"Uploaded: {uploaded.id}")
+
+# 2. Ask multiple questions using the same file_id
+questions = [
+    "What are the key terms and conditions?",
+    "What is the termination clause?",
+    "Summarize the payment schedule.",
+]
+
+for question in questions:
+    response = client.beta.messages.create(
+        model="claude-opus-4-6",
+        max_tokens=16000,
+        messages=[{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": question},
+                {
+                    "type": "document",
+                    "source": {"type": "file", "file_id": uploaded.id}
+                }
+            ]
+        }],
+        betas=["files-api-2025-04-14"],
+    )
+    print(f"\nQ: {question}")
+    text = next((b.text for b in response.content if b.type == "text"), "")
+    print(f"A: {text[:200]}")
+
+# 3. Clean up when done
+client.beta.files.delete(uploaded.id)
+```

--- a/.claude/skills/claude-api/python/claude-api/streaming.md
+++ b/.claude/skills/claude-api/python/claude-api/streaming.md
@@ -1,0 +1,162 @@
+# Streaming — Python
+
+## Quick Start
+
+```python
+with client.messages.stream(
+    model="claude-opus-4-6",
+    max_tokens=64000,
+    messages=[{"role": "user", "content": "Write a story"}]
+) as stream:
+    for text in stream.text_stream:
+        print(text, end="", flush=True)
+```
+
+### Async
+
+```python
+async with async_client.messages.stream(
+    model="claude-opus-4-6",
+    max_tokens=64000,
+    messages=[{"role": "user", "content": "Write a story"}]
+) as stream:
+    async for text in stream.text_stream:
+        print(text, end="", flush=True)
+```
+
+---
+
+## Handling Different Content Types
+
+Claude may return text, thinking blocks, or tool use. Handle each appropriately:
+
+> **Opus 4.6:** Use `thinking: {type: "adaptive"}`. On older models, use `thinking: {type: "enabled", budget_tokens: N}` instead.
+
+```python
+with client.messages.stream(
+    model="claude-opus-4-6",
+    max_tokens=64000,
+    thinking={"type": "adaptive"},
+    messages=[{"role": "user", "content": "Analyze this problem"}]
+) as stream:
+    for event in stream:
+        if event.type == "content_block_start":
+            if event.content_block.type == "thinking":
+                print("\n[Thinking...]")
+            elif event.content_block.type == "text":
+                print("\n[Response:]")
+
+        elif event.type == "content_block_delta":
+            if event.delta.type == "thinking_delta":
+                print(event.delta.thinking, end="", flush=True)
+            elif event.delta.type == "text_delta":
+                print(event.delta.text, end="", flush=True)
+```
+
+---
+
+## Streaming with Tool Use
+
+The Python tool runner currently returns complete messages. Use streaming for individual API calls within a manual loop if you need per-token streaming with tools:
+
+```python
+with client.messages.stream(
+    model="claude-opus-4-6",
+    max_tokens=64000,
+    tools=tools,
+    messages=messages
+) as stream:
+    for text in stream.text_stream:
+        print(text, end="", flush=True)
+
+    response = stream.get_final_message()
+    # Continue with tool execution if response.stop_reason == "tool_use"
+```
+
+---
+
+## Getting the Final Message
+
+```python
+with client.messages.stream(
+    model="claude-opus-4-6",
+    max_tokens=64000,
+    messages=[{"role": "user", "content": "Hello"}]
+) as stream:
+    for text in stream.text_stream:
+        print(text, end="", flush=True)
+
+    # Get full message after streaming
+    final_message = stream.get_final_message()
+    print(f"\n\nTokens used: {final_message.usage.output_tokens}")
+```
+
+---
+
+## Streaming with Progress Updates
+
+```python
+def stream_with_progress(client, **kwargs):
+    """Stream a response with progress updates."""
+    total_tokens = 0
+    content_parts = []
+
+    with client.messages.stream(**kwargs) as stream:
+        for event in stream:
+            if event.type == "content_block_delta":
+                if event.delta.type == "text_delta":
+                    text = event.delta.text
+                    content_parts.append(text)
+                    print(text, end="", flush=True)
+
+            elif event.type == "message_delta":
+                if event.usage and event.usage.output_tokens is not None:
+                    total_tokens = event.usage.output_tokens
+
+        final_message = stream.get_final_message()
+
+    print(f"\n\n[Tokens used: {total_tokens}]")
+    return "".join(content_parts)
+```
+
+---
+
+## Error Handling in Streams
+
+```python
+try:
+    with client.messages.stream(
+        model="claude-opus-4-6",
+        max_tokens=64000,
+        messages=[{"role": "user", "content": "Write a story"}]
+    ) as stream:
+        for text in stream.text_stream:
+            print(text, end="", flush=True)
+except anthropic.APIConnectionError:
+    print("\nConnection lost. Please retry.")
+except anthropic.RateLimitError:
+    print("\nRate limited. Please wait and retry.")
+except anthropic.APIStatusError as e:
+    print(f"\nAPI error: {e.status_code}")
+```
+
+---
+
+## Stream Event Types
+
+| Event Type            | Description                 | When it fires                     |
+| --------------------- | --------------------------- | --------------------------------- |
+| `message_start`       | Contains message metadata   | Once at the beginning             |
+| `content_block_start` | New content block beginning | When a text/tool_use block starts |
+| `content_block_delta` | Incremental content update  | For each token/chunk              |
+| `content_block_stop`  | Content block complete      | When a block finishes             |
+| `message_delta`       | Message-level updates       | Contains `stop_reason`, usage     |
+| `message_stop`        | Message complete            | Once at the end                   |
+
+## Best Practices
+
+1. **Always flush output** — Use `flush=True` to show tokens immediately
+2. **Handle partial responses** — If the stream is interrupted, you may have incomplete content
+3. **Track token usage** — The `message_delta` event contains usage information
+4. **Use timeouts** — Set appropriate timeouts for your application
+5. **Default to streaming** — Use `.get_final_message()` to get the complete response even when streaming, giving you timeout protection without needing to handle individual events

--- a/.claude/skills/claude-api/python/claude-api/tool-use.md
+++ b/.claude/skills/claude-api/python/claude-api/tool-use.md
@@ -1,0 +1,590 @@
+# Tool Use — Python
+
+For conceptual overview (tool definitions, tool choice, tips), see [shared/tool-use-concepts.md](../../shared/tool-use-concepts.md).
+
+## Tool Runner (Recommended)
+
+**Beta:** The tool runner is in beta in the Python SDK.
+
+Use the `@beta_tool` decorator to define tools as typed functions, then pass them to `client.beta.messages.tool_runner()`:
+
+```python
+import anthropic
+from anthropic import beta_tool
+
+client = anthropic.Anthropic()
+
+@beta_tool
+def get_weather(location: str, unit: str = "celsius") -> str:
+    """Get current weather for a location.
+
+    Args:
+        location: City and state, e.g., San Francisco, CA.
+        unit: Temperature unit, either "celsius" or "fahrenheit".
+    """
+    # Your implementation here
+    return f"72°F and sunny in {location}"
+
+# The tool runner handles the agentic loop automatically
+runner = client.beta.messages.tool_runner(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    tools=[get_weather],
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+)
+
+# Each iteration yields a BetaMessage; iteration stops when Claude is done
+for message in runner:
+    print(message)
+```
+
+For async usage, use `@beta_async_tool` with `async def` functions.
+
+**Key benefits of the tool runner:**
+
+- No manual loop — the SDK handles calling tools and feeding results back
+- Type-safe tool inputs via decorators
+- Tool schemas are generated automatically from function signatures
+- Iteration stops automatically when Claude has no more tool calls
+
+---
+
+## MCP Tool Conversion Helpers
+
+**Beta.** Convert [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) tools, prompts, and resources to Anthropic API types for use with the tool runner. Requires `pip install anthropic[mcp]` (Python 3.10+).
+
+> **Note:** The Claude API also supports an `mcp_servers` parameter that lets Claude connect directly to remote MCP servers. Use these helpers instead when you need local MCP servers, prompts, resources, or more control over the MCP connection.
+
+### MCP Tools with Tool Runner
+
+```python
+from anthropic import AsyncAnthropic
+from anthropic.lib.tools.mcp import async_mcp_tool
+from mcp import ClientSession
+from mcp.client.stdio import stdio_client, StdioServerParameters
+
+client = AsyncAnthropic()
+
+async with stdio_client(StdioServerParameters(command="mcp-server")) as (read, write):
+    async with ClientSession(read, write) as mcp_client:
+        await mcp_client.initialize()
+
+        tools_result = await mcp_client.list_tools()
+        # tool_runner is sync — returns the runner, not a coroutine
+        runner = client.beta.messages.tool_runner(
+            model="claude-opus-4-6",
+            max_tokens=16000,
+            messages=[{"role": "user", "content": "Use the available tools"}],
+            tools=[async_mcp_tool(t, mcp_client) for t in tools_result.tools],
+        )
+        async for message in runner:
+            print(message)
+```
+
+For sync usage, use `mcp_tool` instead of `async_mcp_tool`.
+
+### MCP Prompts
+
+```python
+from anthropic.lib.tools.mcp import mcp_message
+
+prompt = await mcp_client.get_prompt(name="my-prompt")
+response = await client.beta.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    messages=[mcp_message(m) for m in prompt.messages],
+)
+```
+
+### MCP Resources as Content
+
+```python
+from anthropic.lib.tools.mcp import mcp_resource_to_content
+
+resource = await mcp_client.read_resource(uri="file:///path/to/doc.txt")
+response = await client.beta.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    messages=[{
+        "role": "user",
+        "content": [
+            mcp_resource_to_content(resource),
+            {"type": "text", "text": "Summarize this document"},
+        ],
+    }],
+)
+```
+
+### Upload MCP Resources as Files
+
+```python
+from anthropic.lib.tools.mcp import mcp_resource_to_file
+
+resource = await mcp_client.read_resource(uri="file:///path/to/data.json")
+uploaded = await client.beta.files.upload(file=mcp_resource_to_file(resource))
+```
+
+Conversion functions raise `UnsupportedMCPValueError` if an MCP value cannot be converted (e.g., unsupported content types like audio, unsupported MIME types).
+
+---
+
+## Manual Agentic Loop
+
+Use this when you need fine-grained control over the loop (e.g., custom logging, conditional tool execution, human-in-the-loop approval):
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+tools = [...]  # Your tool definitions
+messages = [{"role": "user", "content": user_input}]
+
+# Agentic loop: keep going until Claude stops calling tools
+while True:
+    response = client.messages.create(
+        model="claude-opus-4-6",
+        max_tokens=16000,
+        tools=tools,
+        messages=messages
+    )
+
+    # If Claude is done (no more tool calls), break
+    if response.stop_reason == "end_turn":
+        break
+
+    # Server-side tool hit iteration limit; re-send to continue
+    if response.stop_reason == "pause_turn":
+        messages = [
+            {"role": "user", "content": user_input},
+            {"role": "assistant", "content": response.content},
+        ]
+        continue
+
+    # Extract tool use blocks from the response
+    tool_use_blocks = [b for b in response.content if b.type == "tool_use"]
+
+    # Append assistant's response (including tool_use blocks)
+    messages.append({"role": "assistant", "content": response.content})
+
+    # Execute each tool and collect results
+    tool_results = []
+    for tool in tool_use_blocks:
+        result = execute_tool(tool.name, tool.input)  # Your implementation
+        tool_results.append({
+            "type": "tool_result",
+            "tool_use_id": tool.id,  # Must match the tool_use block's id
+            "content": result
+        })
+
+    # Append tool results as a user message
+    messages.append({"role": "user", "content": tool_results})
+
+# Final response text
+final_text = next(b.text for b in response.content if b.type == "text")
+```
+
+---
+
+## Handling Tool Results
+
+```python
+response = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    tools=tools,
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}]
+)
+
+for block in response.content:
+    if block.type == "tool_use":
+        tool_name = block.name
+        tool_input = block.input
+        tool_use_id = block.id
+
+        result = execute_tool(tool_name, tool_input)
+
+        followup = client.messages.create(
+            model="claude-opus-4-6",
+            max_tokens=16000,
+            tools=tools,
+            messages=[
+                {"role": "user", "content": "What's the weather in Paris?"},
+                {"role": "assistant", "content": response.content},
+                {
+                    "role": "user",
+                    "content": [{
+                        "type": "tool_result",
+                        "tool_use_id": tool_use_id,
+                        "content": result
+                    }]
+                }
+            ]
+        )
+```
+
+---
+
+## Multiple Tool Calls
+
+```python
+tool_results = []
+
+for block in response.content:
+    if block.type == "tool_use":
+        result = execute_tool(block.name, block.input)
+        tool_results.append({
+            "type": "tool_result",
+            "tool_use_id": block.id,
+            "content": result
+        })
+
+# Send all results back at once
+if tool_results:
+    followup = client.messages.create(
+        model="claude-opus-4-6",
+        max_tokens=16000,
+        tools=tools,
+        messages=[
+            *previous_messages,
+            {"role": "assistant", "content": response.content},
+            {"role": "user", "content": tool_results}
+        ]
+    )
+```
+
+---
+
+## Error Handling in Tool Results
+
+```python
+tool_result = {
+    "type": "tool_result",
+    "tool_use_id": tool_use_id,
+    "content": "Error: Location 'xyz' not found. Please provide a valid city name.",
+    "is_error": True
+}
+```
+
+---
+
+## Tool Choice
+
+```python
+response = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    tools=tools,
+    tool_choice={"type": "tool", "name": "get_weather"},  # Force specific tool
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}]
+)
+```
+
+---
+
+## Code Execution
+
+### Basic Usage
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+
+response = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    messages=[{
+        "role": "user",
+        "content": "Calculate the mean and standard deviation of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
+    }],
+    tools=[{
+        "type": "code_execution_20260120",
+        "name": "code_execution"
+    }]
+)
+
+for block in response.content:
+    if block.type == "text":
+        print(block.text)
+    elif block.type == "bash_code_execution_tool_result":
+        print(f"stdout: {block.content.stdout}")
+```
+
+### Upload Files for Analysis
+
+```python
+# 1. Upload a file
+uploaded = client.beta.files.upload(file=open("sales_data.csv", "rb"))
+
+# 2. Pass to code execution via container_upload block
+# Code execution is GA; Files API is still beta (pass via extra_headers)
+response = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    extra_headers={"anthropic-beta": "files-api-2025-04-14"},
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Analyze this sales data. Show trends and create a visualization."},
+            {"type": "container_upload", "file_id": uploaded.id}
+        ]
+    }],
+    tools=[{"type": "code_execution_20260120", "name": "code_execution"}]
+)
+```
+
+### Retrieve Generated Files
+
+```python
+import os
+
+OUTPUT_DIR = "./claude_outputs"
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+for block in response.content:
+    if block.type == "bash_code_execution_tool_result":
+        result = block.content
+        if result.type == "bash_code_execution_result" and result.content:
+            for file_ref in result.content:
+                if file_ref.type == "bash_code_execution_output":
+                    metadata = client.beta.files.retrieve_metadata(file_ref.file_id)
+                    file_content = client.beta.files.download(file_ref.file_id)
+                    # Use basename to prevent path traversal; validate result
+                    safe_name = os.path.basename(metadata.filename)
+                    if not safe_name or safe_name in (".", ".."):
+                        print(f"Skipping invalid filename: {metadata.filename}")
+                        continue
+                    output_path = os.path.join(OUTPUT_DIR, safe_name)
+                    file_content.write_to_file(output_path)
+                    print(f"Saved: {output_path}")
+```
+
+### Container Reuse
+
+```python
+# First request: set up environment
+response1 = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    messages=[{"role": "user", "content": "Install tabulate and create data.json with sample data"}],
+    tools=[{"type": "code_execution_20260120", "name": "code_execution"}]
+)
+
+# Get container ID from response
+container_id = response1.container.id
+
+# Second request: reuse the same container
+response2 = client.messages.create(
+    container=container_id,
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    messages=[{"role": "user", "content": "Read data.json and display as a formatted table"}],
+    tools=[{"type": "code_execution_20260120", "name": "code_execution"}]
+)
+```
+
+### Response Structure
+
+```python
+for block in response.content:
+    if block.type == "text":
+        print(block.text)  # Claude's explanation
+    elif block.type == "server_tool_use":
+        print(f"Running: {block.name} - {block.input}")  # What Claude is doing
+    elif block.type == "bash_code_execution_tool_result":
+        result = block.content
+        if result.type == "bash_code_execution_result":
+            if result.return_code == 0:
+                print(f"Output: {result.stdout}")
+            else:
+                print(f"Error: {result.stderr}")
+        else:
+            print(f"Tool error: {result.error_code}")
+    elif block.type == "text_editor_code_execution_tool_result":
+        print(f"File operation: {block.content}")
+```
+
+---
+
+## Memory Tool
+
+### Basic Usage
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()
+
+response = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    messages=[{"role": "user", "content": "Remember that my preferred language is Python."}],
+    tools=[{"type": "memory_20250818", "name": "memory"}],
+)
+```
+
+### SDK Memory Helper
+
+Subclass `BetaAbstractMemoryTool`:
+
+```python
+from anthropic.lib.tools import BetaAbstractMemoryTool
+
+class MyMemoryTool(BetaAbstractMemoryTool):
+    def view(self, command): ...
+    def create(self, command): ...
+    def str_replace(self, command): ...
+    def insert(self, command): ...
+    def delete(self, command): ...
+    def rename(self, command): ...
+
+memory = MyMemoryTool()
+
+# Use with tool runner
+runner = client.beta.messages.tool_runner(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    tools=[memory],
+    messages=[{"role": "user", "content": "Remember my preferences"}],
+)
+
+for message in runner:
+    print(message)
+```
+
+For full implementation examples, use WebFetch:
+
+- `https://github.com/anthropics/anthropic-sdk-python/blob/main/examples/memory/basic.py`
+
+---
+
+## Structured Outputs
+
+### JSON Outputs (Pydantic — Recommended)
+
+```python
+from pydantic import BaseModel
+from typing import List
+import anthropic
+
+class ContactInfo(BaseModel):
+    name: str
+    email: str
+    plan: str
+    interests: List[str]
+    demo_requested: bool
+
+client = anthropic.Anthropic()
+
+response = client.messages.parse(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    messages=[{
+        "role": "user",
+        "content": "Extract: Jane Doe (jane@co.com) wants Enterprise, interested in API and SDKs, wants a demo."
+    }],
+    output_format=ContactInfo,
+)
+
+# response.parsed_output is a validated ContactInfo instance
+contact = response.parsed_output
+print(contact.name)           # "Jane Doe"
+print(contact.interests)      # ["API", "SDKs"]
+```
+
+### Raw Schema
+
+```python
+response = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    messages=[{
+        "role": "user",
+        "content": "Extract info: John Smith (john@example.com) wants the Enterprise plan."
+    }],
+    output_config={
+        "format": {
+            "type": "json_schema",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "email": {"type": "string"},
+                    "plan": {"type": "string"},
+                    "demo_requested": {"type": "boolean"}
+                },
+                "required": ["name", "email", "plan", "demo_requested"],
+                "additionalProperties": False
+            }
+        }
+    }
+)
+
+import json
+# output_config.format guarantees the first block is text with valid JSON
+text = next(b.text for b in response.content if b.type == "text")
+data = json.loads(text)
+```
+
+### Strict Tool Use
+
+```python
+response = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    messages=[{"role": "user", "content": "Book a flight to Tokyo for 2 passengers on March 15"}],
+    tools=[{
+        "name": "book_flight",
+        "description": "Book a flight to a destination",
+        "strict": True,
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "destination": {"type": "string"},
+                "date": {"type": "string", "format": "date"},
+                "passengers": {"type": "integer", "enum": [1, 2, 3, 4, 5, 6, 7, 8]}
+            },
+            "required": ["destination", "date", "passengers"],
+            "additionalProperties": False
+        }
+    }]
+)
+```
+
+### Using Both Together
+
+```python
+response = client.messages.create(
+    model="claude-opus-4-6",
+    max_tokens=16000,
+    messages=[{"role": "user", "content": "Plan a trip to Paris next month"}],
+    output_config={
+        "format": {
+            "type": "json_schema",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "summary": {"type": "string"},
+                    "next_steps": {"type": "array", "items": {"type": "string"}}
+                },
+                "required": ["summary", "next_steps"],
+                "additionalProperties": False
+            }
+        }
+    },
+    tools=[{
+        "name": "search_flights",
+        "description": "Search for available flights",
+        "strict": True,
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "destination": {"type": "string"},
+                "date": {"type": "string", "format": "date"}
+            },
+            "required": ["destination", "date"],
+            "additionalProperties": False
+        }
+    }]
+)
+```

--- a/.claude/skills/claude-api/python/managed-agents/README.md
+++ b/.claude/skills/claude-api/python/managed-agents/README.md
@@ -1,0 +1,329 @@
+# Managed Agents — Python
+
+> **Bindings not shown here:** This README covers the most common managed-agents flows for Python. If you need a class, method, namespace, field, or behavior that isn't shown, WebFetch the Python SDK repo **or the relevant docs page** from `shared/live-sources.md` rather than guess. Do not extrapolate from cURL shapes or another language's SDK.
+
+> **Agents are persistent — create once, reference by ID.** Store the agent ID returned by `agents.create` and pass it to every subsequent `sessions.create`; do not call `agents.create` in the request path. The Anthropic CLI is one convenient way to create agents and environments from version-controlled YAML — its URL is in `shared/live-sources.md`. The examples below show in-code creation for completeness; in production the create call belongs in setup, not in the request path.
+
+## Installation
+
+```bash
+pip install anthropic
+```
+
+## Client Initialization
+
+```python
+import anthropic
+
+# Default (uses ANTHROPIC_API_KEY env var)
+client = anthropic.Anthropic()
+
+# Explicit API key
+client = anthropic.Anthropic(api_key="your-api-key")
+```
+
+---
+
+## Create an Environment
+
+```python
+environment = client.beta.environments.create(
+    name="my-dev-env",
+    config={
+        "type": "cloud",
+        "networking": {"type": "unrestricted"},
+    },
+)
+print(environment.id)  # env_...
+```
+
+---
+
+## Create an Agent (required first step)
+
+> ⚠️ **There is no inline agent config.** `model`/`system`/`tools` live on the agent object, not the session. Always start with `agents.create()` — the session only takes `agent={"type": "agent", "id": agent.id}`.
+
+### Minimal
+
+```python
+# 1. Create the agent (reusable, versioned)
+agent = client.beta.agents.create(
+    name="Coding Assistant",
+    model="claude-opus-4-6",
+    tools=[{"type": "agent_toolset_20260401", "default_config": {"enabled": True}}],
+)
+
+# 2. Start a session
+session = client.beta.sessions.create(
+    agent={"type": "agent", "id": agent.id, "version": agent.version},
+    environment_id=environment.id,
+)
+print(session.id, session.status)
+```
+
+### With system prompt and custom tools
+
+```python
+import os
+
+agent = client.beta.agents.create(
+    name="Code Reviewer",
+    model="claude-opus-4-6",
+    system="You are a senior code reviewer.",
+    tools=[
+        {"type": "agent_toolset_20260401"},
+        {
+            "type": "custom",
+            "name": "run_tests",
+            "description": "Run the test suite",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "test_path": {"type": "string", "description": "Path to test file"}
+                },
+                "required": ["test_path"],
+            },
+        },
+    ],
+)
+
+session = client.beta.sessions.create(
+    agent={"type": "agent", "id": agent.id, "version": agent.version},
+    environment_id=environment.id,
+    title="Code review session",
+    resources=[
+        {
+            "type": "github_repository",
+            "url": "https://github.com/owner/repo",
+            "mount_path": "/workspace/repo",
+            "authorization_token": os.environ["GITHUB_TOKEN"],
+            "branch": "main",
+        }
+    ],
+)
+```
+
+---
+
+## Send a User Message
+
+```python
+client.beta.sessions.events.send(
+    session_id=session.id,
+    events=[
+        {
+            "type": "user.message",
+            "content": [{"type": "text", "text": "Review the auth module"}],
+        }
+    ],
+)
+```
+
+> 💡 **Stream-first:** Open the stream *before* (or concurrently with) sending the message. The stream only delivers events that occur after it opens — stream-after-send means early events arrive buffered in one batch. See [Steering Patterns](../../shared/managed-agents-events.md#steering-patterns).
+
+---
+
+## Stream Events (SSE)
+
+```python
+import json
+
+# Stream-first: open stream, then send while stream is live
+with client.beta.sessions.stream(
+    session_id=session.id,
+) as stream:
+    client.beta.sessions.events.send(
+        session_id=session.id,
+        events=[{"type": "user.message", "content": [{"type": "text", "text": "..."}]}],
+    )
+    for event in stream:
+        ...  # process events
+
+# Standalone stream iteration:
+with client.beta.sessions.stream(
+    session_id=session.id,
+) as stream:
+    for event in stream:
+        if event.type == "agent.message":
+            for block in event.content:
+                if block.type == "text":
+                    print(block.text, end="", flush=True)
+        elif event.type == "agent.custom_tool_use":
+            # Custom tool invocation — session is now idle
+            print(f"\nCustom tool call: {event.tool_name}")
+            print(f"Input: {json.dumps(event.input)}")
+            # Send result back (see below)
+        elif event.type == "session.status_idle":
+            print("\n--- Agent idle ---")
+        elif event.type == "session.status_terminated":
+            print("\n--- Session terminated ---")
+            break
+```
+
+---
+
+## Provide Custom Tool Result
+
+```python
+client.beta.sessions.events.send(
+    session_id=session.id,
+    events=[
+        {
+            "type": "user.custom_tool_result",
+            "custom_tool_use_id": "sevt_abc123",
+            "content": [{"type": "text", "text": "All 42 tests passed."}],
+        }
+    ],
+)
+```
+
+---
+
+## Poll Events
+
+```python
+events = client.beta.sessions.events.list(
+    session_id=session.id,
+)
+for event in events.data:
+    print(f"{event.type}: {event.id}")
+```
+
+> ⚠️ **Prefer the SDK over raw `requests`/`httpx`.** If you hand-roll a poll loop, don't assume `timeout=(5, 60)` or `httpx.Timeout(120)` caps total call duration — both are **per-chunk** read timeouts (reset on every byte), so a trickling response can block forever. For a hard wall-clock deadline, track `time.monotonic()` at the loop level and bail explicitly, or wrap with `asyncio.wait_for()`. See [Receiving Events](../../shared/managed-agents-events.md#receiving-events).
+
+---
+
+## Full Streaming Loop with Custom Tools
+
+```python
+import json
+
+
+def run_custom_tool(tool_name: str, tool_input: dict) -> str:
+    """Execute a custom tool and return the result."""
+    if tool_name == "run_tests":
+        # Your tool implementation here
+        return "All tests passed."
+    return f"Unknown tool: {tool_name}"
+
+
+def run_session(client, session_id: str):
+    """Stream events and handle custom tool calls."""
+    while True:
+        with client.beta.sessions.stream(
+            session_id=session_id,
+        ) as stream:
+            tool_calls = []
+            for event in stream:
+                if event.type == "agent.message":
+                    for block in event.content:
+                        if block.type == "text":
+                            print(block.text, end="", flush=True)
+                elif event.type == "agent.custom_tool_use":
+                    tool_calls.append(event)
+                elif event.type == "session.status_idle":
+                    break
+                elif event.type == "session.status_terminated":
+                    return
+
+        if not tool_calls:
+            break
+
+        # Process custom tool calls
+        results = []
+        for call in tool_calls:
+            result = run_custom_tool(call.tool_name, call.input)
+            results.append({
+                "type": "user.custom_tool_result",
+                "custom_tool_use_id": call.id,
+                "content": [{"type": "text", "text": result}],
+            })
+
+        client.beta.sessions.events.send(
+            session_id=session_id,
+            events=results,
+        )
+```
+
+---
+
+## Upload a File
+
+```python
+with open("data.csv", "rb") as f:
+    file = client.beta.files.upload(
+        file=f,
+    )
+
+# Use in a session
+session = client.beta.sessions.create(
+    agent={"type": "agent", "id": agent.id, "version": agent.version},
+    environment_id=environment.id,
+    resources=[{"type": "file", "file_id": file.id, "mount_path": "/workspace/data.csv"}],
+)
+```
+
+---
+
+## List and Download Session Files
+
+List files the agent wrote to `/mnt/session/outputs/` during a session, then download them.
+
+```python
+# List files associated with a session
+files = client.beta.files.list(session_id=session.id)
+for f in files.data:
+    print(f.filename, f.size_bytes)
+    # Download each file and save to disk
+    file_content = client.beta.files.download(f.id)
+    file_content.write_to_file(f.filename)
+```
+
+> 💡 There's a brief indexing lag (~1–3s) between `session.status_idle` and output files appearing in `files.list` (with `scope=session_id` as a query param). Retry once or twice if the list is empty.
+
+---
+
+## Session Management
+
+```python
+# Get session details
+session = client.beta.sessions.retrieve(session_id="sess_abc123")
+print(session.status, session.usage)
+
+# List sessions
+sessions = client.beta.sessions.list()
+
+# Delete a session
+client.beta.sessions.delete(session_id="sess_abc123")
+
+# Archive a session
+client.beta.sessions.archive(session_id="sess_abc123")
+```
+
+---
+
+## MCP Server Integration
+
+```python
+# Agent declares MCP server (no auth here — auth goes in a vault)
+agent = client.beta.agents.create(
+    name="MCP Agent",
+    model="claude-opus-4-6",
+    mcp_servers=[
+        {"type": "url", "name": "my-tools", "url": "https://my-mcp-server.example.com/sse"},
+    ],
+    tools=[
+        {"type": "agent_toolset_20260401", "default_config": {"enabled": True}},
+        {"type": "mcp_toolset", "mcp_server_name": "my-tools"},
+    ],
+)
+
+# Session attaches vault(s) containing credentials for those MCP server URLs
+session = client.beta.sessions.create(
+    agent=agent.id,
+    environment_id=environment.id,
+    vault_ids=[vault.id],
+)
+```
+
+See `shared/managed-agents-tools.md` §Vaults for creating vaults and adding credentials.

--- a/.claude/skills/claude-api/ruby/claude-api.md
+++ b/.claude/skills/claude-api/ruby/claude-api.md
@@ -1,0 +1,113 @@
+# Claude API — Ruby
+
+> **Note:** The Ruby SDK supports the Claude API. A tool runner is available in beta via `client.beta.messages.tool_runner()`. Agent SDK is not yet available for Ruby.
+
+## Installation
+
+```bash
+gem install anthropic
+```
+
+## Client Initialization
+
+```ruby
+require "anthropic"
+
+# Default (uses ANTHROPIC_API_KEY env var)
+client = Anthropic::Client.new
+
+# Explicit API key
+client = Anthropic::Client.new(api_key: "your-api-key")
+```
+
+---
+
+## Basic Message Request
+
+```ruby
+message = client.messages.create(
+  model: :"claude-opus-4-6",
+  max_tokens: 16000,
+  messages: [
+    { role: "user", content: "What is the capital of France?" }
+  ]
+)
+# content is an array of polymorphic block objects (TextBlock, ThinkingBlock,
+# ToolUseBlock, ...). .type is a Symbol — compare with :text, not "text".
+# .text raises NoMethodError on non-TextBlock entries.
+message.content.each do |block|
+  puts block.text if block.type == :text
+end
+```
+
+---
+
+## Streaming
+
+```ruby
+stream = client.messages.stream(
+  model: :"claude-opus-4-6",
+  max_tokens: 64000,
+  messages: [{ role: "user", content: "Write a haiku" }]
+)
+
+stream.text.each { |text| print(text) }
+```
+
+---
+
+## Tool Use
+
+The Ruby SDK supports tool use via raw JSON schema definitions and also provides a beta tool runner for automatic tool execution.
+
+### Tool Runner (Beta)
+
+```ruby
+class GetWeatherInput < Anthropic::BaseModel
+  required :location, String, doc: "City and state, e.g. San Francisco, CA"
+end
+
+class GetWeather < Anthropic::BaseTool
+  doc "Get the current weather for a location"
+
+  input_schema GetWeatherInput
+
+  def call(input)
+    "The weather in #{input.location} is sunny and 72°F."
+  end
+end
+
+client.beta.messages.tool_runner(
+  model: :"claude-opus-4-6",
+  max_tokens: 16000,
+  tools: [GetWeather.new],
+  messages: [{ role: "user", content: "What's the weather in San Francisco?" }]
+).each_message do |message|
+  puts message.content
+end
+```
+
+### Manual Loop
+
+See the [shared tool use concepts](../shared/tool-use-concepts.md) for the tool definition format and agentic loop pattern.
+
+---
+
+## Prompt Caching
+
+`system_:` (trailing underscore — avoids shadowing `Kernel#system`) takes an array of text blocks; set `cache_control` on the last block. Plain hashes work via the `OrHash` type alias. For placement patterns and the silent-invalidator audit checklist, see `shared/prompt-caching.md`.
+
+```ruby
+message = client.messages.create(
+  model: :"claude-opus-4-6",
+  max_tokens: 16000,
+  system_: [
+    { type: "text", text: long_system_prompt, cache_control: { type: "ephemeral" } }
+  ],
+  messages: [{ role: "user", content: "Summarize the key points" }]
+)
+```
+
+For 1-hour TTL: `cache_control: { type: "ephemeral", ttl: "1h" }`. There's also a top-level `cache_control:` on `messages.create` that auto-places on the last cacheable block.
+
+Verify hits via `message.usage.cache_creation_input_tokens` / `message.usage.cache_read_input_tokens`.

--- a/.claude/skills/claude-api/ruby/managed-agents/README.md
+++ b/.claude/skills/claude-api/ruby/managed-agents/README.md
@@ -1,0 +1,389 @@
+# Managed Agents — Ruby
+
+> **Bindings not shown here:** This README covers the most common managed-agents flows for Ruby. If you need a class, method, namespace, field, or behavior that isn't shown, WebFetch the Ruby SDK repo **or the relevant docs page** from `shared/live-sources.md` rather than guess. Do not extrapolate from cURL shapes or another language's SDK.
+
+> **Agents are persistent — create once, reference by ID.** Store the agent ID returned by `client.beta.agents.create` and pass it to every subsequent `client.beta.sessions.create`; do not call `agents.create` in the request path. The Anthropic CLI is one convenient way to create agents and environments from version-controlled YAML — its URL is in `shared/live-sources.md`. The examples below show in-code creation for completeness; in production the create call belongs in setup, not in the request path.
+
+## Installation
+
+```bash
+gem install anthropic
+```
+
+## Client Initialization
+
+```ruby
+require "anthropic"
+
+# Default (uses ANTHROPIC_API_KEY env var)
+client = Anthropic::Client.new
+
+# Explicit API key
+client = Anthropic::Client.new(api_key: "your-api-key")
+```
+
+> ⚠️ **Trailing underscores:** The Ruby SDK uses `system_:` and `send_(` (trailing underscore) to avoid shadowing `Kernel#system` and `Kernel#send`. Use these forms throughout managed-agents code.
+
+---
+
+## Create an Environment
+
+```ruby
+environment = client.beta.environments.create(
+  name: "my-dev-env",
+  config: {
+    type: "cloud",
+    networking: {type: "unrestricted"}
+  }
+)
+puts "Environment ID: #{environment.id}" # env_...
+```
+
+---
+
+## Create an Agent (required first step)
+
+> ⚠️ **There is no inline agent config.** `model`/`system_`/`tools` live on the agent object, not the session. Always start with `client.beta.agents.create()` — the session takes either `agent: agent.id` or the typed hash form `agent: {type: "agent", id: agent.id, version: agent.version}`.
+
+### Minimal
+
+```ruby
+# 1. Create the agent (reusable, versioned)
+agent = client.beta.agents.create(
+  name: "Coding Assistant",
+  model: :"claude-opus-4-6",
+  system_: "You are a helpful coding assistant.",
+  tools: [{type: "agent_toolset_20260401"}]
+)
+
+# 2. Start a session
+session = client.beta.sessions.create(
+  agent: {type: "agent", id: agent.id, version: agent.version},
+  environment_id: environment.id,
+  title: "Quickstart session"
+)
+puts "Session ID: #{session.id}"
+```
+
+### Updating an Agent
+
+Updates create new versions; the agent object is immutable per version.
+
+```ruby
+updated_agent = client.beta.agents.update(
+  agent.id,
+  version: agent.version,
+  system_: "You are a helpful coding agent. Always write tests."
+)
+puts "New version: #{updated_agent.version}"
+
+# List all versions
+client.beta.agents.versions.list(agent.id).auto_paging_each do |version|
+  puts "Version #{version.version}: #{version.updated_at.iso8601}"
+end
+
+# Archive the agent
+archived = client.beta.agents.archive(agent.id)
+puts "Archived at: #{archived.archived_at.iso8601}"
+```
+
+---
+
+## Send a User Message
+
+```ruby
+client.beta.sessions.events.send_(
+  session.id,
+  events: [{
+    type: "user.message",
+    content: [{type: "text", text: "Review the auth module"}]
+  }]
+)
+```
+
+> 💡 **Stream-first:** Open the stream *before* (or concurrently with) sending the message. The stream only delivers events that occur after it opens — stream-after-send means early events arrive buffered in one batch. See [Steering Patterns](../../shared/managed-agents-events.md#steering-patterns).
+
+---
+
+## Stream Events (SSE)
+
+```ruby
+# Open the stream first, then send the user message
+stream = client.beta.sessions.events.stream_events(session.id)
+
+client.beta.sessions.events.send_(
+  session.id,
+  events: [{
+    type: "user.message",
+    content: [{type: "text", text: "Summarize the repo README"}]
+  }]
+)
+
+stream.each do |event|
+  case event.type
+  in :"agent.message"
+    event.content.each { |block| print block.text }
+  in :"agent.tool_use"
+    puts "\n[Using tool: #{event.name}]"
+  in :"session.status_idle"
+    break
+  in :"session.error"
+    puts "\n[Error: #{event.error&.message || "unknown"}]"
+    break
+  else
+    # ignore other event types
+  end
+end
+```
+
+> ℹ️ Event `.type` is a Symbol (compare with `:"agent.message"`, not `"agent.message"`).
+
+### Reconnecting and Tailing
+
+When reconnecting mid-session, list past events first to dedupe, then tail live events:
+
+```ruby
+require "set"
+
+stream = client.beta.sessions.events.stream_events(session.id)
+
+# Stream is open and buffering. List history before tailing live.
+seen_event_ids = Set.new
+client.beta.sessions.events.list(session.id).auto_paging_each { |past| seen_event_ids << past.id }
+
+# Tail live events, skipping anything already seen
+stream.each do |event|
+  next if seen_event_ids.include?(event.id)
+  seen_event_ids << event.id
+  case event.type
+  in :"agent.message"
+    event.content.each { |block| print block.text }
+  in :"session.status_idle"
+    break
+  else
+    # ignore other event types
+  end
+end
+```
+
+---
+
+## Provide Custom Tool Result
+
+> ℹ️ The Ruby managed-agents bindings for `user.custom_tool_result` are not yet documented in this skill or in the apps source examples. Refer to `shared/managed-agents-events.md` for the wire format and the `anthropic` Ruby gem repository for the corresponding params.
+
+---
+
+## Poll Events
+
+```ruby
+client.beta.sessions.events.list(session.id).auto_paging_each do |event|
+  puts "#{event.type}: #{event.id}"
+end
+```
+
+---
+
+## Upload a File
+
+```ruby
+require "pathname"
+
+file = client.beta.files.upload(file: Pathname("data.csv"))
+puts "File ID: #{file.id}"
+
+# Mount in a session
+session = client.beta.sessions.create(
+  agent: agent.id,
+  environment_id: environment.id,
+  resources: [
+    {
+      type: "file",
+      file_id: file.id,
+      mount_path: "/workspace/data.csv"
+    }
+  ]
+)
+```
+
+### Add and Manage Resources on an Existing Session
+
+```ruby
+# Attach an additional file to an open session
+resource = client.beta.sessions.resources.add(
+  session.id,
+  type: "file",
+  file_id: file.id
+)
+puts resource.id # "sesrsc_01ABC..."
+
+# List resources on the session
+listed = client.beta.sessions.resources.list(session.id)
+listed.data.each { |entry| puts "#{entry.id} #{entry.type}" }
+
+# Detach a resource
+client.beta.sessions.resources.delete(resource.id, session_id: session.id)
+```
+
+---
+
+## List and Download Session Files
+
+> ℹ️ Listing and downloading files an agent wrote during a session is not yet documented for Ruby in this skill or in the apps source examples. See `shared/managed-agents-events.md` and the `anthropic` Ruby gem repository for the file list/download bindings.
+
+---
+
+## Session Management
+
+```ruby
+# List environments
+environments = client.beta.environments.list
+
+# Retrieve a specific environment
+env = client.beta.environments.retrieve(environment.id)
+
+# Archive an environment (read-only, existing sessions continue)
+client.beta.environments.archive(environment.id)
+
+# Delete an environment (only if no sessions reference it)
+client.beta.environments.delete(environment.id)
+
+# Delete a session
+client.beta.sessions.delete(session.id)
+```
+
+---
+
+## MCP Server Integration
+
+```ruby
+# Agent declares MCP server (no auth here — auth goes in a vault)
+agent = client.beta.agents.create(
+  name: "GitHub Assistant",
+  model: :"claude-opus-4-6",
+  mcp_servers: [
+    {
+      type: "url",
+      name: "github",
+      url: "https://api.githubcopilot.com/mcp/"
+    }
+  ],
+  tools: [
+    {type: "agent_toolset_20260401"},
+    {type: "mcp_toolset", mcp_server_name: "github"}
+  ]
+)
+
+# Session attaches vault(s) containing credentials for those MCP server URLs
+session = client.beta.sessions.create(
+  agent: {type: "agent", id: agent.id, version: agent.version},
+  environment_id: environment.id,
+  vault_ids: [vault.id]
+)
+```
+
+See `shared/managed-agents-tools.md` §Vaults for creating vaults and adding credentials.
+
+---
+
+## Vaults
+
+```ruby
+# Create a vault
+vault = client.beta.vaults.create(
+  display_name: "Alice",
+  metadata: {external_user_id: "usr_abc123"}
+)
+puts vault.id # "vlt_01ABC..."
+
+# Add an OAuth credential
+credential = client.beta.vaults.credentials.create(
+  vault.id,
+  display_name: "Alice's Slack",
+  auth: {
+    type: "mcp_oauth",
+    mcp_server_url: "https://mcp.slack.com/mcp",
+    access_token: "xoxp-...",
+    expires_at: "2026-04-15T00:00:00Z",
+    refresh: {
+      token_endpoint: "https://slack.com/api/oauth.v2.access",
+      client_id: "1234567890.0987654321",
+      scope: "channels:read chat:write",
+      refresh_token: "xoxe-1-...",
+      token_endpoint_auth: {
+        type: "client_secret_post",
+        client_secret: "abc123..."
+      }
+    }
+  }
+)
+
+# Rotate the credential (e.g., after a token refresh)
+client.beta.vaults.credentials.update(
+  credential.id,
+  vault_id: vault.id,
+  auth: {
+    type: "mcp_oauth",
+    access_token: "xoxp-new-...",
+    expires_at: "2026-05-15T00:00:00Z",
+    refresh: {refresh_token: "xoxe-1-new-..."}
+  }
+)
+
+# Archive a vault
+client.beta.vaults.archive(vault.id)
+```
+
+---
+
+## GitHub Repository Integration
+
+Mount a GitHub repository as a session resource (a vault holds the GitHub MCP credential):
+
+```ruby
+session = client.beta.sessions.create(
+  agent: agent.id,
+  environment_id: environment.id,
+  vault_ids: [vault.id],
+  resources: [
+    {
+      type: "github_repository",
+      url: "https://github.com/org/repo",
+      mount_path: "/workspace/repo",
+      authorization_token: "ghp_your_github_token"
+    }
+  ]
+)
+```
+
+Multiple repositories on the same session:
+
+```ruby
+resources = [
+  {
+    type: "github_repository",
+    url: "https://github.com/org/frontend",
+    mount_path: "/workspace/frontend",
+    authorization_token: "ghp_your_github_token"
+  },
+  {
+    type: "github_repository",
+    url: "https://github.com/org/backend",
+    mount_path: "/workspace/backend",
+    authorization_token: "ghp_your_github_token"
+  }
+]
+```
+
+Rotating a repository's authorization token:
+
+```ruby
+listed = client.beta.sessions.resources.list(session.id)
+repo_resource_id = listed.data.first.id
+
+client.beta.sessions.resources.update(
+  repo_resource_id,
+  session_id: session.id,
+  authorization_token: "ghp_your_new_github_token"
+)
+```

--- a/.claude/skills/claude-api/shared/agent-design.md
+++ b/.claude/skills/claude-api/shared/agent-design.md
@@ -1,0 +1,101 @@
+# Agent Design Patterns
+
+This file covers decision heuristics for building agents on the Claude API: which primitives to reach for, how to design your tool surface, and how to manage context and cost over long runs. For per-tool mechanics and code examples, see `tool-use-concepts.md` and the language-specific folders.
+
+---
+
+## Model Parameters
+
+| Parameter | When to use it | What to expect |
+| --- | --- | --- |
+| **Adaptive thinking** (`thinking: {type: "adaptive"}`) | When you want Claude to control when and how much to think. | Claude determines thinking depth per request and automatically interleaves thinking between tool calls. No token budget to tune. |
+| **Effort** (`output_config: {effort: ...}`) | When adjusting the tradeoff between thoroughness and token efficiency. | Lower effort → fewer and more-consolidated tool calls, less preamble, terser confirmations. `medium` is often a favorable balance. Use `max` when correctness matters more than cost. |
+
+See `SKILL.md` §Thinking & Effort for model support and parameter details.
+
+---
+
+## Designing Your Tool Surface
+
+### Bash vs. dedicated tools
+
+Claude doesn't know your application's security boundary, approval policy, or UX surface. Claude emits tool calls; your harness handles them. The shape of those tool calls determines what the harness can do.
+
+A **bash tool** gives Claude broad programmatic leverage — it can perform almost any action. But it gives the harness only an opaque command string, the same shape for every action. Promoting an action to a **dedicated tool** gives the harness an action-specific hook with typed arguments it can intercept, gate, render, or audit.
+
+**When to promote an action to a dedicated tool:**
+
+- **Security boundary.** Actions that require gating are natural candidates. Reversibility is a useful criterion: hard-to-reverse actions (external API calls, sending messages, deleting data) can be gated behind user confirmation. A `send_email` tool is easy to gate; `bash -c "curl -X POST ..."` is not.
+- **Staleness checks.** A dedicated `edit` tool can reject writes if the file changed since Claude last read it. Bash can't enforce that invariant.
+- **Rendering.** Some actions benefit from custom UI. Claude Code promotes question-asking to a tool so it can render as a modal, present options, and block the agent loop until answered.
+- **Scheduling.** Read-only tools like `glob` and `grep` can be marked parallel-safe. When the same actions run through bash, the harness can't tell a parallel-safe `grep` from a parallel-unsafe `git push`, so it must serialize.
+
+**Rule of thumb:** Start with bash for breadth. Promote to dedicated tools when you need to gate, render, audit, or parallelize the action.
+
+---
+
+## Anthropic-Provided Tools
+
+| Tool | Side | When to use it | What to expect |
+| --- | --- | --- | --- |
+| **Bash** | Client | Claude needs to execute shell commands. | Claude emits commands; your harness executes them. Reference implementation provided. |
+| **Text editor** | Client | Claude needs to read or edit files. | Claude views, creates, and edits files via your implementation. Reference implementation provided. |
+| **Computer use** | Client or Server | Claude needs to interact with GUIs, web apps, or visual interfaces. | Claude takes screenshots and issues mouse/keyboard commands. Can be self-hosted (you run the environment) or Anthropic-hosted. |
+| **Code execution** | Server | Claude needs to run code in a sandbox you don't want to manage. | Anthropic-hosted container with built-in file and bash sub-tools. No client-side execution. |
+| **Web search / fetch** | Server | Claude needs information past its training cutoff (news, current events, recent docs) or the content of a specific URL. | Claude issues a query or URL; Anthropic executes it and returns results with citations. |
+| **Memory** | Client | Claude needs to save context across sessions. | Claude reads/writes a `/memories` directory. You implement the storage backend. |
+
+**Client-side** tools are defined by Anthropic (name, schema, Claude's usage pattern) but executed by your harness. Anthropic provides reference implementations. **Server-side** tools run entirely on Anthropic infrastructure — declare them in `tools` and Claude handles the rest.
+
+---
+
+## Composing Tool Calls: Programmatic Tool Calling
+
+With standard tool use, each tool call is a round trip: Claude calls the tool, the result lands in Claude's context, Claude reasons about it, then calls the next tool. Three sequential actions (read profile → look up orders → check inventory) means three round trips. Each adds latency and tokens, and most of the intermediate data is never needed again.
+
+**Programmatic tool calling (PTC)** lets Claude compose those calls into a script instead. The script runs in the code execution container. When the script calls a tool, the container pauses, the call is executed (client-side or server-side), and the result returns to the running code — not to Claude's context. The script processes it with normal control flow (loops, filters, branches). Only the script's final output returns to Claude.
+
+| When to use it | What to expect |
+| --- | --- |
+| Many sequential tool calls, or large intermediate results you want filtered before they hit the context window. | Claude writes code that invokes tools as functions. Runs in the code execution container. Token cost scales with final output, not intermediate results. |
+
+---
+
+## Scaling the Tool and Instruction Set
+
+| Feature | When to use it | What to expect |
+| --- | --- | --- |
+| **Tool search** | Many tools available, but only a few relevant per request. Don't want all schemas in context upfront. | Claude searches the tool set and loads only relevant schemas. Tool definitions are appended, not swapped — preserves cache (see Caching below). |
+| **Skills** | Task-specific instructions Claude should load only when relevant. | Each skill is a folder with a `SKILL.md`. The skill's description sits in context by default; Claude reads the full file when the task calls for it. |
+
+Both patterns keep the fixed context small and load detail on demand.
+
+---
+
+## Long-Running Agents: Managing Context
+
+| Pattern | When to use it | What to expect |
+| --- | --- | --- |
+| **Context editing** | Context grows stale over many turns (old tool results, completed thinking). | Tool results and thinking blocks are cleared based on configurable thresholds. Keeps the transcript lean without summarizing. |
+| **Compaction** | Conversation likely to reach or exceed the context window limit. | Earlier context is summarized into a compaction block server-side. See `SKILL.md` §Compaction for the critical `response.content` handling. |
+| **Memory** | State must persist across sessions (not just within one conversation). | Claude reads/writes files in a memory directory. Survives process restarts. |
+
+**Choosing between them:** Context editing and compaction operate within a session — editing prunes stale turns, compaction summarizes when you're near the limit. Memory is for cross-session persistence. Many long-running agents use all three.
+
+---
+
+## Caching for Agents
+
+**Read `prompt-caching.md` first.** It covers the prefix-match invariant, breakpoint placement, the silent-invalidator audit, and why changing tools or models mid-session breaks the cache. This section covers only the agent-specific workarounds for those constraints.
+
+| Constraint (from `prompt-caching.md`) | Agent-specific workaround |
+| --- | --- |
+| Editing the system prompt mid-session invalidates the cache. | Append a `<system-reminder>` block in the `messages` array instead. The cached prefix stays intact. Claude Code uses this for time updates and mode transitions. |
+| Switching models mid-session invalidates the cache. | Spawn a **subagent** with the cheaper model for the sub-task; keep the main loop on one model. Claude Code's Explore subagents use Haiku this way. |
+| Adding/removing tools mid-session invalidates the cache. | Use **tool search** for dynamic discovery — it appends tool schemas rather than swapping them, so the existing prefix is preserved. |
+
+For multi-turn breakpoint placement, use top-level auto-caching — see `prompt-caching.md` §Placement patterns.
+
+---
+
+For live documentation on any of these features, see `live-sources.md`.

--- a/.claude/skills/claude-api/shared/error-codes.md
+++ b/.claude/skills/claude-api/shared/error-codes.md
@@ -1,0 +1,206 @@
+# HTTP Error Codes Reference
+
+This file documents HTTP error codes returned by the Claude API, their common causes, and how to handle them. For language-specific error handling examples, see the `python/` or `typescript/` folders.
+
+## Error Code Summary
+
+| Code | Error Type              | Retryable | Common Cause                         |
+| ---- | ----------------------- | --------- | ------------------------------------ |
+| 400  | `invalid_request_error` | No        | Invalid request format or parameters |
+| 401  | `authentication_error`  | No        | Invalid or missing API key           |
+| 403  | `permission_error`      | No        | API key lacks permission             |
+| 404  | `not_found_error`       | No        | Invalid endpoint or model ID         |
+| 413  | `request_too_large`     | No        | Request exceeds size limits          |
+| 429  | `rate_limit_error`      | Yes       | Too many requests                    |
+| 500  | `api_error`             | Yes       | Anthropic service issue              |
+| 529  | `overloaded_error`      | Yes       | API is temporarily overloaded        |
+
+## Detailed Error Information
+
+### 400 Bad Request
+
+**Causes:**
+
+- Malformed JSON in request body
+- Missing required parameters (`model`, `max_tokens`, `messages`)
+- Invalid parameter types (e.g., string where integer expected)
+- Empty messages array
+- Messages not alternating user/assistant
+
+**Example error:**
+
+```json
+{
+  "type": "error",
+  "error": {
+    "type": "invalid_request_error",
+    "message": "messages: roles must alternate between \"user\" and \"assistant\""
+  },
+  "request_id": "req_011CSHoEeqs5C35K2UUqR7Fy"
+}
+```
+
+**Fix:** Validate request structure before sending. Check that:
+
+- `model` is a valid model ID
+- `max_tokens` is a positive integer
+- `messages` array is non-empty and alternates correctly
+
+---
+
+### 401 Unauthorized
+
+**Causes:**
+
+- Missing `x-api-key` header or `Authorization` header
+- Invalid API key format
+- Revoked or deleted API key
+
+**Fix:** Ensure `ANTHROPIC_API_KEY` environment variable is set correctly.
+
+---
+
+### 403 Forbidden
+
+**Causes:**
+
+- API key doesn't have access to the requested model
+- Organization-level restrictions
+- Attempting to access beta features without beta access
+
+**Fix:** Check your API key permissions in the Console. You may need a different API key or to request access to specific features.
+
+---
+
+### 404 Not Found
+
+**Causes:**
+
+- Typo in model ID (e.g., `claude-sonnet-4.6` instead of `claude-sonnet-4-6`)
+- Using deprecated model ID
+- Invalid API endpoint
+
+**Fix:** Use exact model IDs from the models documentation. You can use aliases (e.g., `claude-opus-4-6`).
+
+---
+
+### 413 Request Too Large
+
+**Causes:**
+
+- Request body exceeds maximum size
+- Too many tokens in input
+- Image data too large
+
+**Fix:** Reduce input size — truncate conversation history, compress/resize images, or split large documents into chunks.
+
+---
+
+### 400 Validation Errors
+
+Some 400 errors are specifically related to parameter validation:
+
+- `max_tokens` exceeds model's limit
+- Invalid `temperature` value (must be 0.0-1.0)
+- `budget_tokens` >= `max_tokens` in extended thinking
+- Invalid tool definition schema
+
+**Common mistake with extended thinking:**
+
+```
+# Wrong: budget_tokens must be < max_tokens
+thinking: budget_tokens=10000, max_tokens=1000  → Error!
+
+# Correct
+thinking: budget_tokens=10000, max_tokens=16000
+```
+
+---
+
+### 429 Rate Limited
+
+**Causes:**
+
+- Exceeded requests per minute (RPM)
+- Exceeded tokens per minute (TPM)
+- Exceeded tokens per day (TPD)
+
+**Headers to check:**
+
+- `retry-after`: Seconds to wait before retrying
+- `x-ratelimit-limit-*`: Your limits
+- `x-ratelimit-remaining-*`: Remaining quota
+
+**Fix:** The Anthropic SDKs automatically retry 429 and 5xx errors with exponential backoff (default: `max_retries=2`). For custom retry behavior, see the language-specific error handling examples.
+
+---
+
+### 500 Internal Server Error
+
+**Causes:**
+
+- Temporary Anthropic service issue
+- Bug in API processing
+
+**Fix:** Retry with exponential backoff. If persistent, check [status.anthropic.com](https://status.anthropic.com).
+
+---
+
+### 529 Overloaded
+
+**Causes:**
+
+- High API demand
+- Service capacity reached
+
+**Fix:** Retry with exponential backoff. Consider using a different model (Haiku is often less loaded), spreading requests over time, or implementing request queuing.
+
+---
+
+## Common Mistakes and Fixes
+
+| Mistake                         | Error            | Fix                                                     |
+| ------------------------------- | ---------------- | ------------------------------------------------------- |
+| `budget_tokens` >= `max_tokens` | 400              | Ensure `budget_tokens` < `max_tokens`                   |
+| Typo in model ID                | 404              | Use valid model ID like `claude-opus-4-6`               |
+| First message is `assistant`    | 400              | First message must be `user`                            |
+| Consecutive same-role messages  | 400              | Alternate `user` and `assistant`                        |
+| API key in code                 | 401 (leaked key) | Use environment variable                                |
+| Custom retry needs              | 429/5xx          | SDK retries automatically; customize with `max_retries` |
+
+## Typed Exceptions in SDKs
+
+**Always use the SDK's typed exception classes** instead of checking error messages with string matching. Each HTTP error code maps to a specific exception class:
+
+| HTTP Code | TypeScript Class                  | Python Class                      |
+| --------- | --------------------------------- | --------------------------------- |
+| 400       | `Anthropic.BadRequestError`       | `anthropic.BadRequestError`       |
+| 401       | `Anthropic.AuthenticationError`   | `anthropic.AuthenticationError`   |
+| 403       | `Anthropic.PermissionDeniedError` | `anthropic.PermissionDeniedError` |
+| 404       | `Anthropic.NotFoundError`         | `anthropic.NotFoundError`         |
+| 429       | `Anthropic.RateLimitError`        | `anthropic.RateLimitError`        |
+| 500+      | `Anthropic.InternalServerError`   | `anthropic.InternalServerError`   |
+| Any       | `Anthropic.APIError`              | `anthropic.APIError`              |
+
+```typescript
+// ✅ Correct: use typed exceptions
+try {
+  const response = await client.messages.create({...});
+} catch (error) {
+  if (error instanceof Anthropic.RateLimitError) {
+    // Handle rate limiting
+  } else if (error instanceof Anthropic.APIError) {
+    console.error(`API error ${error.status}:`, error.message);
+  }
+}
+
+// ❌ Wrong: don't check error messages with string matching
+try {
+  const response = await client.messages.create({...});
+} catch (error) {
+  const msg = error instanceof Error ? error.message : String(error);
+  if (msg.includes("429") || msg.includes("rate_limit")) { ... }
+}
+```
+
+All exception classes extend `Anthropic.APIError`, which has a `status` property. Use `instanceof` checks from most specific to least specific (e.g., check `RateLimitError` before `APIError`).

--- a/.claude/skills/claude-api/shared/live-sources.md
+++ b/.claude/skills/claude-api/shared/live-sources.md
@@ -1,0 +1,131 @@
+# Live Documentation Sources
+
+This file contains WebFetch URLs for fetching current information from platform.claude.com and Agent SDK repositories. Use these when users need the latest data that may have changed since the cached content was last updated.
+
+## When to Use WebFetch
+
+- User explicitly asks for "latest" or "current" information
+- Cached data seems incorrect
+- User asks about features not covered in cached content
+- User needs specific API details or examples
+
+## Claude API Documentation URLs
+
+### Models & Pricing
+
+| Topic           | URL                                                                   | Extraction Prompt                                                               |
+| --------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Models Overview | `https://platform.claude.com/docs/en/about-claude/models/overview.md` | "Extract current model IDs, context windows, and pricing for all Claude models" |
+| Pricing         | `https://platform.claude.com/docs/en/pricing.md`                      | "Extract current pricing per million tokens for input and output"               |
+
+### Core Features
+
+| Topic             | URL                                                                          | Extraction Prompt                                                                      |
+| ----------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Extended Thinking | `https://platform.claude.com/docs/en/build-with-claude/extended-thinking.md` | "Extract extended thinking parameters, budget_tokens requirements, and usage examples" |
+| Adaptive Thinking | `https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking.md` | "Extract adaptive thinking setup, effort levels, and Claude Opus 4.6 usage examples"         |
+| Effort Parameter  | `https://platform.claude.com/docs/en/build-with-claude/effort.md`            | "Extract effort levels, cost-quality tradeoffs, and interaction with thinking"        |
+| Tool Use          | `https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview.md`  | "Extract tool definition schema, tool_choice options, and handling tool results"       |
+| Streaming         | `https://platform.claude.com/docs/en/build-with-claude/streaming.md`         | "Extract streaming event types, SDK examples, and best practices"                      |
+| Prompt Caching    | `https://platform.claude.com/docs/en/build-with-claude/prompt-caching.md`    | "Extract cache_control usage, pricing benefits, and implementation examples"           |
+
+### Media & Files
+
+| Topic       | URL                                                                    | Extraction Prompt                                                 |
+| ----------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Vision      | `https://platform.claude.com/docs/en/build-with-claude/vision.md`      | "Extract supported image formats, size limits, and code examples" |
+| PDF Support | `https://platform.claude.com/docs/en/build-with-claude/pdf-support.md` | "Extract PDF handling capabilities, limits, and examples"         |
+
+### API Operations
+
+| Topic            | URL                                                                         | Extraction Prompt                                                                                       |
+| ---------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Batch Processing | `https://platform.claude.com/docs/en/build-with-claude/batch-processing.md` | "Extract batch API endpoints, request format, and polling for results"                                  |
+| Files API        | `https://platform.claude.com/docs/en/build-with-claude/files.md`            | "Extract file upload, download, and referencing in messages, including supported types and beta header" |
+| Token Counting   | `https://platform.claude.com/docs/en/build-with-claude/token-counting.md`   | "Extract token counting API usage and examples"                                                         |
+| Rate Limits      | `https://platform.claude.com/docs/en/api/rate-limits.md`                    | "Extract current rate limits by tier and model"                                                         |
+| Errors           | `https://platform.claude.com/docs/en/api/errors.md`                         | "Extract HTTP error codes, meanings, and retry guidance"                                                |
+
+### Tools
+
+| Topic          | URL                                                                                    | Extraction Prompt                                                                        |
+| -------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Code Execution | `https://platform.claude.com/docs/en/agents-and-tools/tool-use/code-execution-tool.md` | "Extract code execution tool setup, file upload, container reuse, and response handling" |
+| Computer Use   | `https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use.md`        | "Extract computer use tool setup, capabilities, and implementation examples"             |
+| Bash Tool      | `https://platform.claude.com/docs/en/agents-and-tools/tool-use/bash-tool.md`           | "Extract bash tool schema, reference implementation, and security considerations"        |
+| Text Editor    | `https://platform.claude.com/docs/en/agents-and-tools/tool-use/text-editor-tool.md`    | "Extract text editor tool commands, schema, and reference implementation"                |
+| Memory Tool    | `https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool.md`         | "Extract memory tool commands, directory structure, and implementation patterns"         |
+| Tool Search    | `https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool.md`    | "Extract tool search setup, when to use, and cache interaction"                          |
+| Programmatic Tool Calling | `https://platform.claude.com/docs/en/agents-and-tools/tool-use/programmatic-tool-calling.md` | "Extract PTC setup, script execution model, and tool invocation from code"    |
+| Skills         | `https://platform.claude.com/docs/en/agents-and-tools/skills.md`                       | "Extract skill folder structure, SKILL.md format, and loading behavior"                  |
+
+### Advanced Features
+
+| Topic              | URL                                                                           | Extraction Prompt                                   |
+| ------------------ | ----------------------------------------------------------------------------- | --------------------------------------------------- |
+| Structured Outputs | `https://platform.claude.com/docs/en/build-with-claude/structured-outputs.md` | "Extract output_config.format usage and schema enforcement"                           |
+| Compaction         | `https://platform.claude.com/docs/en/build-with-claude/compaction.md`         | "Extract compaction setup, trigger config, and streaming with compaction"             |
+| Context Editing    | `https://platform.claude.com/docs/en/build-with-claude/context-editing.md`    | "Extract context editing thresholds, what gets cleared, and configuration"            |
+| Citations          | `https://platform.claude.com/docs/en/build-with-claude/citations.md`          | "Extract citation format and implementation"        |
+| Context Windows    | `https://platform.claude.com/docs/en/build-with-claude/context-windows.md`    | "Extract context window sizes and token management" |
+
+### Managed Agents
+
+Use these when a managed-agents binding, behavior, or wire-level detail isn't covered in the cached `shared/managed-agents-*.md` concept files or in `{lang}/managed-agents/README.md`.
+
+| Topic                 | URL                                                                              | Extraction Prompt                                                                               |
+| --------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Overview              | `https://platform.claude.com/docs/en/managed-agents/overview.md`                 | "Extract the high-level architecture and how agents/sessions/environments/vaults fit together" |
+| Quickstart            | `https://platform.claude.com/docs/en/managed-agents/quickstart.md`               | "Extract the minimal end-to-end agent → environment → session → stream code path"              |
+| Agent Setup           | `https://platform.claude.com/docs/en/managed-agents/agent-setup.md`              | "Extract agent create/update/list-versions/archive lifecycle and parameters"                   |
+| Define Outcomes       | `https://platform.claude.com/docs/en/managed-agents/define-outcomes.md`          | "Extract outcome definitions, evaluation hooks, and success criteria configuration"             |
+| Sessions              | `https://platform.claude.com/docs/en/managed-agents/sessions.md`                 | "Extract session lifecycle, status transitions, idle/terminated semantics, and resume rules"    |
+| Environments          | `https://platform.claude.com/docs/en/managed-agents/environments.md`             | "Extract environment config (cloud/networking), management endpoints, and reuse model"          |
+| Events and Streaming  | `https://platform.claude.com/docs/en/managed-agents/events-and-streaming.md`     | "Extract event stream types, stream-first ordering, reconnect/dedupe, and steering patterns"    |
+| Tools                 | `https://platform.claude.com/docs/en/managed-agents/tools.md`                    | "Extract built-in toolset, custom tool definitions, and tool result wire format"                |
+| Files                 | `https://platform.claude.com/docs/en/managed-agents/files.md`                    | "Extract file upload, mount paths, session resources, and listing/downloading session outputs"  |
+| Permission Policies   | `https://platform.claude.com/docs/en/managed-agents/permission-policies.md`      | "Extract permission policy types (allow/deny/confirm) and per-tool config"                     |
+| Multi-Agent           | `https://platform.claude.com/docs/en/managed-agents/multi-agent.md`              | "Extract multi-agent composition patterns, sub-agent invocation, and result handoff"            |
+| Observability         | `https://platform.claude.com/docs/en/managed-agents/observability.md`            | "Extract logging, tracing, and usage telemetry exposed by managed agents"                       |
+| GitHub                | `https://platform.claude.com/docs/en/managed-agents/github.md`                   | "Extract github_repository resource shape, multi-repo mounting, and token rotation"             |
+| MCP Connector         | `https://platform.claude.com/docs/en/managed-agents/mcp-connector.md`            | "Extract MCP server declaration on agents and vault-based credential injection at session"     |
+| Vaults                | `https://platform.claude.com/docs/en/managed-agents/vaults.md`                   | "Extract vault create, credential add/rotate, OAuth refresh shape, and archive"                 |
+| Skills                | `https://platform.claude.com/docs/en/managed-agents/skills.md`                   | "Extract skill packaging and loading model for managed agents"                                  |
+| Memory                | `https://platform.claude.com/docs/en/managed-agents/memory.md`                   | "Extract memory resource shape, scoping, and lifecycle"                                         |
+| Onboarding            | `https://platform.claude.com/docs/en/managed-agents/onboarding.md`               | "Extract first-run setup, prerequisites, and account/region requirements"                      |
+| Cloud Containers      | `https://platform.claude.com/docs/en/managed-agents/cloud-containers.md`         | "Extract cloud container runtime, image config, and network/storage knobs"                     |
+| Migration             | `https://platform.claude.com/docs/en/managed-agents/migration.md`                | "Extract migration paths from earlier APIs/preview shapes to GA managed agents"                 |
+
+### Anthropic CLI
+
+The `ant` CLI provides terminal access to the Claude API. Every API resource is exposed as a subcommand. It is one convenient way to create agents, environments, sessions, and other resources from version-controlled YAML, and to inspect responses interactively.
+
+| Topic         | URL                                                     | Extraction Prompt                                                                                  |
+| ------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Anthropic CLI | `https://platform.claude.com/docs/en/api/sdks/cli.md`   | "Extract CLI install, authentication, command structure, and the beta:agents/environments/sessions commands" |
+
+---
+
+## Claude API SDK Repositories
+
+WebFetch these when a binding (class, method, namespace, field) isn't covered in the cached `{lang}/` skill files or in the managed-agents docs above. The SDKs include beta managed-agents support for `/v1/agents`, `/v1/sessions`, `/v1/environments`, and related resources — search the repo for `BetaManagedAgents`, `beta.agents`, `beta.sessions`, or the equivalent namespace for that language.
+
+| SDK        | URL                                                      | Extraction Prompt                                                                                                       |
+| ---------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Python     | `https://github.com/anthropics/anthropic-sdk-python`     | "Extract beta managed-agents namespaces, classes, and method signatures (`client.beta.agents`, `client.beta.sessions`)" |
+| TypeScript | `https://github.com/anthropics/anthropic-sdk-typescript` | "Extract beta managed-agents namespaces, classes, and method signatures (`client.beta.agents`, `client.beta.sessions`)" |
+| Java       | `https://github.com/anthropics/anthropic-sdk-java`       | "Extract beta managed-agents classes, builders, and method signatures (`client.beta().agents()`, `BetaManagedAgents*`)" |
+| Go         | `https://github.com/anthropics/anthropic-sdk-go`         | "Extract beta managed-agents types and method signatures (`client.Beta.Agents`, `BetaManagedAgents*` event types)"      |
+| Ruby       | `https://github.com/anthropics/anthropic-sdk-ruby`       | "Extract beta managed-agents methods and parameter shapes (`client.beta.agents`, `client.beta.sessions`)"               |
+| C#         | `https://github.com/anthropics/anthropic-sdk-csharp`     | "Extract beta managed-agents classes and method signatures (NuGet package, `BetaManagedAgents*` types)"                 |
+| PHP        | `https://github.com/anthropics/anthropic-sdk-php`        | "Extract beta managed-agents classes and method signatures (`$client->beta->agents`, `BetaManagedAgents*` params)"      |
+
+---
+
+## Fallback Strategy
+
+If WebFetch fails (network issues, URL changed):
+
+1. Use cached content from the language-specific files (note the cache date)
+2. Inform user the data may be outdated
+3. Suggest they check platform.claude.com or the GitHub repos directly

--- a/.claude/skills/claude-api/shared/managed-agents-api-reference.md
+++ b/.claude/skills/claude-api/shared/managed-agents-api-reference.md
@@ -1,0 +1,299 @@
+# Managed Agents — Endpoint Reference
+
+All endpoints require `x-api-key` and `anthropic-version: 2023-06-01` headers. Managed Agents endpoints additionally require the `anthropic-beta` header.
+
+## Beta Headers
+
+```
+anthropic-beta: managed-agents-2026-04-01
+```
+
+The SDK adds this header automatically for all `client.beta.{agents,environments,sessions,vaults}.*` calls. Skills endpoints use `skills-2025-10-02`; Files endpoints use `files-api-2025-04-14`.
+
+---
+
+## SDK Method Reference
+
+All resources are under the `beta` namespace. Python and TypeScript share identical method names.
+
+| Resource | Python / TypeScript (`client.beta.*`) | Go (`client.Beta.*`) |
+| --- | --- | --- |
+| Agents | `agents.create` / `retrieve` / `update` / `list` / `archive` | `Agents.New` / `Get` / `Update` / `List` / `Archive` |
+| Agent Versions | `agents.versions.list` | `Agents.Versions.List` |
+| Environments | `environments.create` / `retrieve` / `update` / `list` / `delete` / `archive` | `Environments.New` / `Get` / `Update` / `List` / `Delete` / `Archive` |
+| Sessions | `sessions.create` / `retrieve` / `update` / `list` / `delete` / `archive` | `Sessions.New` / `Get` / `Update` / `List` / `Delete` / `Archive` |
+| Session Events | `sessions.events.list` / `send` / `stream` | `Sessions.Events.List` / `Send` / `StreamEvents` |
+| Session Resources | `sessions.resources.add` / `retrieve` / `update` / `list` / `delete` | `Sessions.Resources.Add` / `Get` / `Update` / `List` / `Delete` |
+| Vaults | `vaults.create` / `retrieve` / `update` / `list` / `delete` / `archive` | `Vaults.New` / `Get` / `Update` / `List` / `Delete` / `Archive` |
+| Credentials | `vaults.credentials.create` / `retrieve` / `update` / `list` / `delete` / `archive` | `Vaults.Credentials.New` / `Get` / `Update` / `List` / `Delete` / `Archive` |
+
+**Naming quirks to watch for:**
+- Agents have **no delete** — only `archive`. Other resources have both.
+- Session resources use `add` (not `create`).
+- Go's event stream is `StreamEvents` (not `Stream`).
+
+**Agent shorthand:** `agent` on session create accepts either a bare string (`agent="agent_abc123"` — uses latest version) or the full reference object (`{type: "agent", id: "agent_abc123", version: 123}`).
+
+**Model shorthand:** `model` on agent create accepts either a bare string (`model="claude-opus-4-6"` — uses `standard` speed) or the full config object (`{type: "model_config", id: "claude-opus-4-6", speed: "fast"}`).
+
+---
+
+## Agents
+
+**Step one of every flow.** Sessions require a pre-created agent — there is no inline agent config under `managed-agents-2026-04-01`.
+
+| Method   | Path                                             | Operation        | Description                              |
+| -------- | ------------------------------------------------ | ---------------- | ---------------------------------------- |
+| `GET` | `/v1/agents` | ListAgents | List agents |
+| `POST` | `/v1/agents` | CreateAgent | Create a saved agent configuration |
+| `GET` | `/v1/agents/{agent_id}` | GetAgent | Get agent details |
+| `POST` | `/v1/agents/{agent_id}` | UpdateAgent | Update agent configuration |
+| `POST` | `/v1/agents/{agent_id}/archive` | ArchiveAgent | Archive an agent (no hard delete for agents) |
+| `GET` | `/v1/agents/{agent_id}/versions` | ListAgentVersions | List agent versions |
+
+## Sessions
+
+| Method   | Path                                             | Operation        | Description                              |
+| -------- | ------------------------------------------------ | ---------------- | ---------------------------------------- |
+| `GET` | `/v1/sessions` | ListSessions | List sessions (paginated) |
+| `POST` | `/v1/sessions` | CreateSession | Create a new session |
+| `GET` | `/v1/sessions/{session_id}` | GetSession | Get session details |
+| `POST` | `/v1/sessions/{session_id}` | UpdateSession | Update session metadata/title |
+| `DELETE` | `/v1/sessions/{session_id}` | DeleteSession | Delete a session |
+| `POST` | `/v1/sessions/{session_id}/archive` | ArchiveSession | Archive a session |
+
+## Events
+
+| Method   | Path                                             | Operation        | Description                              |
+| -------- | ------------------------------------------------ | ---------------- | ---------------------------------------- |
+| `GET` | `/v1/sessions/{session_id}/events` | ListEvents | List events (polling, paginated) |
+| `POST` | `/v1/sessions/{session_id}/events` | SendEvents | Send events (user message, tool result) |
+| `GET` | `/v1/sessions/{session_id}/events/stream` | StreamEvents | Stream events via SSE |
+
+## Session Resources
+
+| Method   | Path                                                    | Operation        | Description                              |
+| -------- | ------------------------------------------------------- | ---------------- | ---------------------------------------- |
+| `GET` | `/v1/sessions/{session_id}/resources` | ListResources | List resources attached to session |
+| `POST` | `/v1/sessions/{session_id}/resources` | AddResource | Attach file or github_repository mount (SDK method: `add`, not `create`) |
+| `GET` | `/v1/sessions/{session_id}/resources/{resource_id}` | GetResource | Get a single resource |
+| `POST` | `/v1/sessions/{session_id}/resources/{resource_id}` | UpdateResource | Update resource |
+| `DELETE` | `/v1/sessions/{session_id}/resources/{resource_id}` | DeleteResource | Remove resource from session |
+
+## Environments
+
+| Method   | Path                                                             | Operation            | Description                         |
+| -------- | ---------------------------------------------------------------- | -------------------- | ----------------------------------- |
+| `POST`   | `/v1/environments`                                     | CreateEnvironment    | Create environment                  |
+| `GET`    | `/v1/environments`                                     | ListEnvironments     | List environments                   |
+| `GET`    | `/v1/environments/{environment_id}`                    | GetEnvironment       | Get environment details             |
+| `POST`   | `/v1/environments/{environment_id}`                    | UpdateEnvironment    | Update environment                  |
+| `DELETE` | `/v1/environments/{environment_id}`                    | DeleteEnvironment    | Delete environment. Returns 204. |
+| `POST`   | `/v1/environments/{environment_id}/archive`            | ArchiveEnvironment   | Archive environment (read-only; existing sessions continue) |
+
+## Vaults
+
+Vaults store MCP credentials that Anthropic manages on your behalf — OAuth credentials with auto-refresh, or static bearer tokens. Attach to sessions via `vault_ids`. See `managed-agents-tools.md` §Vaults for the conceptual guide and credential shapes.
+
+| Method   | Path                                             | Operation        | Description                              |
+| -------- | ------------------------------------------------ | ---------------- | ---------------------------------------- |
+| `POST`   | `/v1/vaults`                                     | CreateVault      | Create a vault                           |
+| `GET`    | `/v1/vaults`                                     | ListVaults       | List vaults                              |
+| `GET`    | `/v1/vaults/{vault_id}`                          | GetVault         | Get vault details                        |
+| `POST`   | `/v1/vaults/{vault_id}`                          | UpdateVault      | Update vault                             |
+| `DELETE` | `/v1/vaults/{vault_id}`                          | DeleteVault      | Delete vault                             |
+| `POST`   | `/v1/vaults/{vault_id}/archive`                  | ArchiveVault     | Archive vault                            |
+
+## Credentials
+
+Credentials are individual secrets stored inside a vault.
+
+| Method   | Path                                                              | Operation          | Description                  |
+| -------- | ----------------------------------------------------------------- | ------------------ | ---------------------------- |
+| `POST`   | `/v1/vaults/{vault_id}/credentials`                               | CreateCredential   | Create a credential          |
+| `GET`    | `/v1/vaults/{vault_id}/credentials`                               | ListCredentials    | List credentials in vault    |
+| `GET`    | `/v1/vaults/{vault_id}/credentials/{credential_id}`               | GetCredential      | Get credential metadata      |
+| `POST`   | `/v1/vaults/{vault_id}/credentials/{credential_id}`               | UpdateCredential   | Update credential            |
+| `DELETE` | `/v1/vaults/{vault_id}/credentials/{credential_id}`               | DeleteCredential   | Delete credential            |
+| `POST`   | `/v1/vaults/{vault_id}/credentials/{credential_id}/archive`       | ArchiveCredential  | Archive credential           |
+
+## Files
+
+| Method   | Path                                             | Operation        | Description                              |
+| -------- | ------------------------------------------------ | ---------------- | ---------------------------------------- |
+| `POST`   | `/v1/files`                            | UploadFile       | Upload a file                            |
+| `GET`    | `/v1/files`                            | ListFiles        | List files                               |
+| `GET`    | `/v1/files/{file_id}`                  | GetFile          | Get file metadata (SDK method: `retrieve_metadata`) |
+| `GET`    | `/v1/files/{file_id}/content`          | DownloadFile     | Download file content                    |
+| `DELETE` | `/v1/files/{file_id}`                  | DeleteFile       | Delete a file                            |
+
+## Skills
+
+| Method   | Path                                                            | Operation          | Description                  |
+| -------- | --------------------------------------------------------------- | ------------------ | ---------------------------- |
+| `POST`   | `/v1/skills`                                          | CreateSkill        | Create a skill               |
+| `GET`    | `/v1/skills`                                          | ListSkills         | List skills                  |
+| `GET`    | `/v1/skills/{skill_id}`                               | GetSkill           | Get skill details            |
+| `DELETE` | `/v1/skills/{skill_id}`                               | DeleteSkill        | Delete a skill               |
+| `POST`   | `/v1/skills/{skill_id}/versions`                      | CreateVersion      | Create skill version         |
+| `GET`    | `/v1/skills/{skill_id}/versions`                      | ListVersions       | List skill versions          |
+| `GET`    | `/v1/skills/{skill_id}/versions/{version}`            | GetVersion         | Get skill version            |
+| `DELETE` | `/v1/skills/{skill_id}/versions/{version}`            | DeleteVersion      | Delete skill version         |
+
+---
+
+## Request/Response Schema Quick Reference
+
+### CreateAgent Request Body
+
+**Always start here.** `model`, `system`, `tools`, `mcp_servers`, `skills` are top-level fields on this object — they do NOT go on the session.
+
+```json
+{
+  "name": "string (required, 1-256 chars)",
+  "model": "claude-opus-4-6 (required — bare string, or {id, speed} object)",
+  "description": "string (optional, up to 2048 chars)",
+  "system": "string (optional, up to 100,000 chars)",
+  "tools": [
+    { "type": "agent_toolset_20260401" }
+  ],
+  "skills": [
+    { "type": "anthropic", "skill_id": "xlsx" },
+    { "type": "custom", "skill_id": "skill_abc123", "version": "1" }
+  ],
+  "mcp_servers": [
+    {
+      "type": "url",
+      "name": "github",
+      "url": "https://api.githubcopilot.com/mcp/"
+    }
+  ],
+  "metadata": {
+    "key": "value (max 16 pairs, keys ≤64 chars, values ≤512 chars)"
+  }
+}
+```
+
+> Limits: `tools` max 50, `skills` max 64, `mcp_servers` max 20 (unique names).
+
+### CreateSession Request Body
+
+```json
+{
+  "agent": "agent_abc123 (required — string shorthand for latest version, or {type: \"agent\", id, version} object)",
+  "environment_id": "env_abc123 (required)",
+  "title": "string (optional)",
+  "resources": [
+    {
+      "type": "github_repository",
+      "url": "https://github.com/owner/repo (required)",
+      "authorization_token": "ghp_... (required)",
+      "mount_path": "/workspace/repo (optional — defaults to /workspace/<repo-name>)",
+      "checkout": { "type": "branch", "name": "main" }
+    }
+  ],
+  "vault_ids": ["vlt_abc123 (optional — MCP credentials with auto-refresh)"],
+  "metadata": {
+    "key": "value"
+  }
+}
+```
+
+> The `agent` field accepts only a string ID or `{type: "agent", id, version}` — `model`/`system`/`tools` live on the agent, not here.
+>
+> **`checkout`** accepts `{type: "branch", name: "..."}` or `{type: "commit", sha: "..."}`. Omit for the repo's default branch.
+
+### CreateEnvironment Request Body
+
+```json
+{
+  "name": "string (required)",
+  "description": "string (optional)",
+  "config": {
+    "type": "cloud",
+    "networking": {
+      "type": "unrestricted | limited (union — see SDK types)"
+    },
+    "packages": { }
+  },
+  "metadata": { "key": "value" }
+}
+```
+
+### SendEvents Request Body
+
+```json
+{
+  "events": [
+    {
+      "type": "user.message",
+      "content": [
+        {
+          "type": "text",
+          "text": "Hello"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Tool Result Event
+
+```json
+{
+  "type": "user.custom_tool_result",
+  "custom_tool_use_id": "sevt_abc123",
+  "content": [{ "type": "text", "text": "Result data" }],
+  "is_error": false
+}
+```
+
+---
+
+## Error Handling
+
+Managed Agents endpoints use the standard Anthropic API error format. Errors are returned with an HTTP status code and a JSON body containing `type`, `error`, and `request_id`:
+
+```json
+{
+  "type": "error",
+  "error": {
+    "type": "invalid_request_error",
+    "message": "Description of what went wrong"
+  },
+  "request_id": "req_011CRv1W3XQ8XpFikNYG7RnE"
+}
+```
+
+Include the `request_id` when reporting issues to Anthropic — it lets us trace the request end-to-end. The inner `error.type` is one of the following:
+
+| Status | Error type | Description |
+|---|---|---|
+| 400 | `invalid_request_error` | The request was malformed or missing required parameters |
+| 401 | `authentication_error` | Invalid or missing API key |
+| 403 | `permission_error` | The API key doesn't have permission for this operation |
+| 404 | `not_found_error` | The requested resource doesn't exist |
+| 409 | `invalid_request_error` | The request conflicts with the resource's current state (e.g., sending to an archived session) |
+| 413 | `request_too_large` | The request body exceeds the maximum allowed size |
+| 429 | `rate_limit_error` | Too many requests — check rate limit headers for retry timing |
+| 500 | `api_error` | An internal server error occurred |
+| 529 | `overloaded_error` | The service is temporarily overloaded — retry with backoff |
+
+Note that `409 Conflict` carries `error.type: "invalid_request_error"` (there is no separate `conflict_error` type); inspect both the HTTP status and the `message` to distinguish conflicts from other invalid requests.
+
+---
+
+## Rate Limits
+
+Managed Agents endpoints have per-organization request-per-minute (RPM) limits, separate from your [Messages API token limits](https://platform.claude.com/docs/en/api/rate-limits). Model inference inside a session still draws from your organization's standard ITPM/OTPM limits.
+
+| Endpoint group | Scope | RPM | Max concurrent |
+|---|---|---|---|
+| Create operations (Agents, Sessions, Vaults) | organization | 60 | — |
+| All other operations (Agents, Sessions, Vaults) | organization | 600 | — |
+| All operations (Environments) | organization | 60 | 5 |
+
+Files and Skills endpoints use the standard tier-based [rate limits](https://platform.claude.com/docs/en/api/rate-limits).
+
+When a limit is exceeded the API returns `429` with a `rate_limit_error` (see [Error Handling](#error-handling) for the response envelope) and a `retry-after` header indicating how many seconds to wait before retrying. The Anthropic SDK reads this header and retries automatically.

--- a/.claude/skills/claude-api/shared/managed-agents-client-patterns.md
+++ b/.claude/skills/claude-api/shared/managed-agents-client-patterns.md
@@ -1,0 +1,205 @@
+# Managed Agents — Common Client Patterns
+
+Patterns you'll write on the client side when driving a Managed Agent session, grounded in working SDK examples.
+
+Code samples are TypeScript — Python and cURL follow the same shape; see `python/managed-agents/README.md` and `curl/managed-agents.md` for equivalents.
+
+---
+
+## 1. Lossless stream reconnect
+
+**Problem:** SSE has no replay. If the connection drops mid-session, a naive reconnect re-opens the stream from "now" and you silently miss every event emitted in between.
+
+**Solution:** on reconnect, fetch the full event history via `events.list()` *before* consuming the live stream, and dedupe on event ID as the live stream catches up.
+
+```ts
+const seenEventIds = new Set<string>()
+const stream = await client.beta.sessions.events.stream(session.id)
+
+// Stream is now open and buffering server-side. Read history first.
+for await (const event of client.beta.sessions.events.list(session.id)) {
+  seenEventIds.add(event.id)
+  handle(event)
+}
+
+// Tail the live stream. Dedupe only gates handle() — terminal checks must run
+// even for already-seen events, or a terminal event that was in the history
+// response gets skipped by `continue` and the loop never exits.
+for await (const event of stream) {
+  if (!seenEventIds.has(event.id)) {
+    seenEventIds.add(event.id)
+    handle(event)
+  }
+  if (event.type === 'session.status_terminated') break
+  if (event.type === 'session.status_idle' && event.stop_reason.type !== 'requires_action') break
+}
+```
+
+---
+
+## 2. `processed_at` — queued vs processed
+
+Every event on the stream carries `processed_at` (ISO 8601). For client-sent events (`user.message`, `user.interrupt`, `user.tool_confirmation`, `user.custom_tool_result`) it's `null` when the event has been queued but not yet picked up by the agent, and populated once the agent processes it. The same event appears on the stream twice — once with `processed_at: null`, once with a timestamp.
+
+```ts
+for await (const event of stream) {
+  if (event.type === 'user.message') {
+    if (event.processed_at == null) onQueued(event.id)
+    else onProcessed(event.id, event.processed_at)
+  }
+}
+```
+
+Use this to drive pending → acknowledged UI state for anything you send. How you map a locally-rendered optimistic message to the server-assigned `event.id` is application-specific (typically via the return value of `events.send()` or FIFO ordering).
+
+---
+
+## 3. Interrupt a running session
+
+Send `user.interrupt` as a normal event. The session keeps running until it reaches a safe boundary, then goes idle.
+
+```ts
+await client.beta.sessions.events.send(session.id, {
+  events: [{ type: 'user.interrupt' }],
+})
+
+// Drain until the session is truly done — see Pattern 5 for the full gate.
+for await (const event of stream) {
+  if (event.type === 'session.status_terminated') break
+  if (
+    event.type === 'session.status_idle' &&
+    event.stop_reason.type !== 'requires_action'
+  ) break
+}
+```
+
+Reference: `interrupt.ts` — sends the interrupt the moment it sees `span.model_request_start`, drains to idle, then verifies via `sessions.retrieve()`.
+
+---
+
+## 4. `tool_confirmation` round-trip
+
+When the agent has `permission_policy: { type: 'always_ask' }`, any call to that tool fires an `agent.tool_use` event with `evaluated_permission === 'ask'` and the session goes idle waiting for a decision. Respond with `user.tool_confirmation`.
+
+```ts
+for await (const event of stream) {
+  if (event.type === 'agent.tool_use' && event.evaluated_permission === 'ask') {
+    await client.beta.sessions.events.send(session.id, {
+      events: [{
+        type: 'user.tool_confirmation',
+        tool_use_id: event.id,         // not a toolu_ id — use event.id
+        result: 'allow',               // or 'deny'
+        // deny_message: '...',        // optional, only with result: 'deny'
+      }],
+    })
+  }
+}
+```
+
+Key points:
+- `tool_use_id` is `event.id` (typically `sevt_...`), **not** a `toolu_...` ID.
+- `result` is `'allow' | 'deny'`. Use `deny_message` to tell the model *why* you denied — it gets surfaced back to the agent.
+- Multiple pending tools: respond once per `agent.tool_use` event with `evaluated_permission === 'ask'`.
+
+Reference: `tool-permissions.ts`.
+
+---
+
+## 5. Correct idle-break gate
+
+Do not break on `session.status_idle` alone. The session goes idle transiently — e.g. between parallel tool executions, while waiting for a `user.tool_confirmation`, or while awaiting a `user.custom_tool_result`. Break when idle with a terminal `stop_reason`, or on `session.status_terminated`.
+
+```ts
+for await (const event of stream) {
+  handle(event)
+  if (event.type === 'session.status_terminated') break
+  if (event.type === 'session.status_idle') {
+    if (event.stop_reason.type === 'requires_action') continue // waiting on you — handle it
+    break // end_turn or retries_exhausted — both terminal
+  }
+}
+```
+
+`stop_reason.type` values on `session.status_idle`:
+- `requires_action` — agent is waiting on a client-side event (tool confirmation, custom tool result). Handle it, don't break.
+- `retries_exhausted` — terminal failure. Break, then check `sessions.retrieve()` for the error state.
+- `end_turn` — normal completion.
+
+---
+
+## 6. Post-idle status-write race
+
+The SSE stream emits `session.status_idle` slightly before the session's queryable status reflects it. Clients that break on idle and immediately call `sessions.delete()` or `sessions.archive()` will intermittently 400 with "cannot delete/archive while running."
+
+Poll before cleanup:
+
+```ts
+let s
+for (let i = 0; i < 10; i++) {
+  s = await client.beta.sessions.retrieve(session.id)
+  if (s.status !== 'running') break
+  await new Promise(r => setTimeout(r, 200))
+}
+if (s?.status !== 'running') {
+  await client.beta.sessions.archive(session.id)
+} // else: still running after 2s — don't archive, let it settle or escalate
+```
+
+---
+
+## 7. Stream-first, then send
+
+Always open the stream **before** sending the kickoff event. Otherwise the agent may process the event and emit the first events before your consumer is attached, and you'll miss them.
+
+```ts
+const stream = await client.beta.sessions.events.stream(session.id)
+await client.beta.sessions.events.send(session.id, {
+  events: [{ type: 'user.message', content: [{ type: 'text', text: 'Hello' }] }],
+})
+for await (const event of stream) { /* ... */ }
+```
+
+The `Promise.all([stream, send])` shape works too, but stream-first is simpler and has the same effect — the stream starts buffering the moment it's opened.
+
+---
+
+## 8. File-mount gotchas
+
+**The mounted resource has a different `file_id` than the file you uploaded.** Session creation makes a session-scoped copy.
+
+```ts
+const uploaded = await client.beta.files.upload({ file, purpose: 'agent_resource' })
+// uploaded.id         → the original file
+const session = await client.beta.sessions.create({
+  /* ... */
+  resources: [{ type: 'file', file_id: uploaded.id, mount_path: '/workspace/data.csv' }],
+})
+// session.resources[0].file_id !== uploaded.id  ← different IDs
+```
+
+Delete the original via `files.delete(uploaded.id)`; the session-scoped copy is garbage-collected with the session. `mount_path` must be absolute — see `shared/managed-agents-environments.md`.
+
+---
+
+## 9. Keep credentials host-side via custom tools
+
+**Problem:** putting a third-party API key in the agent's vault or environment means the sandbox holds the secret. For keys tied to a human (Linear personal keys, `gh` CLI auth) or keys you'd rather not ship into a container, that's undesirable.
+
+**Solution:** expose the operation as a custom tool. The agent emits `agent.custom_tool_use`; your orchestrator executes the call with its own credentials and responds with `user.custom_tool_result`. The container never sees the key.
+
+```ts
+// Agent template: declare the tool, no credentials
+tools: [{ type: 'custom', name: 'linear_graphql', input_schema: { /* query, vars */ } }]
+
+// Orchestrator: handle the call with host-side creds
+for await (const event of stream) {
+  if (event.type === 'agent.custom_tool_use' && event.name === 'linear_graphql') {
+    const result = await linear.request(event.input.query, event.input.vars) // host's key
+    await client.beta.sessions.events.send(session.id, {
+      events: [{ type: 'user.custom_tool_result', tool_use_id: event.id, result }],
+    })
+  }
+}
+```
+
+Same shape works for `gh` CLI, local eval scripts, or anything else that needs host-only auth or binaries.

--- a/.claude/skills/claude-api/shared/managed-agents-core.md
+++ b/.claude/skills/claude-api/shared/managed-agents-core.md
@@ -1,0 +1,216 @@
+# Managed Agents — Core Concepts
+
+## Architecture
+
+Managed Agents is built around four core concepts:
+
+| Concept | Endpoint | What it is |
+|---|---|---|
+| **Agent** | `/v1/agents` | A persisted, versioned object defining the agent's capabilities and persona: model, system prompt, tools, MCP servers, skills. **Must be created before starting a session.** See the Agents section below. |
+| **Session** | `/v1/sessions` | A stateful interaction with an agent. References a pre-created agent by ID + an environment + initial instructions. Produces an event stream. |
+| **Environment** | `/v1/environments` | A template defining the configuration for container provisioning. |
+| **Container** | N/A | An isolated compute instance where the agent's **tools** execute (bash, file ops, code). The agent loop does not run here — it runs on Anthropic's orchestration layer and acts on the container via tool calls. |
+
+```
+                       ┌─────────────────────────────────────┐
+                       │  Anthropic orchestration layer      │
+Agent (config) ───────▶│  (agent loop: Claude + tool calls)  │
+                       └──────────────┬──────────────────────┘
+                                      │ tool calls
+                                      ▼
+Environment (template) ──▶ Container (tool execution workspace)
+                                 │
+                         Session ─┤
+                                 ├── Resources (files, repos — mounted at startup)
+                                 ├── Vault IDs (MCP credential references)
+                                 └── Conversation (event stream in/out)
+```
+
+> **Agent creation is a prerequisite.** Sessions reference a pre-created agent by ID — `model`/`system`/`tools` live on the agent object, never on the session. Every flow starts with `POST /v1/agents`.
+
+---
+
+## Session Lifecycle
+
+```
+rescheduling → running ↔ idle → terminated
+```
+
+| Status         | Description                                                        |
+| -------------- | ------------------------------------------------------------------ |
+| `idle` | Agent has finished the current task, and is awaiting input. It's either waiting for input to continue working via a `user.message` or blocked awaiting a `user.custom_tool_result` or `user.tool_confirmation`. The `stop_reason` attached contains more information about why the Agent has stopped working. |
+| `running` | Session has starting running, and the Agent is actively doing work. |
+| `rescheduling` | Session is (re)scheduling after a retryable error has occurred, ready to be picked up by the orchestration system. |
+| `terminated` | Session has terminated, entering an irreversible and unusable state.  |
+
+- Events can be sent when the session is `running` or `idle`. Messages are queued and processed in order.
+- The agent transitions `idle → running` when it receives a new event, then back to `idle` when done.
+- Errors surface as `session.error` events in the stream, not as a status value.
+
+### Built-in session features
+
+- **Context compaction** — if you approach max context, the API automatically condenses session history to keep the interaction going
+- **Prompt caching** — historical repeated tokens are cached, reducing processing time and cost
+- **Extended thinking** — on by default, returned as `agent.thinking` events
+
+### Session operations
+
+| Operation | Notes |
+|---|---|
+| List / fetch | Paginated list or single resource by ID |
+| Update | Only `title` is updatable |
+| Archive | Session becomes **read-only**. Not reversible. |
+| Delete | Permanently deletes session, event history, container, and checkpoints. |
+
+---
+
+## Sessions
+
+A session is a running agent instance inside an environment.
+
+### Session Object
+
+Key fields returned by the API:
+
+| Field           | Type     | Description                                         |
+| --------------- | -------- | --------------------------------------------------- |
+| `type` | string | Always `"session"` |
+| `id` | string | Unique session ID |
+| `title` | string | Human-readable title |
+| `status` | string | `idle`, `running`, `rescheduling`, `terminated` |
+| `created_at` | string | ISO 8601 timestamp |
+| `updated_at` | string | ISO 8601 timestamp |
+| `archived_at` | string | ISO 8601 timestamp (nullable) |
+| `environment_id` | string | Environment ID |
+| `agent` | object | Agent configuration |
+| `resources` | array | Attached files and repos |
+| `metadata` | object | User-provided key-value pairs (max 8 keys) |
+| `usage` | object | Token usage statistics |
+
+### Creating a session
+
+**A session is meaningless without an agent.** Sessions reference a pre-created agent by ID. Create the agent first via `agents.create()`, then reference it:
+
+```ts
+// 1. Create the agent (reusable, versioned)
+const agent = await client.beta.agents.create(
+  {
+    name: "Coding Assistant",
+    model: "claude-opus-4-6",
+    system: "You are a helpful coding agent.",
+    tools: [{ type: "agent_toolset_20260401"}],
+  },
+);
+
+// 2. Start a session that references it
+const session = await client.beta.sessions.create(
+  {
+    agent: agent.id,  // string shorthand → latest version. Or: { type: "agent", id: agent.id, version: agent.version }
+    environment_id: environmentId,
+    title: "Hello World Session",
+  },
+);
+```
+
+**Session creation parameters:**
+
+| Field           | Type     | Required | Description                                    |
+| --------------- | -------- | -------- | ---------------------------------------------- |
+| `agent`         | string or object | **Yes** | String shorthand `"agent_abc123"` (latest version) or `{type: "agent", id, version}` |
+| `environment_id`| string   | **Yes**  | Environment ID                                 |
+| `title`         | string   | No       | Human-readable name (appears in logs/dashboards) |
+| `resources`     | array    | No       | Files or GitHub repos, mounted to the container at startup |
+| `vault_ids`     | array    | No       | Vault IDs (`vlt_*`) — MCP credentials with auto-refresh. See `shared/managed-agents-tools.md` → Vaults. |
+| `metadata`      | object   | No       | User-provided key-value pairs                  |
+
+**Agent configuration fields** (passed to `agents.create()`, not `sessions.create()`):
+
+| Field         | Type     | Required | Description                                    |
+| ------------- | -------- | -------- | ---------------------------------------------- |
+| `name`        | string   | **Yes**  | Human-readable name (1-256 chars)              |
+| `model`       | string or object | **Yes** | Claude model ID (bare string, or `{id, speed}` object). All Claude 4.5+ models supported. |
+| `system`      | string   | No       | System prompt — defines the agent's behavior (up to 100K chars) |
+| `tools`       | array    | No       | Encompasses three kinds: (1) pre-built Claude Agent tools (`agent_toolset_20260401`), (2) MCP tools (`mcp_toolset`), and (3) custom client-side tools. Max 128. |
+| `mcp_servers` | array    | No       | MCP server connections — standardized third-party capabilities (e.g. GitHub, Asana). Max 20, unique names. See `shared/managed-agents-tools.md` → MCP Servers. |
+| `skills`      | array    | No       | Customized "best-practices" context with progressive disclosure. Max 64. See `shared/managed-agents-tools.md` → Skills. |
+| `description` | string   | No       | Description of the agent (up to 2048 chars)    |
+| `metadata`    | object   | No       | Arbitrary key-value pairs (max 16, keys ≤64 chars, values ≤512 chars) |
+
+---
+
+## Agents
+
+**This is where every Managed Agents flow begins.** The agent object is a persisted, versioned configuration — you create it once, then reference it by ID every time you start a session. No agent → no session.
+
+### Agent Object
+
+The API is **flat** — `model`, `system`, `tools` etc. are top-level fields, not wrapped in an `agent:{}` sub-object.
+
+| Field              | Type     | Required | Description                                        |
+| ------------------ | -------- | -------- | -------------------------------------------------- |
+| `name`             | string   | Yes      | Human-readable name                                |
+| `model`            | string   | Yes      | Claude model ID                                    |
+| `system`           | string   | No       | System prompt                                      |
+| `tools`            | array    | No       | Agent toolset / MCP toolset / custom tools         |
+| `mcp_servers`      | array    | No       | MCP server connections                             |
+| `skills`           | array    | No       | Skill references (max 64)                          |
+| `description`      | string   | No       | Description of the agent                           |
+| `metadata`         | object   | No       | Arbitrary key-value pairs                          |
+
+### Lifecycle: create once, run many, update in place
+
+The agent is a **persistent resource**, not a per-run parameter. The intended pattern:
+
+```
+┌─ setup (once) ─────────┐     ┌─ runtime (every invocation) ─┐
+│ agents.create()        │     │ sessions.create(             │
+│   → store agent_id     │ ──→ │   agent={type:..., id: ID}   │
+│     in config/env/db   │     │ )                            │
+└────────────────────────┘     └──────────────────────────────┘
+```
+
+**Anti-pattern:** calling `agents.create()` at the top of every script run. This accumulates orphaned agent objects, pays create latency on every invocation, and defeats the versioning model. If you see `agents.create()` in a function that's called per-request or per-cron-tick, that's wrong — hoist it to one-time setup and persist the ID.
+
+### Versioning
+
+Each `POST /v1/agents/{id}` (update) creates a new immutable version (numeric timestamp, e.g. `1772585501101368014`). The agent's history is append-only — you can't edit a past version.
+
+**Why version:**
+- **Reproducibility** — pin a session to a known-good config: `{type: "agent", id, version: 3}`
+- **Safe iteration** — update the agent without breaking sessions already running on the old version
+- **Rollback** — if a new system prompt regresses, pin new sessions back to the prior version while you debug
+
+**`version` is optional.** Omit it (or use the string shorthand `agent="agent_abc123"`) to get the latest version at session-creation time. Pass it explicitly (`{type: "agent", id, version: N}`) to pin for reproducibility.
+
+**Getting the version to pin:** `agents.create()` and `agents.update()` both return `version` in the response. Store it alongside `agent_id`. To fetch the current latest for an existing agent: `GET /v1/agents/{id}` → `.version`.
+
+**When to update vs create new:** Update (`POST /v1/agents/{id}`) when it's conceptually the same agent with tweaked behavior (better prompt, extra tool). Create a new agent when it's a different persona/purpose. Rule of thumb: if you'd give it the same `name`, update.
+
+### Agent Endpoints
+
+| Operation        | Method   | Path                                  |
+| ---------------- | -------- | ------------------------------------- |
+| Create           | `POST`   | `/v1/agents`                          |
+| List             | `GET`    | `/v1/agents`                          |
+| Get              | `GET`    | `/v1/agents/{id}`                     |
+| Update           | `POST`   | `/v1/agents/{id}`                     |
+| Archive          | `POST`   | `/v1/agents/{id}/archive`             |
+
+### Using an Agent in a Session
+
+Reference the agent by string ID (latest version) or by object with an explicit version:
+
+```python
+# String shorthand — uses the agent's latest version
+session = client.beta.sessions.create(
+    agent=agent.id,
+    environment_id=environment_id,
+)
+
+# Or pin to a specific version (int)
+session = client.beta.sessions.create(
+    agent={"type": "agent", "id": agent.id, "version": agent.version},
+    environment_id=environment_id,
+)
+```
+

--- a/.claude/skills/claude-api/shared/managed-agents-environments.md
+++ b/.claude/skills/claude-api/shared/managed-agents-environments.md
@@ -1,0 +1,202 @@
+# Managed Agents — Environments & Resources
+
+## Environments
+
+Creating a session requires an `environment_id`. Environments are **reusable configuration templates** for spinning up containers in Anthropic's infrastructure — you might create different environments for different use cases (e.g. data visualization vs web development, with different package sets). Anthropic handles scaling, container lifecycle, and work orchestration.
+
+**Environment names must be unique.** Creating an environment with an existing name returns 409.
+
+### Networking
+
+| Network Policy                  | Description                                                   |
+| ------------------------------- | ------------------------------------------------------------- |
+| `unrestricted`                  | Full egress (except legal blocklist)                          |
+| `package_managers_and_custom`   | Package managers + custom `allowed_hosts`                      |
+
+```json
+{
+  "networking": {
+    "type": "package_managers_and_custom",
+    "allowed_hosts": ["api.example.com"]
+  }
+}
+```
+
+**MCP caveat:** If using restricted networking, make sure `allowed_hosts` includes your MCP server domains. Otherwise the container can't reach them and tools silently fail.
+
+### Creating an environment
+
+The SDK adds `managed-agents-2026-04-01` automatically. TypeScript:
+
+```ts
+const env = await client.beta.environments.create({
+  name: "my_env",
+  config: {
+    type: "cloud",
+    networking: { type: "unrestricted" },
+  },
+});
+```
+
+### Environment CRUD
+
+| Operation        | Method   | Path                                       | Notes |
+| ---------------- | -------- | ------------------------------------------ | ----- |
+| Create           | `POST`   | `/v1/environments`                         | |
+| List             | `GET`    | `/v1/environments`                         | Paginated (`limit`, `after_id`, `before_id`) |
+| Get              | `GET`    | `/v1/environments/{id}`                    | |
+| Update           | `POST`   | `/v1/environments/{id}`                    | Changes apply only to **new** containers; existing sessions keep their original config |
+| Delete           | `DELETE` | `/v1/environments/{id}`                    | Returns 204. |
+| Archive          | `POST`   | `/v1/environments/{id}/archive`            | Read-only. New sessions can't be created; existing ones continue. |
+
+---
+
+## Resources
+
+Attach files and GitHub repositories to a session. **Session creation blocks until all resources are mounted** — the container won't go `running` until every file and repo is in place. Max **999 file resources** per session. Multiple GitHub repositories per session are supported.
+
+### File Uploads (input — host → agent)
+
+Upload a file first via the Files API, then reference by `file_id` + `mount_path`:
+
+```ts
+// 1. Upload
+const file = await client.beta.files.upload({
+  file: fs.createReadStream("data.csv"),
+  purpose: "agent",
+});
+
+// 2. Attach as a session resource
+const session = await client.beta.sessions.create({
+  agent: agent.id,
+  environment_id: envId,
+  resources: [
+    { type: "file", file_id: file.id, mount_path: "/workspace/data.csv" }
+  ],
+});
+```
+
+**`mount_path` is required** and must be absolute. Parent directories are created automatically. Agent working directory defaults to `/workspace`. Files are mounted read-only — the agent writes modified versions to new paths.
+
+### Session outputs (output — agent → host)
+
+The agent can write files to `/mnt/session/outputs/` during a session. These are automatically captured by the Files API and can be listed and downloaded afterwards:
+
+```ts
+// After the turn completes, list output files scoped to this session:
+for await (const f of client.beta.files.list({ scope: session.id })) {
+  console.log(f.filename, f.size_bytes);
+  const resp = await client.beta.files.download(f.id);
+  const text = await resp.text();
+}
+```
+
+**Requirements:**
+- The `write` tool (or `bash`) must be enabled for the agent to create output files.
+- Session-scoped `files.list` / `files.download` captures outputs written to `/mnt/session/outputs/`.
+- `session_id` is a query filter on `files.list` (not yet in SDK types — cast or spread through).
+- There's a brief indexing lag (~1–3s) between `session.status_idle` and output files appearing in `files.list`. Retry once or twice if empty.
+
+This gives you a bidirectional file bridge: upload reference data in, download agent artifacts out.
+
+### GitHub Repositories
+
+Clones a GitHub repository into the session container during initialization, before the agent begins execution. The agent can read, edit, commit, and push via `bash` (`git`). Multiple repositories per session are supported — add one `resources` entry per repo.
+
+**Fields:**
+
+| Field | Required | Notes |
+|---|---|---|
+| `type` | ✅ | `"github_repository"` |
+| `url` | ✅ | The GitHub repository URL |
+| `authorization_token` | ✅ | GitHub Personal Access Token with repository access. **Never echoed in API responses.** |
+| `mount_path` | ❌ | Path where the repository will be cloned. Defaults to `/workspace/<repo-name>`. |
+| `checkout` | ❌ | `{type: "branch", name: "..."}` or `{type: "commit", sha: "..."}`. Defaults to the repo's default branch. |
+
+**Token permission levels** (fine-grained PATs):
+- `Contents: Read` — clone only
+- `Contents: Read and write` — push changes and create pull requests
+
+> ‼️ **To generate pull requests** you also need GitHub **MCP server** access — the `github_repository` resource gives filesystem access only. See `shared/managed-agents-tools.md` → MCP Servers. The PR workflow is: edit files in the mounted repo → push branch via `bash` → create PR via MCP `create_pull_request` tool.
+
+**TypeScript:**
+
+```ts
+// 1. Create the agent — declare GitHub MCP (no auth here)
+const agent = await client.beta.agents.create(
+  {
+    name: 'GitHub Agent',
+    model: 'claude-opus-4-6',
+    mcp_servers: [
+      { type: 'url', name: 'github', url: 'https://api.githubcopilot.com/mcp/' },
+    ],
+    tools: [
+      { type: 'agent_toolset_20260401', default_config: { enabled: true } },
+      { type: 'mcp_toolset', mcp_server_name: 'github' },
+    ],
+  },
+);
+
+// 2. Start a session — attach vault for MCP auth + mount the repo
+const session = await client.beta.sessions.create({
+  agent: agent.id,
+  environment_id: envId,
+  vault_ids: [vaultId],  // vault contains the GitHub MCP OAuth credential
+  resources: [
+    {
+      type: 'github_repository',
+      url: 'https://github.com/owner/repo',
+      authorization_token: process.env.GITHUB_TOKEN,  // repo clone token (≠ MCP auth)
+      checkout: { type: 'branch', name: 'main' },
+    },
+  ],
+});
+```
+
+**Python:**
+
+```python
+import os
+
+agent = client.beta.agents.create(
+    name="GitHub Agent",
+    model="claude-opus-4-6",
+    mcp_servers=[{
+        "type": "url",
+        "name": "github",
+        "url": "https://api.githubcopilot.com/mcp/",
+    }],
+    tools=[
+        {"type": "agent_toolset_20260401", "default_config": {"enabled": True}},
+        {"type": "mcp_toolset", "mcp_server_name": "github"},
+    ],
+)
+
+session = client.beta.sessions.create(
+    agent=agent.id,
+    environment_id=env_id,
+    vault_ids=[vault_id],  # vault contains the GitHub MCP OAuth credential
+    resources=[{
+        "type": "github_repository",
+        "url": "https://github.com/owner/repo",
+        "authorization_token": os.environ["GITHUB_TOKEN"],  # repo clone token (≠ MCP auth)
+        "checkout": {"type": "branch", "name": "main"},
+    }],
+)
+```
+
+---
+
+## Files API
+
+Upload and manage files for use as session resources, and download files the agent wrote to `/mnt/session/outputs/`.
+
+| Operation        | Method   | Path                                  | SDK |
+| ---------------- | -------- | ------------------------------------- | --- |
+| Upload           | `POST`   | `/v1/files`                           | `client.beta.files.upload({ file })` |
+| List             | `GET`    | `/v1/files?session_id=...`            | `client.beta.files.list({ session_id })` |
+| Get Metadata     | `GET`    | `/v1/files/{id}`                      | `client.beta.files.retrieveMetadata(id)` |
+| Download         | `GET`    | `/v1/files/{id}/content`              | `client.beta.files.download(id)` → `Response` |
+| Delete           | `DELETE` | `/v1/files/{id}`                      | `client.beta.files.delete(id)` |
+
+The `session_id` filter on List scopes the results to files written to `/mnt/session/outputs/` by that session. Without the filter, you get all files uploaded to your account.

--- a/.claude/skills/claude-api/shared/managed-agents-events.md
+++ b/.claude/skills/claude-api/shared/managed-agents-events.md
@@ -1,0 +1,187 @@
+# Managed Agents — Events & Steering
+
+## Events
+
+### Sending Events
+
+Send events to a session via `POST /v1/sessions/{id}/events`.
+
+| Event Type                | When to Send                                        |
+| ------------------------- | --------------------------------------------------- |
+| `user.message`            | Send a user message |
+| `user.interrupt`          | Interrupt the agent while it's running |
+| `user.tool_confirmation`  | Approve/deny a tool call (when `always_ask` policy) |
+| `user.custom_tool_result` | Provide result for a custom tool call |
+
+### Receiving Events
+
+Two methods:
+
+1. **Streaming (SSE)**: `GET /v1/sessions/{id}/events/stream` — real-time Server-Sent Events. **Long-lived** — the server sends periodic heartbeats to keep the connection alive.
+2. **Polling**: `GET /v1/sessions/{id}/events` — paginated event list (query params: `limit` default 1000, `page`). **Returns immediately** — this is a plain paginated GET, not a long-poll.
+
+All received events carry `id`, `type`, and `processed_at` (ISO 8601; `null` if not yet processed by the agent).
+
+> ⚠️ **Robust polling (raw HTTP).** If you bypass the SDK and roll your own poll loop, don't rely on `requests` or `httpx` timeouts as wall-clock caps — they're **per-chunk** read timeouts, reset every time a byte arrives. A trickling response (heartbeats, a wedged chunked-encoding body, a misbehaving proxy) can keep the call blocked indefinitely even with `timeout=(5, 60)` or `httpx.Timeout(120)`. Neither library has a "total wall-clock" timeout built in. For a hard deadline: track `time.monotonic()` at the loop level and break/cancel if a single request exceeds your budget (e.g. via a watchdog thread, or `asyncio.wait_for()` around async httpx). **Prefer the SDK** — `client.beta.sessions.events.stream()` and `client.beta.sessions.events.list()` handle timeout + retry sanely.
+>
+> If `GET /v1/sessions/{id}/events` (paginated) ever hangs after headers, you've likely hit `GET /v1/sessions/{id}/events` by mistake or a server-side stall — report it; don't treat it as a client-config problem.
+
+### Event Types (Received)
+
+Event types use dot notation, grouped by namespace:
+
+| Event Type | Description |
+| --- | --- |
+| `agent.message` | Agent text output |
+| `agent.thinking` | Extended thinking blocks |
+| `agent.tool_use` | Agent used a built-in tool (`agent_toolset_20260401`) |
+| `agent.tool_result` | Result from a built-in tool |
+| `agent.mcp_tool_use` | Agent used an MCP tool |
+| `agent.mcp_tool_result` | Result from an MCP tool |
+| `agent.custom_tool_use` | Agent invoked a custom tool — session goes idle, you respond with `user.custom_tool_result` |
+| `agent.thread_context_compacted` | Conversation context was compacted |
+| `session.status_idle` | Agent has finished the current task, and is awaiting input. It's either waiting for input to continue working via a `user.message` or blocked awaiting a `user.custom_tool_result` or `user.tool_confirmation`. The `stop_reason` attached contains more information about why the Agent has stopped working. |
+| `session.status_running` | Session has starting running, and the Agent is actively doing work. |
+| `session.status_rescheduled` | Session is (re)scheduling after a retryable error has occurred, ready to be picked up by the orchestration system. |
+| `session.status_terminated` | Session has terminated, entering an irreversible and unusable state.  |
+| `session.error` | Error occurred during processing |
+| `span.model_request_start` | Model inference started |
+| `span.model_request_end` | Model inference completed |
+
+The stream also echoes back user-sent events (`user.message`, `user.interrupt`, `user.tool_confirmation`, `user.custom_tool_result`).
+
+---
+
+## Steering Patterns
+
+Practical patterns for driving a session via the events surface.
+
+### Stream-first ordering
+
+**Open the stream before sending events.** The stream only delivers events that occur *after* it's opened — it does not replay current state or historical events. If you send a message first and open the stream second, early events (including fast status transitions) arrive buffered in a single batch and you lose the ability to react to them in real time.
+
+```ts
+// ✅ Correct — stream and send concurrently
+const [response] = await Promise.all([
+  streamEvents(sessionId),   // opens SSE connection
+  sendMessage(sessionId, text),
+]);
+
+// ❌ Wrong — events before stream opens arrive as a single buffered batch
+await sendMessage(sessionId, text);
+const response = await streamEvents(sessionId);
+```
+
+**For full history,** use `GET /v1/sessions/{id}/events` (paginated list) — the stream only gives you live events from connection onward.
+
+### Reconnecting after a dropped stream
+
+**The SSE stream has no replay.** If your connection drops (httpx read timeout, network blip) and you reconnect, you only get events emitted *after* reconnection. Any events emitted during the gap are lost from the stream.
+
+**The consolidation pattern:** on every (re)connect, overlap the stream with a history fetch and dedupe by event ID:
+
+```python
+def connect_with_consolidation(client, session_id):
+    # 1. Open the SSE stream first
+    stream = client.beta.sessions.events.stream(session_id=session_id)
+
+    # 2. Fetch history to cover any gap
+    history = client.beta.sessions.events.list(
+        session_id=session_id,
+    )
+
+    # 3. Yield history first, then stream — dedupe by event.id
+    seen = set()
+    for ev in history.data:
+        seen.add(ev.id)
+        yield ev
+    for ev in stream:
+        if ev.id not in seen:
+            seen.add(ev.id)
+            yield ev
+```
+
+### Message queuing
+
+**You don't have to wait for a response before sending the next message.** User events are queued server-side and processed in order. This is useful for chat bridges where the user sends rapid follow-ups:
+
+```ts
+// All three go into one session; agent processes them in order
+await sendMessage(sessionId, "Summarize the README");
+await sendMessage(sessionId, "Actually also check the CONTRIBUTING guide");
+await sendMessage(sessionId, "And compare the two");
+// Stream once — agent responds to all three as a coherent turn
+```
+
+Events can be sent up to the Session at any time. There is no need to wait on a specific session status to enqueue new events via `client.beta.sessions.events.send()`
+
+### Interrupt
+
+An `interrupt` event **jumps the queue** (ahead of any pending user messages) and forces the session into `idle`. Use this for "stop" / "nevermind" / "cancel" commands:
+
+```ts
+await client.beta.sessions.events.send(sessionId, {
+  events: [{ type: 'interrupt' }],
+});
+```
+
+The agent stops mid-task. It does not see the interrupt as a message — it just halts. Send a follow-up `user` event to explain what to do instead.
+
+> **Note**: Interrupt events may have empty IDs in the current implementation. When troubleshooting, use the `processed_at` timestamp along with surrounding event IDs.
+
+### Event payloads
+
+some events carry useful metadata beyond the status change itself:
+
+`session.status_idle` — includes a `stop_reason` field which elaborates on why the session stopped and what type of further action is required by the user.
+```json
+{
+  "id": "sevt_456",
+  "processed_at": "2026-04-07T04:27:43.197Z",
+  "stop_reason": {
+    "event_ids": [
+      "sevt_123"
+    ],
+    "type": "requires_action"
+  },
+  "type": "status_idle"
+}
+```
+
+`span.model_request_end` contains a `model_usage` field for cost tracking and efficiency analysis:
+
+```json
+{
+  "type": "span.model_request_end",
+  "id": "sevt_456",
+  "is_error": false,
+  "model_request_start_id": "sevt_123",
+  "model_usage": {
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 6656,
+    "input_tokens": 3571,
+    "output_tokens": 727
+  },
+  "processed_at": "2026-04-07T04:11:32.189Z"
+}
+```
+
+**`agent.thread_context_compacted`** — emitted when the conversation history was summarized to fit context. Includes `pre_compaction_tokens` so you know how much was squeezed:
+
+```json
+{
+  "id": "sevt_abc123",
+  "processed_at": "2026-03-24T14:05:15.787Z",
+  "type": "agent.thread_context_compacted"
+}
+```
+
+### Archive
+
+When done with a session, archive it to free resources:
+
+```ts
+await client.beta.sessions.archive(sessionId);
+```
+
+

--- a/.claude/skills/claude-api/shared/managed-agents-onboarding.md
+++ b/.claude/skills/claude-api/shared/managed-agents-onboarding.md
@@ -1,0 +1,114 @@
+# Managed Agents — Onboarding Flow
+
+> **Invoked via `/claude-api managed-agents-onboard`?** You're in the right place. Run the interview below — don't summarize it back to the user, ask the questions.
+
+Use this when a user wants to set up a Managed Agent from scratch. Three steps: **branch on know-vs-explore → configure the template → set up the session**. End by emitting working code.
+
+> Read `shared/managed-agents-core.md` alongside this — it has full detail for each knob. This doc is the interview script, not the reference.
+
+---
+
+Claude Managed Agents is a hosted agent: Anthropic runs the agent loop on its orchestration layer and provisions a sandboxed container per session where the agent's tools execute. You supply the agent config and the environment config; the harness — event stream, sandbox orchestration, prompt caching, context compaction, and extended thinking — is handled for you.
+
+**What you supply:**
+- **An agent config** — tools, skills, model, system prompt. Reusable and versioned.
+- **An environment config** — the sandbox your agent's tools execute in (networking, packages). Reusable across agents.
+
+Each run of the agent is a **session**.
+
+---
+
+## 1. Know or explore?
+
+Ask the user:
+
+> Do you already know the agent you want to build, or would you like to explore some common patterns first?
+
+### Explore path — show the patterns
+
+Four shapes, same runtime code path (`sessions.create()` → `sessions.events.send()` → stream). Only the trigger and sink differ.
+
+| Pattern | Trigger | Example |
+|---|---|---|
+| Event-triggered | Webhook | GitHub PR push → CMA (GitHub tool) → Slack | # <------ MC maybe delete?
+| Scheduled | Cron | Daily brief: browser + GitHub + Jira → CMA → Slack | # <------ MC maybe delete?
+| Fire-and-forget PR | Human | Slack slash-command → CMA (GitHub tool) → PR passing CI |
+| Research + dashboard | Human | Topic → CMA (web search + `frontend-design` skill) → HTML dashboard |
+
+Ask which shape fits, then continue with the Know path using it as the reference.
+
+### Know path — configure template
+
+Three rounds. Batch the questions in each round; don't ask them one at a time.
+
+**Round A — Tools.** Start here; it's the most concrete part. Three types; ask which the user wants (any combination):
+
+| Type | What it is | How to guide |
+|---|---|---|
+| **Prebuilt Claude Agent tools** (`agent_toolset_20260401`) | Ready-to-use: `bash`, `read`, `write`, `edit`, `glob`, `grep`, `web_fetch`, `web_search`. Enable all at once, or individually via `enabled: true/false`. | Recommend enabling the full toolset. List the 8 tools so the user knows what they're getting. Full detail: `shared/managed-agents-tools.md` → Agent Toolset. |
+| **MCP tools** | Third-party integrations (GitHub, Linear, Asana, etc.) via `mcp_toolset`. Credentials live in a vault, not inline. | Ask which services. For each, walk through MCP server URL + vault credentials. Full detail: `shared/managed-agents-tools.md` → MCP Servers + Vaults. |
+| **Custom tools** | The user's own app handles these tool calls — agent fires `agent.custom_tool_use`, the app sends a result message back. | Ask for each tool: name, description, input schema. The app code that handles the event is *their* code — don't generate it. Full detail: `shared/managed-agents-tools.md` → Custom Tools. |
+
+**Round B — Skills, files, and repos.** What the agent has on hand when it starts.
+
+*Skills* — two types; both work the same way — Claude auto-uses them when relevant. Max 64 per agent.
+- [ ] **Pre-built Agent Skills**: `xlsx`, `docx`, `pptx`, `pdf`. Reference by name.
+- [ ] **Custom Skills**: skills uploaded to the user's org via the Skills API. Reference by `skill_id` + optional `version`. If the skill doesn't exist yet, walk the user through `POST /v1/skills` + `POST /v1/skills/{id}/versions` (beta header `skills-2025-10-02`). Full detail: `shared/managed-agents-tools.md` → Skills + Skills API.
+
+*GitHub repositories* — any repos the agent needs on-disk? For each:
+- [ ] Repo URL (`https://github.com/org/repo`)
+- [ ] `authorization_token` (PAT or GitHub App token scoped to the repo)
+- [ ] Optional `mount_path` (defaults to `/workspace/<repo-name>`) and `checkout` (branch or SHA)
+
+Emit as `resources: [{type: "github_repository", url, authorization_token, ...}]`. Full detail: `shared/managed-agents-environments.md` → GitHub Repositories.
+
+> ‼️ **PR creation needs the GitHub MCP server too.** `github_repository` gives filesystem access only — to open PRs, also attach the GitHub MCP server in Round A and credential it via a vault. The workflow is: edit files in the mounted repo → push branch via `bash` → create PR via the MCP `create_pull_request` tool.
+
+*Files* — any local files to seed the session with? For each:
+- [ ] Upload via the Files API → persist `file_id`
+- [ ] Choose a `mount_path` — absolute, e.g. `/workspace/data.csv` (parents auto-created; files mount read-only)
+
+Emit as `resources: [{type: "file", file_id, mount_path}]`. Max 999 file resources. Agent working directory defaults to `/workspace`. Full detail: `shared/managed-agents-environments.md` → Files API.
+
+**Round C — Environment + identity:**
+- [ ] Networking: unrestricted internet from the container, or lock egress to specific hosts? (If locked, MCP server domains must be in `allowed_hosts` or tools silently fail.)
+- [ ] Name?
+- [ ] Job (one or two sentences — becomes the system prompt)?
+- [ ] Model? (default `claude-opus-4-6`)
+
+---
+
+## 2. Set up the session
+
+Per-run. Points at the agent + environment, attaches credentials, kicks off.
+
+**Vault credentials** (if the agent declared MCP servers):
+- [ ] Existing vault, or create one? (`client.beta.vaults.create()` + `vaults.credentials.create()`)
+
+Credentials are write-only, matched to MCP servers by URL, auto-refreshed. See `shared/managed-agents-tools.md` → Vaults.
+
+**Kickoff:**
+- [ ] First message to the agent?
+
+Session creation blocks until all resources mount. Open the event stream before sending the kickoff. Stream is SSE; break on `session.status_terminated`, or on `session.status_idle` with a terminal `stop_reason` — i.e. anything except `requires_action`, which fires transiently while the session waits on a tool confirmation or custom-tool result (see `shared/managed-agents-client-patterns.md` Pattern 5). Usage lands on `span.model_request_end`. Agent-written artifacts end up in `/mnt/session/outputs/` — download via `files.list({scope: session_id})`.
+
+---
+
+## 3. Emit the code
+
+Go straight from the last interview answer to the code — no preamble about the setup-vs-runtime split, no "the critical thing to internalize…", no lecture about `agents.create()` being one-time. The two-block structure below already shows that; don't narrate it. Generate **two clearly-separated blocks** per language detected (Python/TS/cURL — see SKILL.md → Language Detection):
+
+**Block 1 — Setup (run once, store the IDs):**
+1. `environments.create()` → persist `env_id`
+2. `agents.create()` with everything from §Round A–C → persist `agent_id` and `agent_version`
+
+Label: `# ONE-TIME SETUP — run once, save the IDs to config/.env`
+
+**Block 2 — Runtime (run on every invocation):**
+1. Load `env_id` + `agent_id` from config/env
+2. `sessions.create(agent=AGENT_ID, environment_id=ENV_ID, resources=[...], vault_ids=[...])`
+3. Open stream, `events.send()` the kickoff, loop until `session.status_terminated` or `session.status_idle && stop_reason.type !== 'requires_action'` (see `shared/managed-agents-client-patterns.md` Pattern 5 for the full gate — do not break on bare `session.status_idle`)
+
+> ⚠️ **Never emit `agents.create()` and `sessions.create()` in the same unguarded block.** That teaches the user to create a new agent on every run — the #1 anti-pattern. If they need a single script, wrap agent creation in `if not os.getenv("AGENT_ID"):`.
+
+Pull exact syntax from `python/managed-agents/README.md`, `typescript/managed-agents/README.md`, or `curl/managed-agents.md`. Don't invent field names.

--- a/.claude/skills/claude-api/shared/managed-agents-overview.md
+++ b/.claude/skills/claude-api/shared/managed-agents-overview.md
@@ -1,0 +1,61 @@
+# Managed Agents — Overview
+
+Managed Agents provisions a container per session as the agent's workspace. The agent loop runs on Anthropic's orchestration layer; the container is where the agent's *tools* execute — bash commands, file operations, code. You create a persisted **Agent** config (model, system prompt, tools, MCP servers, skills), then start **Sessions** that reference it. The session streams events back to you; you send user messages and tool results in.
+
+## ⚠️ THE MANDATORY FLOW: Agent (once) → Session (every run)
+
+**Why agents are separate objects: versioning.** An agent is a persisted, versioned config — every update creates a new immutable version, and sessions pin to a version at creation time. This lets you iterate on the agent (tweak the prompt, add a tool) without breaking sessions already running, roll back if a change regresses, and A/B test versions side-by-side. None of that works if you `agents.create()` fresh on every run.
+
+Every session references a pre-created `/v1/agents` object. Create the agent once, store the ID, and reuse it across runs.
+
+| Step | Call | Frequency |
+|---|---|---|
+| 1 | `POST /v1/agents` — `model`, `system`, `tools`, `mcp_servers`, `skills` live here | **ONCE.** Store `agent.id` **and** `agent.version`. |
+| 2 | `POST /v1/sessions` — `agent: "agent_abc123"` or `{type: "agent", id, version}` | **Every run.** String shorthand uses latest version. |
+
+If you're about to write `sessions.create()` with `model`, `system`, or `tools` on the session body — **stop**. Those fields live on `agents.create()`. The session takes a *pointer* only.
+
+**When generating code, separate setup from runtime.** `agents.create()` belongs in a setup script (or a guarded `if agent_id is None:` block), not at the top of the hot path. If the user's code calls `agents.create()` on every invocation, they're accumulating orphaned agents and paying the create latency for nothing. The correct shape is: create once → persist the ID (config file, env var, secrets manager) → every run loads the ID and calls `sessions.create()`.
+
+**To change the agent's behavior, use `POST /v1/agents/{id}` — don't create a new one.** Each update bumps the version; running sessions keep their pinned version, new sessions get the latest (or pin explicitly via `{type: "agent", id, version}`). See `shared/managed-agents-core.md` → Agents → Versioning.
+
+## Beta Headers
+
+Managed Agents is in beta. The SDK sets required beta headers automatically:
+
+| Beta Header                    | What it enables                                      |
+| ------------------------------ | ---------------------------------------------------- |
+| `managed-agents-2026-04-01`    | Agents, Environments, Sessions, Events, Session Resources, Vaults, Credentials |
+| `skills-2025-10-02`            | Skills API (for managing custom skill definitions)   |
+| `files-api-2025-04-14`         | Files API for file uploads                           |
+
+**Note: do not intermix beta headers** — If you need to upload a skill or file via the Skills API or Files API you will need to use the appropriate beta header as listed above. However, you do NOT need to inlude either the Skills or Files beta header when using any of the Managed Agents endpints listed in row 1 above. Do NOT include intermix beta headers and prefer to use the Skills or Files beta headers when using their specific endpoints.
+
+
+## Reading Guide
+
+| User wants to...                       | Read these files                                        |
+| -------------------------------------- | ------------------------------------------------------- |
+| **Get started from scratch / "help me set up an agent"** | `shared/managed-agents-onboarding.md` — guided interview (WHERE→WHO→WHAT→WATCH), then emit code |
+| Understand how the API works           | `shared/managed-agents-core.md`                         |
+| See the full endpoint reference        | `shared/managed-agents-api-reference.md`                |
+| **Create an agent** (required first step) | `shared/managed-agents-core.md` (Agents section) + language file |
+| Update/version an agent                | `shared/managed-agents-core.md` (Agents → Versioning) — update, don't re-create |
+| Create a session                       | `shared/managed-agents-core.md` + `{lang}/managed-agents/README.md` |
+| Configure tools and permissions        | `shared/managed-agents-tools.md`                        |
+| Set up MCP servers                     | `shared/managed-agents-tools.md` (MCP Servers section)  |
+| Stream events / handle tool_use        | `shared/managed-agents-events.md` + language file       |
+| Set up environments                    | `shared/managed-agents-environments.md` + language file |
+| Upload files / attach repos            | `shared/managed-agents-environments.md` (Resources)     |
+| Store MCP credentials                  | `shared/managed-agents-tools.md` (Vaults section)       |
+
+## Common Pitfalls
+
+- **Agent FIRST, then session — NO EXCEPTIONS** — the session's `agent` field accepts **only** a string ID or `{type: "agent", id, version}`. `model`, `system`, `tools`, `mcp_servers`, `skills` are **top-level fields on `POST /v1/agents`**, never on `sessions.create()`. If the user hasn't created an agent, that is step zero of every example.
+- **Agent ONCE, not every run** — `agents.create()` is a setup step. Store the returned `agent_id` and reuse it; don't call `agents.create()` at the top of your hot path. If the agent's config needs to change, `POST /v1/agents/{id}` — each update creates a new version, and sessions can pin to a specific version for reproducibility.
+- **MCP auth goes through vaults** — the agent's `mcp_servers` array declares `{type, name, url}` only (no auth). Credentials live in vaults (`client.beta.vaults.credentials.create`) and attach to sessions via `vault_ids`. Anthropic auto-refreshes OAuth tokens using the stored refresh token.
+- **Stream to get events** — `GET /v1/sessions/{id}/events/stream` is the primary way to receive agent output in real-time.
+- **SSE stream has no replay — reconnect with consolidation** — if the stream drops while a `agent.tool_use`, `agent.mcp_tool_use`, or `agent.custom_tool_use` is pending resolution (`user.tool_confirmation` for the first two, `user.custom_tool_result` for the last one), the session deadlocks (client disconnects → session idles → reconnect happens → no client resolution happens). On every (re)connect: open stream with `GET /v1/sessions/{id}/events/stream` , fetch `GET /v1/sessions/{id}/events`, dedupe by event ID, then proceed. See `shared/managed-agents-events.md` → Reconnecting after a dropped stream.
+- **Don't trust HTTP-library timeouts as wall-clock caps** — `requests` `timeout=(c, r)` and `httpx.Timeout(n)` are *per-chunk* read timeouts; they reset every byte, so a trickling connection can block indefinitely. For a hard deadline on raw-HTTP polling, track `time.monotonic()` at the loop level and bail explicitly. Prefer the SDK's `sessions.events.stream()` / `session.events.list()` over hand-rolled HTTP. See `shared/managed-agents-events.md` → Receiving Events.
+- **Messages queue** — you can send events while the session is `running` or `idle`; they're processed in order. No need to wait for a response before sending the next message.
+- **Cloud environments only** — `config.type: "cloud"` is the only supported environment type.

--- a/.claude/skills/claude-api/shared/managed-agents-tools.md
+++ b/.claude/skills/claude-api/shared/managed-agents-tools.md
@@ -1,0 +1,301 @@
+# Managed Agents — Tools & Skills
+
+## Tools
+
+### Server tools vs client tools
+
+| Type | Who runs it | How it works |
+|---|---|---|
+| **Prebuilt Claude Agent tools** (`agent_toolset_20260401`) | Anthropic, on the session's container | File ops, bash, web search, etc. Enable all at once or configure individually with `enabled: true/false`. |
+| **MCP tools** (`mcp_toolset`) | Anthropic, on the session's container | Capabilities exposed by connected MCP servers. Grant access per-server via the toolset. |
+| **Custom tools** | **You** — your application handles the call and returns results | Agent emits a `agent.custom_tool_use` event, session goes `idle`, you send back a `user.custom_tool_result` event. |
+
+**Recommendation:** Enable all prebuilt tools via `agent_toolset_20260401`, then disable individually as needed.
+
+**Versioning:** The toolset is a versioned, static resource. When underlying tools change, a new toolset version is created (hence `_20260401`) so you always know exactly what you're getting.
+
+### Agent Toolset
+
+The `agent_toolset_20260401` provides these built-in tools:
+
+| Tool                   | Description                              |
+| ---------------------- | ---------------------------------------- |
+| `bash` | Execute bash commands in a shell session |
+| `read` | Read a file from the local filesystem, including text, images, PDFs, and Jupyter notebooks |
+| `write` | Write a file to the local filesystem |
+| `edit` | Perform string replacement in a file |
+| `glob` | Fast file pattern matching using glob patterns |
+| `grep` | Text search using regex patterns |
+| `web_fetch` | Fetch content from a URL |
+| `web_search` | Search the web for information |
+
+Enable the full toolset:
+
+```json
+{
+  "tools": [
+    { "type": "agent_toolset_20260401" }
+  ]
+}
+```
+
+### Per-Tool Configuration
+
+Override defaults for individual tools. This example enables everything except bash:
+
+```json
+{
+  "tools": [
+    {
+      "type": "agent_toolset_20260401",
+      "default_config": { "enabled": true },
+      "configs": [
+        { "name": "bash", "enabled": false }
+      ]
+    }
+  ]
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `type` | ✅ | `"agent_toolset_20260401"` |
+| `default_config` | ❌ | Applied to all tools. `{ "enabled": bool, "permission_policy": {...} }` |
+| `configs` | ❌ | Per-tool overrides: `[{ "name": "...", "enabled": bool, "permission_policy": {...} }]` |
+
+### Permission Policies
+
+Control when server-executed tools (agent toolset + MCP) run automatically vs wait for approval. Does not apply to custom tools.
+
+| Policy | Behavior |
+|---|---|
+| `always_allow` | Tool executes automatically (default) |
+| `always_ask` | Session emits `session.status_idle` and pauses until you send a `tool_confirmation` event |
+
+```json
+{
+  "type": "agent_toolset_20260401",
+  "default_config": {
+    "enabled": true,
+    "permission_policy": { "type": "always_allow" }
+  },
+  "configs": [
+    { "name": "bash", "permission_policy": { "type": "always_ask" } }
+  ]
+}
+```
+
+**Responding to `always_ask`:** Send a `user.tool_confirmation` event with `tool_use_id` from the triggering `agent_tool_use`/`mcp_tool_use` event:
+
+```json
+{ "type": "tool_confirmation", "tool_use_id": "sevt_abc123", "result": "allow" }
+{ "type": "tool_confirmation", "tool_use_id": "sevt_def456", "result": "deny", "message": "Read .env.example instead" }
+```
+
+The optional `message` on a deny is delivered to the agent so it can adjust its approach.
+
+To enable only specific tools, flip the default off and opt-in per tool:
+
+```json
+{
+  "tools": [
+    {
+      "type": "agent_toolset_20260401",
+      "default_config": { "enabled": false },
+      "configs": [
+        { "name": "bash", "enabled": true },
+        { "name": "read", "enabled": true }
+      ]
+    }
+  ]
+}
+```
+
+### Custom Tools (Client-Side)
+
+Custom tools are executed by **your application**, not Anthropic. The flow:
+
+1. Agent decides to use the tool → session emits a `agent.custom_tool_use` event with inputs
+2. Session goes `idle` waiting for you
+3. Your application executes the tool
+4. You send back a `user.custom_tool_result` event with the output
+5. Session resumes `running`
+
+No permission policy needed — you're the one executing.
+
+```json
+{
+  "tools": [
+    {
+      "type": "custom",
+      "name": "get_weather",
+      "description": "Fetch current weather for a city.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "city": { "type": "string", "description": "City name" }
+        },
+        "required": ["city"]
+      }
+    }
+  ]
+}
+```
+
+### MCP Servers
+
+MCP (Model Context Protocol) servers expose standardized third-party capabilities (e.g. Asana, GitHub, Linear). **Configuration is split across agent and vault:**
+
+1. **Agent creation** declares which servers to connect to (`type`, `name`, `url` — no auth). The agent's `mcp_servers` array has no auth field.
+2. **Vault** stores the OAuth credentials. Attach via `vault_ids` on session create.
+
+This keeps secrets out of reusable agent definitions. Each vault credential is tied to one MCP server URL; Anthropic matches credentials to servers by URL.
+
+**Agent side — declare servers (no auth):**
+
+| Field | Required | Description |
+|---|---|---|
+| `type` | ✅ | `"url"` |
+| `name` | ✅ | Unique name — referenced by `mcp_toolset.mcp_server_name` |
+| `url` | ✅ | The MCP server's endpoint URL (Streamable HTTP transport) |
+
+```json
+{
+  "mcp_servers": [
+    { "type": "url", "name": "linear", "url": "https://mcp.linear.app/mcp" }
+  ],
+  "tools": [
+    { "type": "mcp_toolset", "mcp_server_name": "linear" }
+  ]
+}
+```
+
+**Session side — attach vault:**
+
+```json
+{
+  "agent": "agent_abc123",
+  "environment_id": "env_abc123",
+  "vault_ids": ["vlt_abc123"]
+}
+```
+
+> 💡 **Per-tool enablement (empirical):** `mcp_toolset` has been observed accepting `default_config: {enabled: false}` + `configs: [{name, enabled: true}]` for an allowlist pattern. The API ref shows only the minimal `{type, mcp_server_name}` form.
+
+> ⚠️ **MCP auth tokens ≠ REST API tokens.** Hosted MCP servers (`mcp.notion.com`, `mcp.linear.app`, etc.) typically require **OAuth bearer tokens**, not the service's native API keys. A Notion `ntn_` integration token authenticates against Notion's REST API but will **not** work as a vault credential for the Notion MCP server. These are different auth systems.
+
+### Vaults — the MCP credential store
+
+**Vaults** store OAuth credentials (access token + refresh token) that Anthropic auto-refreshes on your behalf via standard OAuth 2.0 `refresh_token` grant. This is the only way to authenticate MCP servers in the launch SDK.
+
+> Formerly known internally as TATs (Tool/Tenant Access Tokens).
+
+**Flow:**
+
+1. Create a vault (`client.beta.vaults.create(...)`) — one per tenant/user, or one shared, depending on your model
+2. Add MCP credentials to it (`client.beta.vaults.credentials.create(...)`) — each credential is tied to one MCP server URL
+3. Reference the vault on session create via `vault_ids: ["vlt_..."]`
+4. Anthropic auto-refreshes tokens before they expire; the agent uses the current access token when calling MCP tools
+
+**Credential shape**:
+
+```json
+{
+  "display_name": "Notion (workspace-foo)",
+  "auth": {
+    "type": "mcp_oauth",
+    "mcp_server_url": "https://mcp.notion.com/mcp",
+    "access_token": "<current access token>",
+    "expires_at": "2026-04-02T14:00:00Z",
+    "refresh": {
+      "refresh_token": "<refresh token>",
+      "client_id": "<your OAuth client_id>",
+      "token_endpoint": "https://api.notion.com/v1/oauth/token",
+      "token_endpoint_auth": { "type": "none" }
+    }
+  }
+}
+```
+
+The `refresh` block is what enables auto-refresh — `token_endpoint` is where Anthropic posts the `refresh_token` grant. `token_endpoint_auth` is a discriminated union:
+
+| `type` | Shape | Use when |
+|---|---|---|
+| `"none"` | `{type: "none"}` | Public OAuth client (no secret) |
+| `"client_secret_basic"` | `{type: "client_secret_basic", client_secret: "..."}` | Confidential client, secret via HTTP Basic auth |
+| `"client_secret_post"` | `{type: "client_secret_post", client_secret: "..."}` | Confidential client, secret in request body |
+
+Omit `refresh` entirely if you only have an access token with no refresh capability — it'll work until it expires, then the agent loses access.
+
+> 💡 **Getting an OAuth token.** How you obtain the initial access and refresh tokens depends on the MCP server — consult its documentation. Once you have them, store them in a vault credential using the shape above; Anthropic auto-refreshes via the `refresh.token_endpoint` from there.
+
+**Scoping:** Vaults are workspace-scoped. Anyone with developer+ role in the API workspace can create, read (metadata only — secrets are write-only), and attach vaults. `vault_ids` can be set at session **create** time but not via session update (the SDK docstring says "Not yet supported; requests setting this field are rejected").
+
+---
+
+## Skills
+
+Skills are reusable, filesystem-based resources that provide your agent with domain-specific expertise: workflows, context, and best practices that transform general-purpose agents into specialists. Unlike prompts (conversation-level instructions for one-off tasks), skills load on-demand and eliminate the need to repeatedly provide the same guidance across multiple conversations.
+
+Two types — both work the same way; the agent automatically uses them when relevant to the task at hand:
+
+| Type | What it is |
+|---|---|
+| **Pre-built Anthropic skills** | Common document tasks (PowerPoint, Excel, Word, PDF). Reference by name (e.g. `xlsx`). |
+| **Custom skills** | Skills you've created in your organization via the Skills API. Reference by `skill_id` + optional `version`. |
+
+**Max 64 skills per agent.** Agent creation uses `managed-agents-2026-04-01`; the separate Skills API (for managing custom skill definitions) uses `skills-2025-10-02`.
+
+### Enabling skills on a session
+
+Skills are attached to the **agent** definition via `agents.create()`:
+
+```ts
+const agent = await client.beta.agents.create(
+  {
+    name: "Financial Agent",
+    model: "claude-opus-4-6",
+    system: "You are a financial analysis agent.",
+    skills: [
+      { type: "anthropic", skill_id: "xlsx" },
+      { type: "custom", skill_id: "skill_abc123", version: "latest" },
+    ],
+  }
+);
+```
+
+Python:
+
+```python
+agent = client.beta.agents.create(
+    name="Financial Agent",
+    model="claude-opus-4-6",
+    system="You are a financial analysis agent.",
+    skills=[
+        {"type": "anthropic", "skill_id": "xlsx"},
+        {"type": "custom", "skill_id": "skill_abc123", "version": "latest"},
+    ]
+)
+```
+
+**Skill reference fields:**
+
+| Field | Anthropic skill | Custom skill |
+|---|---|---|
+| `type` | `"anthropic"` | `"custom"` |
+| `skill_id` | Skill name (e.g. `"xlsx"`, `"docx"`, `"pptx"`, `"pdf"`) | Skill ID from Skills API (e.g. `"skill_abc123"`) |
+| `version` | — | `"latest"` or a specific version number |
+
+### Skills API
+
+| Operation             | Method   | Path                                            |
+| --------------------- | -------- | ----------------------------------------------- |
+| Create Skill          | `POST`   | `/v1/skills`                                    |
+| List Skills           | `GET`    | `/v1/skills`                                    |
+| Get Skill             | `GET`    | `/v1/skills/{id}`                               |
+| Delete Skill          | `DELETE` | `/v1/skills/{id}`                               |
+| Create Version        | `POST`   | `/v1/skills/{id}/versions`                      |
+| List Versions         | `GET`    | `/v1/skills/{id}/versions`                      |
+| Get Version           | `GET`    | `/v1/skills/{id}/versions/{version}`            |
+| Delete Version        | `DELETE` | `/v1/skills/{id}/versions/{version}`            |
+

--- a/.claude/skills/claude-api/shared/models.md
+++ b/.claude/skills/claude-api/shared/models.md
@@ -1,0 +1,119 @@
+# Claude Model Catalog
+
+**Only use exact model IDs listed in this file.** Never guess or construct model IDs — incorrect IDs will cause API errors. Use aliases wherever available. For the latest information, WebFetch the Models Overview URL in `shared/live-sources.md`, or query the Models API directly (see Programmatic Model Discovery below).
+
+## Programmatic Model Discovery
+
+For **live** capability data — context window, max output tokens, feature support (thinking, vision, effort, structured outputs, etc.) — query the Models API instead of relying on the cached tables below. Use this when the user asks "what's the context window for X", "does model X support vision/thinking/effort", "which models support feature Y", or wants to select a model by capability at runtime.
+
+```python
+m = client.models.retrieve("claude-opus-4-6")
+m.id                 # "claude-opus-4-6"
+m.display_name       # "Claude Opus 4.6"
+m.max_input_tokens   # context window (int)
+m.max_tokens         # max output tokens (int)
+
+# capabilities is an untyped nested dict — bracket access, check ["supported"] at the leaf
+caps = m.capabilities
+caps["image_input"]["supported"]                       # vision
+caps["thinking"]["types"]["adaptive"]["supported"]     # adaptive thinking
+caps["effort"]["max"]["supported"]                     # effort: max (also low/medium/high)
+caps["structured_outputs"]["supported"]
+caps["context_management"]["compact_20260112"]["supported"]
+
+# filter across all models — iterate the page object directly (auto-paginates); do NOT use .data
+[m for m in client.models.list()
+ if m.capabilities["thinking"]["types"]["adaptive"]["supported"]
+ and m.max_input_tokens >= 200_000]
+```
+
+Top-level fields (`id`, `display_name`, `max_input_tokens`, `max_tokens`) are typed attributes. `capabilities` is a dict — use bracket access, not attribute access. The API returns the full capability tree for every model with `supported: true/false` at each leaf, so bracket chains are safe without `.get()` guards. TypeScript SDK: same method names, also auto-paginates on iteration.
+
+### Raw HTTP
+
+```bash
+curl https://api.anthropic.com/v1/models/claude-opus-4-6 \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01"
+```
+
+```json
+{
+  "id": "claude-opus-4-6",
+  "display_name": "Claude Opus 4.6",
+  "max_input_tokens": 1000000,
+  "max_tokens": 128000,
+  "capabilities": {
+    "image_input": {"supported": true},
+    "structured_outputs": {"supported": true},
+    "thinking": {"supported": true, "types": {"enabled": {"supported": true}, "adaptive": {"supported": true}}},
+    "effort": {"supported": true, "low": {"supported": true}, …, "max": {"supported": true}},
+    …
+  }
+}
+```
+
+## Current Models (recommended)
+
+| Friendly Name     | Alias (use this)    | Full ID                       | Context        | Max Output | Status |
+|-------------------|---------------------|-------------------------------|----------------|------------|--------|
+| Claude Opus 4.6   | `claude-opus-4-6`   | —                             | 200K (1M beta) | 128K       | Active |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` | -                             | 200K (1M beta) | 64K        | Active |
+| Claude Haiku 4.5  | `claude-haiku-4-5`  | `claude-haiku-4-5-20251001`   | 200K           | 64K        | Active |
+
+### Model Descriptions
+
+- **Claude Opus 4.6** — Our most intelligent model for building agents and coding. Supports adaptive thinking (recommended), 128K max output tokens (requires streaming for large outputs). 1M context window available in beta via `context-1m-2025-08-07` header.
+- **Claude Sonnet 4.6** — Our best combination of speed and intelligence. Supports adaptive thinking (recommended). 1M context window available in beta via `context-1m-2025-08-07` header. 64K max output tokens.
+- **Claude Haiku 4.5** — Fastest and most cost-effective model for simple tasks.
+
+## Legacy Models (still active)
+
+| Friendly Name     | Alias (use this)    | Full ID                       | Status |
+|-------------------|---------------------|-------------------------------|--------|
+| Claude Opus 4.5   | `claude-opus-4-5`   | `claude-opus-4-5-20251101`    | Active |
+| Claude Opus 4.1   | `claude-opus-4-1`   | `claude-opus-4-1-20250805`    | Active |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5` | `claude-sonnet-4-5-20250929`  | Active |
+| Claude Sonnet 4   | `claude-sonnet-4-0` | `claude-sonnet-4-20250514`    | Active |
+| Claude Opus 4     | `claude-opus-4-0`   | `claude-opus-4-20250514`      | Active |
+
+## Deprecated Models (retiring soon)
+
+| Friendly Name     | Alias (use this)    | Full ID                       | Status     | Retires      |
+|-------------------|---------------------|-------------------------------|------------|--------------|
+| Claude Haiku 3    | —                   | `claude-3-haiku-20240307`     | Deprecated | Apr 19, 2026 |
+
+## Retired Models (no longer available)
+
+| Friendly Name     | Full ID                       | Retired     |
+|-------------------|-------------------------------|-------------|
+| Claude Sonnet 3.7 | `claude-3-7-sonnet-20250219`  | Feb 19, 2026 |
+| Claude Haiku 3.5  | `claude-3-5-haiku-20241022`   | Feb 19, 2026 |
+| Claude Opus 3     | `claude-3-opus-20240229`      | Jan 5, 2026 |
+| Claude Sonnet 3.5 | `claude-3-5-sonnet-20241022`  | Oct 28, 2025 |
+| Claude Sonnet 3.5 | `claude-3-5-sonnet-20240620`  | Oct 28, 2025 |
+| Claude Sonnet 3   | `claude-3-sonnet-20240229`    | Jul 21, 2025 |
+| Claude 2.1        | `claude-2.1`                  | Jul 21, 2025 |
+| Claude 2.0        | `claude-2.0`                  | Jul 21, 2025 |
+
+## Resolving User Requests
+
+When a user asks for a model by name, use this table to find the correct model ID:
+
+| User says...                              | Use this model ID              |
+|-------------------------------------------|--------------------------------|
+| "opus", "most powerful"                   | `claude-opus-4-6`              |
+| "opus 4.6"                                | `claude-opus-4-6`              |
+| "opus 4.5"                                | `claude-opus-4-5`              |
+| "opus 4.1"                                | `claude-opus-4-1`              |
+| "opus 4", "opus 4.0"                      | `claude-opus-4-0`              |
+| "sonnet", "balanced"                      | `claude-sonnet-4-6`            |
+| "sonnet 4.6"                              | `claude-sonnet-4-6`            |
+| "sonnet 4.5"                              | `claude-sonnet-4-5`            |
+| "sonnet 4", "sonnet 4.0"                  | `claude-sonnet-4-0`            |
+| "sonnet 3.7"                              | Retired — suggest `claude-sonnet-4-5` |
+| "sonnet 3.5"                              | Retired — suggest `claude-sonnet-4-5` |
+| "haiku", "fast", "cheap"                  | `claude-haiku-4-5`             |
+| "haiku 4.5"                               | `claude-haiku-4-5`             |
+| "haiku 3.5"                               | Retired — suggest `claude-haiku-4-5` |
+| "haiku 3"                                 | Deprecated — suggest `claude-haiku-4-5` |

--- a/.claude/skills/claude-api/shared/prompt-caching.md
+++ b/.claude/skills/claude-api/shared/prompt-caching.md
@@ -1,0 +1,171 @@
+# Prompt Caching — Design & Optimization
+
+This file covers how to design prompt-building code for effective caching. For language-specific syntax, see the `## Prompt Caching` section in each language's README or single-file doc.
+
+## The one invariant everything follows from
+
+**Prompt caching is a prefix match. Any change anywhere in the prefix invalidates everything after it.**
+
+The cache key is derived from the exact bytes of the rendered prompt up to each `cache_control` breakpoint. A single byte difference at position N — a timestamp, a reordered JSON key, a different tool in the list — invalidates the cache for all breakpoints at positions ≥ N.
+
+Render order is: `tools` → `system` → `messages`. A breakpoint on the last system block caches both tools and system together.
+
+Design the prompt-building path around this constraint. Get the ordering right and most caching works for free. Get it wrong and no amount of `cache_control` markers will help.
+
+---
+
+## Workflow for optimizing existing code
+
+When asked to add or optimize caching:
+
+1. **Trace the prompt assembly path.** Find where `system`, `tools`, and `messages` are constructed. Identify every input that flows into them.
+2. **Classify each input by stability:**
+   - Never changes → belongs early in the prompt, before any breakpoint
+   - Changes per-session → belongs after the global prefix, cache per-session
+   - Changes per-turn → belongs at the end, after the last breakpoint
+   - Changes per-request (timestamps, UUIDs, random IDs) → **eliminate or move to the very end**
+3. **Check rendered order matches stability order.** Stable content must physically precede volatile content. If a timestamp is interpolated into the system prompt header, everything after it is uncacheable regardless of markers.
+4. **Place breakpoints at stability boundaries.** See placement patterns below.
+5. **Audit for silent invalidators.** See anti-patterns table.
+
+---
+
+## Placement patterns
+
+### Large system prompt shared across many requests
+
+Put a breakpoint on the last system text block. If there are tools, they render before system — the marker on the last system block caches tools + system together.
+
+```json
+"system": [
+  {"type": "text", "text": "<large shared prompt>", "cache_control": {"type": "ephemeral"}}
+]
+```
+
+### Multi-turn conversations
+
+Put a breakpoint on the last content block of the most-recently-appended turn. Each subsequent request reuses the entire prior conversation prefix. Earlier breakpoints remain valid read points, so hits accrue incrementally as the conversation grows.
+
+```json
+// Last content block of the last user turn
+messages[-1].content[-1].cache_control = {"type": "ephemeral"}
+```
+
+### Shared prefix, varying suffix
+
+Many requests share a large fixed preamble (few-shot examples, retrieved docs, instructions) but differ in the final question. Put the breakpoint at the end of the **shared** portion, not at the end of the whole prompt — otherwise every request writes a distinct cache entry and nothing is ever read.
+
+```json
+"messages": [{"role": "user", "content": [
+  {"type": "text", "text": "<shared context>", "cache_control": {"type": "ephemeral"}},
+  {"type": "text", "text": "<varying question>"}  // no marker — differs every time
+]}]
+```
+
+### Prompts that change from the beginning every time
+
+Don't cache. If the first 1K tokens differ per request, there is no reusable prefix. Adding `cache_control` only pays the cache-write premium with zero reads. Leave it off.
+
+---
+
+## Architectural guidance
+
+These are the decisions that matter more than marker placement. Fix these first.
+
+**Keep the system prompt frozen.** Don't interpolate "current date: X", "mode: Y", "user name: Z" into the system prompt — those sit at the front of the prefix and invalidate everything downstream. Inject dynamic context as a user or assistant message later in `messages`. A message at turn 5 invalidates nothing before turn 5.
+
+**Don't change tools or model mid-conversation.** Tools render at position 0; adding, removing, or reordering a tool invalidates the entire cache. Same for switching models (caches are model-scoped). If you need "modes", don't swap the tool set — give Claude a tool that records the mode transition, or pass the mode as message content. Serialize tools deterministically (sort by name).
+
+**Fork operations must reuse the parent's exact prefix.** Side computations (summarization, compaction, sub-agents) often spin up a separate API call. If the fork rebuilds `system` / `tools` / `model` with any difference, it misses the parent's cache entirely. Copy the parent's `system`, `tools`, and `model` verbatim, then append fork-specific content at the end.
+
+---
+
+## Silent invalidators
+
+When reviewing code, grep for these inside anything that feeds the prompt prefix:
+
+| Pattern | Why it breaks caching |
+|---|---|
+| `datetime.now()` / `Date.now()` / `time.time()` in system prompt | Prefix changes every request |
+| `uuid4()` / `crypto.randomUUID()` / request IDs early in content | Same — every request is unique |
+| `json.dumps(d)` without `sort_keys=True` / iterating a `set` | Non-deterministic serialization → prefix bytes differ |
+| f-string interpolating session/user ID into system prompt | Per-user prefix; no cross-user sharing |
+| Conditional system sections (`if flag: system += ...`) | Every flag combination is a distinct prefix |
+| `tools=build_tools(user)` where set varies per user | Tools render at position 0; nothing caches across users |
+
+Fix by moving the dynamic piece after the last breakpoint, making it deterministic, or deleting it if it's not load-bearing.
+
+---
+
+## API reference
+
+```json
+"cache_control": {"type": "ephemeral"}              // 5-minute TTL (default)
+"cache_control": {"type": "ephemeral", "ttl": "1h"} // 1-hour TTL
+```
+
+- Max **4** `cache_control` breakpoints per request.
+- Goes on any content block: system text blocks, tool definitions, message content blocks (`text`, `image`, `tool_use`, `tool_result`, `document`).
+- Top-level `cache_control` on `messages.create()` auto-places on the last cacheable block — simplest option when you don't need fine-grained placement.
+- Minimum cacheable prefix is model-dependent. Shorter prefixes silently won't cache even with a marker — no error, just `cache_creation_input_tokens: 0`:
+
+| Model | Minimum |
+|---|---:|
+| Opus 4.6, Opus 4.5, Haiku 4.5 | 4096 tokens |
+| Sonnet 4.6, Haiku 3.5, Haiku 3 | 2048 tokens |
+| Sonnet 4.5, Sonnet 4.1, Sonnet 4, Sonnet 3.7 | 1024 tokens |
+
+A 3K-token prompt caches on Sonnet 4.5 but silently won't on Opus 4.6.
+
+**Economics:** Cache reads cost ~0.1× base input price. Cache writes cost **1.25× for 5-minute TTL, 2× for 1-hour TTL**. Break-even depends on TTL: with 5-minute TTL, two requests break even (1.25× + 0.1× = 1.35× vs 2× uncached); with 1-hour TTL, you need at least three requests (2× + 0.2× = 2.2× vs 3× uncached). The 1-hour TTL keeps entries alive across gaps in bursty traffic, but the doubled write cost means it needs more reads to pay off.
+
+---
+
+## Verifying cache hits
+
+The response `usage` object reports cache activity:
+
+| Field | Meaning |
+|---|---|
+| `cache_creation_input_tokens` | Tokens written to cache this request (you paid the ~1.25× write premium) |
+| `cache_read_input_tokens` | Tokens served from cache this request (you paid ~0.1×) |
+| `input_tokens` | Tokens processed at full price (not cached) |
+
+If `cache_read_input_tokens` is zero across repeated requests with identical prefixes, a silent invalidator is at work — diff the rendered prompt bytes between two requests to find it.
+
+**`input_tokens` is the uncached remainder only.** Total prompt size = `input_tokens + cache_creation_input_tokens + cache_read_input_tokens`. If your agent ran for hours but `input_tokens` shows 4K, the rest was served from cache — check the sum, not the single field.
+
+Language-specific access: `response.usage.cache_read_input_tokens` (Python/TS/Ruby), `$message->usage->cacheReadInputTokens` (PHP), `resp.Usage.CacheReadInputTokens` (Go/C#), `.usage().cacheReadInputTokens()` (Java).
+
+---
+
+## Invalidation hierarchy
+
+Not every parameter change invalidates everything. The API has three cache tiers, and changes only invalidate their own tier and below:
+
+| Change | Tools cache | System cache | Messages cache |
+|---|:---:|:---:|:---:|
+| Tool definitions (add/remove/reorder) | ❌ | ❌ | ❌ |
+| Model switch | ❌ | ❌ | ❌ |
+| `speed`, web-search, citations toggle | ✅ | ❌ | ❌ |
+| System prompt content | ✅ | ❌ | ❌ |
+| `tool_choice`, images, `thinking` enable/disable | ✅ | ✅ | ❌ |
+| Message content | ✅ | ✅ | ❌ |
+
+Implication: you can change `tool_choice` per-request or toggle `thinking` without losing the tools+system cache. Don't over-worry about these — only tool-definition and model changes force a full rebuild.
+
+---
+
+## 20-block lookback window
+
+Each breakpoint walks backward **at most 20 content blocks** to find a prior cache entry. If a single turn adds more than 20 blocks (common in agentic loops with many tool_use/tool_result pairs), the next request's breakpoint won't find the previous cache and silently misses.
+
+Fix: place an intermediate breakpoint every ~15 blocks in long turns, or put the marker on a block that's within 20 of the previous turn's last cached block.
+
+---
+
+## Concurrent-request timing
+
+A cache entry becomes readable only after the first response **begins streaming**. N parallel requests with identical prefixes all pay full price — none can read what the others are still writing.
+
+For fan-out patterns: send 1 request, await the first streamed token (not the full response), then fire the remaining N−1. They'll read the cache the first one just wrote.

--- a/.claude/skills/claude-api/shared/tool-use-concepts.md
+++ b/.claude/skills/claude-api/shared/tool-use-concepts.md
@@ -1,0 +1,327 @@
+# Tool Use Concepts
+
+This file covers the conceptual foundations of tool use with the Claude API. For language-specific code examples, see the `python/`, `typescript/`, or other language folders. For decision heuristics on which tools to expose, how to manage context in long-running agents, and caching strategy, see `agent-design.md`.
+
+## User-Defined Tools
+
+### Tool Definition Structure
+
+> **Note:** When using the Tool Runner (beta), tool schemas are generated automatically from your function signatures (Python), Zod schemas (TypeScript), annotated classes (Java), `jsonschema` struct tags (Go), or `BaseTool` subclasses (Ruby). The raw JSON schema format below is for the manual approach — including PHP's `BetaRunnableTool`, which wraps a run closure around a hand-written schema — or SDKs without tool runner support.
+
+Each tool requires a name, description, and JSON Schema for its inputs:
+
+```json
+{
+  "name": "get_weather",
+  "description": "Get current weather for a location",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "location": {
+        "type": "string",
+        "description": "City and state, e.g., San Francisco, CA"
+      },
+      "unit": {
+        "type": "string",
+        "enum": ["celsius", "fahrenheit"],
+        "description": "Temperature unit"
+      }
+    },
+    "required": ["location"]
+  }
+}
+```
+
+**Best practices for tool definitions:**
+
+- Use clear, descriptive names (e.g., `get_weather`, `search_database`, `send_email`)
+- Write detailed descriptions — Claude uses these to decide when to use the tool
+- Include descriptions for each property
+- Use `enum` for parameters with a fixed set of values
+- Mark truly required parameters in `required`; make others optional with defaults
+
+---
+
+### Tool Choice Options
+
+Control when Claude uses tools:
+
+| Value                             | Behavior                                      |
+| --------------------------------- | --------------------------------------------- |
+| `{"type": "auto"}`                | Claude decides whether to use tools (default) |
+| `{"type": "any"}`                 | Claude must use at least one tool             |
+| `{"type": "tool", "name": "..."}` | Claude must use the specified tool            |
+| `{"type": "none"}`                | Claude cannot use tools                       |
+
+Any `tool_choice` value can also include `"disable_parallel_tool_use": true` to force Claude to use at most one tool per response. By default, Claude may request multiple tool calls in a single response.
+
+---
+
+### Tool Runner vs Manual Loop
+
+**Tool Runner (Recommended):** The SDK's tool runner handles the agentic loop automatically — it calls the API, detects tool use requests, executes your tool functions, feeds results back to Claude, and repeats until Claude stops calling tools. Available in Python, TypeScript, Java, Go, Ruby, and PHP SDKs (beta). The Python SDK also provides MCP conversion helpers (`anthropic.lib.tools.mcp`) to convert MCP tools, prompts, and resources for use with the tool runner — see `python/claude-api/tool-use.md` for details.
+
+**Manual Agentic Loop:** Use when you need fine-grained control over the loop (e.g., custom logging, conditional tool execution, human-in-the-loop approval). Loop until `stop_reason == "end_turn"`, always append the full `response.content` to preserve tool_use blocks, and ensure each `tool_result` includes the matching `tool_use_id`.
+
+**Stop reasons for server-side tools:** When using server-side tools (code execution, web search, etc.), the API runs a server-side sampling loop. If this loop reaches its default limit of 10 iterations, the response will have `stop_reason: "pause_turn"`. To continue, re-send the user message and assistant response and make another API request — the server will resume where it left off. Do NOT add an extra user message like "Continue." — the API detects the trailing `server_tool_use` block and knows to resume automatically.
+
+```python
+# Handle pause_turn in your agentic loop
+if response.stop_reason == "pause_turn":
+    messages = [
+        {"role": "user", "content": user_query},
+        {"role": "assistant", "content": response.content},
+    ]
+    # Make another API request — server resumes automatically
+    response = client.messages.create(
+        model="claude-opus-4-6", messages=messages, tools=tools
+    )
+```
+
+Set a `max_continuations` limit (e.g., 5) to prevent infinite loops. For the full guide, see: `https://platform.claude.com/docs/en/build-with-claude/handling-stop-reasons`
+
+> **Security:** The tool runner executes your tool functions automatically whenever Claude requests them. For tools with side effects (sending emails, modifying databases, financial transactions), validate inputs within your tool functions and consider requiring confirmation for destructive operations. Use the manual agentic loop if you need human-in-the-loop approval before each tool execution.
+
+---
+
+### Handling Tool Results
+
+When Claude uses a tool, the response contains a `tool_use` block. You must:
+
+1. Execute the tool with the provided input
+2. Send the result back in a `tool_result` message
+3. Continue the conversation
+
+**Error handling in tool results:** When a tool execution fails, set `"is_error": true` and provide an informative error message. Claude will typically acknowledge the error and either try a different approach or ask for clarification.
+
+**Multiple tool calls:** Claude can request multiple tools in a single response. Handle them all before continuing — send all results back in a single `user` message.
+
+---
+
+## Server-Side Tools: Code Execution
+
+The code execution tool lets Claude run code in a secure, sandboxed container. Unlike user-defined tools, server-side tools run on Anthropic's infrastructure — you don't execute anything client-side. Just include the tool definition and Claude handles the rest.
+
+### Key Facts
+
+- Runs in an isolated container (1 CPU, 5 GiB RAM, 5 GiB disk)
+- No internet access (fully sandboxed)
+- Python 3.11 with data science libraries pre-installed
+- Containers persist for 30 days and can be reused across requests
+- Free when used with web search/web fetch tools; otherwise $0.05/hour after 1,550 free hours/month per organization
+
+### Tool Definition
+
+The tool requires no schema — just declare it in the `tools` array:
+
+```json
+{
+  "type": "code_execution_20260120",
+  "name": "code_execution"
+}
+```
+
+Claude automatically gains access to `bash_code_execution` (run shell commands) and `text_editor_code_execution` (create/view/edit files).
+
+### Pre-installed Python Libraries
+
+- **Data science**: pandas, numpy, scipy, scikit-learn, statsmodels
+- **Visualization**: matplotlib, seaborn
+- **File processing**: openpyxl, xlsxwriter, pillow, pypdf, pdfplumber, python-docx, python-pptx
+- **Math**: sympy, mpmath
+- **Utilities**: tqdm, python-dateutil, pytz, sqlite3
+
+Additional packages can be installed at runtime via `pip install`.
+
+### Supported File Types for Upload
+
+| Type   | Extensions                         |
+| ------ | ---------------------------------- |
+| Data   | CSV, Excel (.xlsx/.xls), JSON, XML |
+| Images | JPEG, PNG, GIF, WebP               |
+| Text   | .txt, .md, .py, .js, etc.          |
+
+### Container Reuse
+
+Reuse containers across requests to maintain state (files, installed packages, variables). Extract the `container_id` from the first response and pass it to subsequent requests.
+
+### Response Structure
+
+The response contains interleaved text and tool result blocks:
+
+- `text` — Claude's explanation
+- `server_tool_use` — What Claude is doing
+- `bash_code_execution_tool_result` — Code execution output (check `return_code` for success/failure)
+- `text_editor_code_execution_tool_result` — File operation results
+
+> **Security:** Always sanitize filenames with `os.path.basename()` / `path.basename()` before writing downloaded files to disk to prevent path traversal attacks. Write files to a dedicated output directory.
+
+---
+
+## Server-Side Tools: Web Search and Web Fetch
+
+Web search and web fetch let Claude search the web and retrieve page content. They run server-side — just include the tool definitions and Claude handles queries, fetching, and result processing automatically.
+
+### Tool Definitions
+
+```json
+[
+  { "type": "web_search_20260209", "name": "web_search" },
+  { "type": "web_fetch_20260209", "name": "web_fetch" }
+]
+```
+
+### Dynamic Filtering (Opus 4.6 / Sonnet 4.6)
+
+The `web_search_20260209` and `web_fetch_20260209` versions support **dynamic filtering** — Claude writes and executes code to filter search results before they reach the context window, improving accuracy and token efficiency. Dynamic filtering is built into these tool versions and activates automatically; you do not need to separately declare the `code_execution` tool or pass any beta header.
+
+```json
+{
+  "tools": [
+    { "type": "web_search_20260209", "name": "web_search" },
+    { "type": "web_fetch_20260209", "name": "web_fetch" }
+  ]
+}
+```
+
+Without dynamic filtering, the previous `web_search_20250305` version is also available.
+
+> **Note:** Only include the standalone `code_execution` tool when your application needs code execution for its own purposes (data analysis, file processing, visualization) independent of web search. Including it alongside `_20260209` web tools creates a second execution environment that can confuse the model.
+
+---
+
+## Server-Side Tools: Programmatic Tool Calling
+
+With standard tool use, each tool call is a round trip: Claude calls, the result enters Claude's context, Claude reasons, then calls the next tool. Chained calls accumulate latency and tokens — most of that intermediate data is never needed again.
+
+Programmatic tool calling lets Claude compose those calls into a script. The script runs in the code execution container; when it invokes a tool, the container pauses, the call executes, and the result returns to the running code (not to Claude's context). The script processes it with normal control flow. Only the final output returns to Claude. Use it when chaining many tool calls or when intermediate results are large and should be filtered before reaching the context window.
+
+For full documentation, use WebFetch:
+
+- URL: `https://platform.claude.com/docs/en/agents-and-tools/tool-use/programmatic-tool-calling`
+
+---
+
+## Server-Side Tools: Tool Search
+
+The tool search tool lets Claude dynamically discover tools from large libraries without loading all definitions into the context window. Use it when you have many tools but only a few are relevant to any given request. Discovered tool schemas are appended to the request, not swapped in — this preserves the prompt cache (see `agent-design.md` §Caching for Agents).
+
+For full documentation, use WebFetch:
+
+- URL: `https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool`
+
+---
+
+## Skills
+
+Skills package task-specific instructions that Claude loads only when relevant. Each skill is a folder containing a `SKILL.md` file. The skill's short description sits in context by default; Claude reads the full file when the current task calls for it. Use skills to keep specialized instructions out of the base system prompt without losing discoverability.
+
+For full documentation, use WebFetch:
+
+- URL: `https://platform.claude.com/docs/en/agents-and-tools/skills`
+
+---
+
+## Tool Use Examples
+
+You can provide sample tool calls directly in your tool definitions to demonstrate usage patterns and reduce parameter errors. This helps Claude understand how to correctly format tool inputs, especially for tools with complex schemas.
+
+For full documentation, use WebFetch:
+
+- URL: `https://platform.claude.com/docs/en/agents-and-tools/tool-use/implement-tool-use`
+
+---
+
+## Server-Side Tools: Computer Use
+
+Computer use lets Claude interact with a desktop environment (screenshots, mouse, keyboard). It can be Anthropic-hosted (server-side, like code execution) or self-hosted (you provide the environment and execute actions client-side).
+
+For full documentation, use WebFetch:
+
+- URL: `https://platform.claude.com/docs/en/agents-and-tools/computer-use/overview`
+
+---
+
+## Context Editing
+
+Context editing clears stale tool results and thinking blocks from the transcript as a long-running agent accumulates turns. Unlike compaction (which summarizes), context editing prunes — the cleared content is removed, not replaced. Use it when old tool outputs are no longer relevant and you want to keep the transcript lean without losing the conversation structure. Thresholds for what to clear are configurable.
+
+For full documentation, use WebFetch:
+
+- URL: `https://platform.claude.com/docs/en/build-with-claude/context-editing`
+
+---
+
+## Client-Side Tools: Memory
+
+The memory tool enables Claude to store and retrieve information across conversations through a memory file directory. Claude can create, read, update, and delete files that persist between sessions.
+
+### Key Facts
+
+- Client-side tool — you control storage via your implementation
+- Supports commands: `view`, `create`, `str_replace`, `insert`, `delete`, `rename`
+- Operates on files in a `/memories` directory
+- The Python, TypeScript, and Java SDKs provide helper classes/functions for implementing the memory backend
+
+> **Security:** Never store API keys, passwords, tokens, or other secrets in memory files. Be cautious with personally identifiable information (PII) — check data privacy regulations (GDPR, CCPA) before persisting user data. The reference implementations have no built-in access control; in multi-user systems, implement per-user memory directories and authentication in your tool handlers.
+
+For full implementation examples, use WebFetch:
+
+- Docs: `https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool.md`
+
+---
+
+## Structured Outputs
+
+Structured outputs constrain Claude's responses to follow a specific JSON schema, guaranteeing valid, parseable output. This is not a separate tool — it enhances the Messages API response format and/or tool parameter validation.
+
+Two features are available:
+
+- **JSON outputs** (`output_config.format`): Control Claude's response format
+- **Strict tool use** (`strict: true`): Guarantee valid tool parameter schemas
+
+**Supported models:** Claude Opus 4.6, Claude Sonnet 4.6, and Claude Haiku 4.5. Legacy models (Claude Opus 4.5, Claude Opus 4.1) also support structured outputs.
+
+> **Recommended:** Use `client.messages.parse()` which automatically validates responses against your schema. When using `messages.create()` directly, use `output_config: {format: {...}}`. The `output_format` convenience parameter is also accepted by some SDK methods (e.g., `.parse()`), but `output_config.format` is the canonical API-level parameter.
+
+### JSON Schema Limitations
+
+**Supported:**
+
+- Basic types: object, array, string, integer, number, boolean, null
+- `enum`, `const`, `anyOf`, `allOf`, `$ref`/`$def`
+- String formats: `date-time`, `time`, `date`, `duration`, `email`, `hostname`, `uri`, `ipv4`, `ipv6`, `uuid`
+- `additionalProperties: false` (required for all objects)
+
+**Not supported:**
+
+- Recursive schemas
+- Numerical constraints (`minimum`, `maximum`, `multipleOf`)
+- String constraints (`minLength`, `maxLength`)
+- Complex array constraints
+- `additionalProperties` set to anything other than `false`
+
+The Python and TypeScript SDKs automatically handle unsupported constraints by removing them from the schema sent to the API and validating them client-side.
+
+### Important Notes
+
+- **First request latency**: New schemas incur a one-time compilation cost. Subsequent requests with the same schema use a 24-hour cache.
+- **Refusals**: If Claude refuses for safety reasons (`stop_reason: "refusal"`), the output may not match your schema.
+- **Token limits**: If `stop_reason: "max_tokens"`, output may be incomplete. Increase `max_tokens`.
+- **Incompatible with**: Citations (returns 400 error), message prefilling.
+- **Works with**: Batches API, streaming, token counting, extended thinking.
+
+---
+
+## Tips for Effective Tool Use
+
+1. **Provide detailed descriptions**: Claude relies heavily on descriptions to understand when and how to use tools
+2. **Use specific tool names**: `get_current_weather` is better than `weather`
+3. **Validate inputs**: Always validate tool inputs before execution
+4. **Handle errors gracefully**: Return informative error messages so Claude can adapt
+5. **Limit tool count**: Too many tools can confuse the model — keep the set focused
+6. **Test tool interactions**: Verify Claude uses tools correctly in various scenarios
+
+For detailed tool use documentation, use WebFetch:
+
+- URL: `https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview`

--- a/.claude/skills/claude-api/typescript/claude-api/README.md
+++ b/.claude/skills/claude-api/typescript/claude-api/README.md
@@ -1,0 +1,333 @@
+# Claude API — TypeScript
+
+## Installation
+
+```bash
+npm install @anthropic-ai/sdk
+```
+
+## Client Initialization
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+// Default (uses ANTHROPIC_API_KEY env var)
+const client = new Anthropic();
+
+// Explicit API key
+const client = new Anthropic({ apiKey: "your-api-key" });
+```
+
+---
+
+## Basic Message Request
+
+```typescript
+const response = await client.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  messages: [{ role: "user", content: "What is the capital of France?" }],
+});
+// response.content is ContentBlock[] — a discriminated union. Narrow by .type
+// before accessing .text (TypeScript will error on content[0].text without this).
+for (const block of response.content) {
+  if (block.type === "text") {
+    console.log(block.text);
+  }
+}
+```
+
+---
+
+## System Prompts
+
+```typescript
+const response = await client.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  system:
+    "You are a helpful coding assistant. Always provide examples in Python.",
+  messages: [{ role: "user", content: "How do I read a JSON file?" }],
+});
+```
+
+---
+
+## Vision (Images)
+
+### URL
+
+```typescript
+const response = await client.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  messages: [
+    {
+      role: "user",
+      content: [
+        {
+          type: "image",
+          source: { type: "url", url: "https://example.com/image.png" },
+        },
+        { type: "text", text: "Describe this image" },
+      ],
+    },
+  ],
+});
+```
+
+### Base64
+
+```typescript
+import fs from "fs";
+
+const imageData = fs.readFileSync("image.png").toString("base64");
+
+const response = await client.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  messages: [
+    {
+      role: "user",
+      content: [
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: imageData },
+        },
+        { type: "text", text: "What's in this image?" },
+      ],
+    },
+  ],
+});
+```
+
+---
+
+## Prompt Caching
+
+**Caching is a prefix match** — any byte change anywhere in the prefix invalidates everything after it. For placement patterns, architectural guidance (frozen system prompt, deterministic tool order, where to put volatile content), and the silent-invalidator audit checklist, read `shared/prompt-caching.md`.
+
+### Automatic Caching (Recommended)
+
+Use top-level `cache_control` to automatically cache the last cacheable block in the request:
+
+```typescript
+const response = await client.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  cache_control: { type: "ephemeral" }, // auto-caches the last cacheable block
+  system: "You are an expert on this large document...",
+  messages: [{ role: "user", content: "Summarize the key points" }],
+});
+```
+
+### Manual Cache Control
+
+For fine-grained control, add `cache_control` to specific content blocks:
+
+```typescript
+const response = await client.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  system: [
+    {
+      type: "text",
+      text: "You are an expert on this large document...",
+      cache_control: { type: "ephemeral" }, // default TTL is 5 minutes
+    },
+  ],
+  messages: [{ role: "user", content: "Summarize the key points" }],
+});
+
+// With explicit TTL (time-to-live)
+const response2 = await client.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  system: [
+    {
+      type: "text",
+      text: "You are an expert on this large document...",
+      cache_control: { type: "ephemeral", ttl: "1h" }, // 1 hour TTL
+    },
+  ],
+  messages: [{ role: "user", content: "Summarize the key points" }],
+});
+```
+
+### Verifying Cache Hits
+
+```typescript
+console.log(response.usage.cache_creation_input_tokens); // tokens written to cache (~1.25x cost)
+console.log(response.usage.cache_read_input_tokens);     // tokens served from cache (~0.1x cost)
+console.log(response.usage.input_tokens);                // uncached tokens (full cost)
+```
+
+If `cache_read_input_tokens` is zero across repeated identical-prefix requests, a silent invalidator is at work — `Date.now()` or a UUID in the system prompt, non-deterministic key ordering, or a varying tool set. See `shared/prompt-caching.md` for the full audit table.
+
+---
+
+## Extended Thinking
+
+> **Opus 4.6 and Sonnet 4.6:** Use adaptive thinking. `budget_tokens` is deprecated on both Opus 4.6 and Sonnet 4.6.
+> **Older models:** Use `thinking: {type: "enabled", budget_tokens: N}` (must be < `max_tokens`, min 1024).
+
+```typescript
+// Opus 4.6: adaptive thinking (recommended)
+const response = await client.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  thinking: { type: "adaptive" },
+  output_config: { effort: "high" }, // low | medium | high | max
+  messages: [
+    { role: "user", content: "Solve this math problem step by step..." },
+  ],
+});
+
+for (const block of response.content) {
+  if (block.type === "thinking") {
+    console.log("Thinking:", block.thinking);
+  } else if (block.type === "text") {
+    console.log("Response:", block.text);
+  }
+}
+```
+
+---
+
+## Error Handling
+
+Use the SDK's typed exception classes — never check error messages with string matching:
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+try {
+  const response = await client.messages.create({...});
+} catch (error) {
+  if (error instanceof Anthropic.BadRequestError) {
+    console.error("Bad request:", error.message);
+  } else if (error instanceof Anthropic.AuthenticationError) {
+    console.error("Invalid API key");
+  } else if (error instanceof Anthropic.RateLimitError) {
+    console.error("Rate limited - retry later");
+  } else if (error instanceof Anthropic.APIError) {
+    console.error(`API error ${error.status}:`, error.message);
+  }
+}
+```
+
+All classes extend `Anthropic.APIError` with a typed `status` field. Check from most specific to least specific. See [shared/error-codes.md](../../shared/error-codes.md) for the full error code reference.
+
+---
+
+## Multi-Turn Conversations
+
+The API is stateless — send the full conversation history each time. Use `Anthropic.MessageParam[]` to type the messages array:
+
+```typescript
+const messages: Anthropic.MessageParam[] = [
+  { role: "user", content: "My name is Alice." },
+  { role: "assistant", content: "Hello Alice! Nice to meet you." },
+  { role: "user", content: "What's my name?" },
+];
+
+const response = await client.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  messages: messages,
+});
+```
+
+**Rules:**
+
+- Consecutive same-role messages are allowed — the API combines them into a single turn
+- First message must be `user`
+- Use SDK types (`Anthropic.MessageParam`, `Anthropic.Message`, `Anthropic.Tool`, etc.) for all API data structures — don't redefine equivalent interfaces
+
+---
+
+### Compaction (long conversations)
+
+> **Beta, Opus 4.6 and Sonnet 4.6.** When conversations approach the 200K context window, compaction automatically summarizes earlier context server-side. The API returns a `compaction` block; you must pass it back on subsequent requests — append `response.content`, not just the text.
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic();
+const messages: Anthropic.Beta.BetaMessageParam[] = [];
+
+async function chat(userMessage: string): Promise<string> {
+  messages.push({ role: "user", content: userMessage });
+
+  const response = await client.beta.messages.create({
+    betas: ["compact-2026-01-12"],
+    model: "claude-opus-4-6",
+    max_tokens: 16000,
+    messages,
+    context_management: {
+      edits: [{ type: "compact_20260112" }],
+    },
+  });
+
+  // Append full content — compaction blocks must be preserved
+  messages.push({ role: "assistant", content: response.content });
+
+  const textBlock = response.content.find(
+    (b): b is Anthropic.Beta.BetaTextBlock => b.type === "text",
+  );
+  return textBlock?.text ?? "";
+}
+
+// Compaction triggers automatically when context grows large
+console.log(await chat("Help me build a Python web scraper"));
+console.log(await chat("Add support for JavaScript-rendered pages"));
+console.log(await chat("Now add rate limiting and error handling"));
+```
+
+---
+
+## Stop Reasons
+
+The `stop_reason` field in the response indicates why the model stopped generating:
+
+| Value           | Meaning                                                         |
+| --------------- | --------------------------------------------------------------- |
+| `end_turn`      | Claude finished its response naturally                          |
+| `max_tokens`    | Hit the `max_tokens` limit — increase it or use streaming       |
+| `stop_sequence` | Hit a custom stop sequence                                      |
+| `tool_use`      | Claude wants to call a tool — execute it and continue           |
+| `pause_turn`    | Model paused and can be resumed (agentic flows)                 |
+| `refusal`       | Claude refused for safety reasons — output may not match schema |
+
+---
+
+## Cost Optimization Strategies
+
+### 1. Use Prompt Caching for Repeated Context
+
+```typescript
+// Automatic caching (simplest — caches the last cacheable block)
+const response = await client.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  cache_control: { type: "ephemeral" },
+  system: largeDocumentText, // e.g., 50KB of context
+  messages: [{ role: "user", content: "Summarize the key points" }],
+});
+
+// First request: full cost
+// Subsequent requests: ~90% cheaper for cached portion
+```
+
+### 2. Use Token Counting Before Requests
+
+```typescript
+const countResponse = await client.messages.countTokens({
+  model: "claude-opus-4-6",
+  messages: messages,
+  system: system,
+});
+
+const estimatedInputCost = countResponse.input_tokens * 0.000005; // $5/1M tokens
+console.log(`Estimated input cost: $${estimatedInputCost.toFixed(4)}`);
+```

--- a/.claude/skills/claude-api/typescript/claude-api/batches.md
+++ b/.claude/skills/claude-api/typescript/claude-api/batches.md
@@ -1,0 +1,106 @@
+# Message Batches API — TypeScript
+
+The Batches API (`POST /v1/messages/batches`) processes Messages API requests asynchronously at 50% of standard prices.
+
+## Key Facts
+
+- Up to 100,000 requests or 256 MB per batch
+- Most batches complete within 1 hour; maximum 24 hours
+- Results available for 29 days after creation
+- 50% cost reduction on all token usage
+- All Messages API features supported (vision, tools, caching, etc.)
+
+---
+
+## Create a Batch
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic();
+
+const messageBatch = await client.messages.batches.create({
+  requests: [
+    {
+      custom_id: "request-1",
+      params: {
+        model: "claude-opus-4-6",
+        max_tokens: 16000,
+        messages: [
+          { role: "user", content: "Summarize climate change impacts" },
+        ],
+      },
+    },
+    {
+      custom_id: "request-2",
+      params: {
+        model: "claude-opus-4-6",
+        max_tokens: 16000,
+        messages: [
+          { role: "user", content: "Explain quantum computing basics" },
+        ],
+      },
+    },
+  ],
+});
+
+console.log(`Batch ID: ${messageBatch.id}`);
+console.log(`Status: ${messageBatch.processing_status}`);
+```
+
+---
+
+## Poll for Completion
+
+```typescript
+let batch;
+while (true) {
+  batch = await client.messages.batches.retrieve(messageBatch.id);
+  if (batch.processing_status === "ended") break;
+  console.log(
+    `Status: ${batch.processing_status}, processing: ${batch.request_counts.processing}`,
+  );
+  await new Promise((resolve) => setTimeout(resolve, 60_000));
+}
+
+console.log("Batch complete!");
+console.log(`Succeeded: ${batch.request_counts.succeeded}`);
+console.log(`Errored: ${batch.request_counts.errored}`);
+```
+
+---
+
+## Retrieve Results
+
+```typescript
+for await (const result of await client.messages.batches.results(
+  messageBatch.id,
+)) {
+  switch (result.result.type) {
+    case "succeeded":
+      console.log(
+        `[${result.custom_id}] ${result.result.message.content[0].text.slice(0, 100)}`,
+      );
+      break;
+    case "errored":
+      if (result.result.error.type === "invalid_request") {
+        console.log(`[${result.custom_id}] Validation error - fix and retry`);
+      } else {
+        console.log(`[${result.custom_id}] Server error - safe to retry`);
+      }
+      break;
+    case "expired":
+      console.log(`[${result.custom_id}] Expired - resubmit`);
+      break;
+  }
+}
+```
+
+---
+
+## Cancel a Batch
+
+```typescript
+const cancelled = await client.messages.batches.cancel(messageBatch.id);
+console.log(`Status: ${cancelled.processing_status}`); // "canceling"
+```

--- a/.claude/skills/claude-api/typescript/claude-api/files-api.md
+++ b/.claude/skills/claude-api/typescript/claude-api/files-api.md
@@ -1,0 +1,98 @@
+# Files API — TypeScript
+
+The Files API uploads files for use in Messages API requests. Reference files via `file_id` in content blocks, avoiding re-uploads across multiple API calls.
+
+**Beta:** Pass `betas: ["files-api-2025-04-14"]` in your API calls (the SDK sets the required header automatically).
+
+## Key Facts
+
+- Maximum file size: 500 MB
+- Total storage: 100 GB per organization
+- Files persist until deleted
+- File operations (upload, list, delete) are free; content used in messages is billed as input tokens
+- Not available on Amazon Bedrock or Google Vertex AI
+
+---
+
+## Upload a File
+
+```typescript
+import Anthropic, { toFile } from "@anthropic-ai/sdk";
+import fs from "fs";
+
+const client = new Anthropic();
+
+const uploaded = await client.beta.files.upload({
+  file: await toFile(fs.createReadStream("report.pdf"), undefined, {
+    type: "application/pdf",
+  }),
+  betas: ["files-api-2025-04-14"],
+});
+
+console.log(`File ID: ${uploaded.id}`);
+console.log(`Size: ${uploaded.size_bytes} bytes`);
+```
+
+---
+
+## Use a File in Messages
+
+### PDF / Text Document
+
+```typescript
+const response = await client.beta.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  messages: [
+    {
+      role: "user",
+      content: [
+        { type: "text", text: "Summarize the key findings in this report." },
+        {
+          type: "document",
+          source: { type: "file", file_id: uploaded.id },
+          title: "Q4 Report",
+          citations: { enabled: true },
+        },
+      ],
+    },
+  ],
+  betas: ["files-api-2025-04-14"],
+});
+
+console.log(response.content[0].text);
+```
+
+---
+
+## Manage Files
+
+### List Files
+
+```typescript
+const files = await client.beta.files.list({
+  betas: ["files-api-2025-04-14"],
+});
+for (const f of files.data) {
+  console.log(`${f.id}: ${f.filename} (${f.size_bytes} bytes)`);
+}
+```
+
+### Delete a File
+
+```typescript
+await client.beta.files.delete("file_011CNha8iCJcU1wXNR6q4V8w", {
+  betas: ["files-api-2025-04-14"],
+});
+```
+
+### Download a File
+
+```typescript
+const response = await client.beta.files.download(
+  "file_011CNha8iCJcU1wXNR6q4V8w",
+  { betas: ["files-api-2025-04-14"] },
+);
+const content = Buffer.from(await response.arrayBuffer());
+await fs.promises.writeFile("output.txt", content);
+```

--- a/.claude/skills/claude-api/typescript/claude-api/streaming.md
+++ b/.claude/skills/claude-api/typescript/claude-api/streaming.md
@@ -1,0 +1,178 @@
+# Streaming — TypeScript
+
+## Quick Start
+
+```typescript
+const stream = client.messages.stream({
+  model: "claude-opus-4-6",
+  max_tokens: 64000,
+  messages: [{ role: "user", content: "Write a story" }],
+});
+
+for await (const event of stream) {
+  if (
+    event.type === "content_block_delta" &&
+    event.delta.type === "text_delta"
+  ) {
+    process.stdout.write(event.delta.text);
+  }
+}
+```
+
+---
+
+## Handling Different Content Types
+
+> **Opus 4.6:** Use `thinking: {type: "adaptive"}`. On older models, use `thinking: {type: "enabled", budget_tokens: N}` instead.
+
+```typescript
+const stream = client.messages.stream({
+  model: "claude-opus-4-6",
+  max_tokens: 64000,
+  thinking: { type: "adaptive" },
+  messages: [{ role: "user", content: "Analyze this problem" }],
+});
+
+for await (const event of stream) {
+  switch (event.type) {
+    case "content_block_start":
+      switch (event.content_block.type) {
+        case "thinking":
+          console.log("\n[Thinking...]");
+          break;
+        case "text":
+          console.log("\n[Response:]");
+          break;
+      }
+      break;
+    case "content_block_delta":
+      switch (event.delta.type) {
+        case "thinking_delta":
+          process.stdout.write(event.delta.thinking);
+          break;
+        case "text_delta":
+          process.stdout.write(event.delta.text);
+          break;
+      }
+      break;
+  }
+}
+```
+
+---
+
+## Streaming with Tool Use (Tool Runner)
+
+Use the tool runner with `stream: true`. The outer loop iterates over tool runner iterations (messages), the inner loop processes stream events:
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+import { betaZodTool } from "@anthropic-ai/sdk/helpers/beta/zod";
+import { z } from "zod";
+
+const client = new Anthropic();
+
+const getWeather = betaZodTool({
+  name: "get_weather",
+  description: "Get current weather for a location",
+  inputSchema: z.object({
+    location: z.string().describe("City and state, e.g., San Francisco, CA"),
+  }),
+  run: async ({ location }) => `72°F and sunny in ${location}`,
+});
+
+const runner = client.beta.messages.toolRunner({
+  model: "claude-opus-4-6",
+  max_tokens: 64000,
+  tools: [getWeather],
+  messages: [
+    { role: "user", content: "What's the weather in Paris and London?" },
+  ],
+  stream: true,
+});
+
+// Outer loop: each tool runner iteration
+for await (const messageStream of runner) {
+  // Inner loop: stream events for this iteration
+  for await (const event of messageStream) {
+    switch (event.type) {
+      case "content_block_delta":
+        switch (event.delta.type) {
+          case "text_delta":
+            process.stdout.write(event.delta.text);
+            break;
+          case "input_json_delta":
+            // Tool input being streamed
+            break;
+        }
+        break;
+    }
+  }
+}
+```
+
+---
+
+## Getting the Final Message
+
+```typescript
+const stream = client.messages.stream({
+  model: "claude-opus-4-6",
+  max_tokens: 64000,
+  messages: [{ role: "user", content: "Hello" }],
+});
+
+for await (const event of stream) {
+  // Process events...
+}
+
+const finalMessage = await stream.finalMessage();
+console.log(`Tokens used: ${finalMessage.usage.output_tokens}`);
+```
+
+---
+
+## Stream Event Types
+
+| Event Type            | Description                 | When it fires                     |
+| --------------------- | --------------------------- | --------------------------------- |
+| `message_start`       | Contains message metadata   | Once at the beginning             |
+| `content_block_start` | New content block beginning | When a text/tool_use block starts |
+| `content_block_delta` | Incremental content update  | For each token/chunk              |
+| `content_block_stop`  | Content block complete      | When a block finishes             |
+| `message_delta`       | Message-level updates       | Contains `stop_reason`, usage     |
+| `message_stop`        | Message complete            | Once at the end                   |
+
+## Best Practices
+
+1. **Always flush output** — Use `process.stdout.write()` for immediate display
+2. **Handle partial responses** — If the stream is interrupted, you may have incomplete content
+3. **Track token usage** — The `message_delta` event contains usage information
+4. **Use `finalMessage()`** — Get the complete `Anthropic.Message` object even when streaming. Don't wrap `.on()` events in `new Promise()` — `finalMessage()` handles all completion/error/abort states internally
+5. **Buffer for web UIs** — Consider buffering a few tokens before rendering to avoid excessive DOM updates
+6. **Use `stream.on("text", ...)` for deltas** — The `text` event provides just the delta string, simpler than manually filtering `content_block_delta` events
+7. **For agentic loops with streaming** — See the [Streaming Manual Loop](./tool-use.md#streaming-manual-loop) section in tool-use.md for combining `stream()` + `finalMessage()` with a tool-use loop
+
+## Raw SSE Format
+
+If using raw HTTP (not SDKs), the stream returns Server-Sent Events:
+
+```
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_...","type":"message",...}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":12}}
+
+event: message_stop
+data: {"type":"message_stop"}
+```

--- a/.claude/skills/claude-api/typescript/claude-api/tool-use.md
+++ b/.claude/skills/claude-api/typescript/claude-api/tool-use.md
@@ -1,0 +1,527 @@
+# Tool Use — TypeScript
+
+For conceptual overview (tool definitions, tool choice, tips), see [shared/tool-use-concepts.md](../../shared/tool-use-concepts.md).
+
+## Tool Runner (Recommended)
+
+**Beta:** The tool runner is in beta in the TypeScript SDK.
+
+Use `betaZodTool` with Zod schemas to define tools with a `run` function, then pass them to `client.beta.messages.toolRunner()`:
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+import { betaZodTool } from "@anthropic-ai/sdk/helpers/beta/zod";
+import { z } from "zod";
+
+const client = new Anthropic();
+
+const getWeather = betaZodTool({
+  name: "get_weather",
+  description: "Get current weather for a location",
+  inputSchema: z.object({
+    location: z.string().describe("City and state, e.g., San Francisco, CA"),
+    unit: z.enum(["celsius", "fahrenheit"]).optional(),
+  }),
+  run: async (input) => {
+    // Your implementation here
+    return `72°F and sunny in ${input.location}`;
+  },
+});
+
+// The tool runner handles the agentic loop and returns the final message
+const finalMessage = await client.beta.messages.toolRunner({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  tools: [getWeather],
+  messages: [{ role: "user", content: "What's the weather in Paris?" }],
+});
+
+console.log(finalMessage.content);
+```
+
+**Key benefits of the tool runner:**
+
+- No manual loop — the SDK handles calling tools and feeding results back
+- Type-safe tool inputs via Zod schemas
+- Tool schemas are generated automatically from Zod definitions
+- Iteration stops automatically when Claude has no more tool calls
+
+---
+
+## Manual Agentic Loop
+
+Use this when you need fine-grained control (custom logging, conditional tool execution, streaming individual iterations, human-in-the-loop approval):
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic();
+const tools: Anthropic.Tool[] = [...]; // Your tool definitions
+let messages: Anthropic.MessageParam[] = [{ role: "user", content: userInput }];
+
+while (true) {
+  const response = await client.messages.create({
+    model: "claude-opus-4-6",
+    max_tokens: 16000,
+    tools: tools,
+    messages: messages,
+  });
+
+  if (response.stop_reason === "end_turn") break;
+
+  // Server-side tool hit iteration limit; append assistant turn and re-send to continue
+  if (response.stop_reason === "pause_turn") {
+    messages.push({ role: "assistant", content: response.content });
+    continue;
+  }
+
+  const toolUseBlocks = response.content.filter(
+    (b): b is Anthropic.ToolUseBlock => b.type === "tool_use",
+  );
+
+  messages.push({ role: "assistant", content: response.content });
+
+  const toolResults: Anthropic.ToolResultBlockParam[] = [];
+  for (const tool of toolUseBlocks) {
+    const result = await executeTool(tool.name, tool.input);
+    toolResults.push({
+      type: "tool_result",
+      tool_use_id: tool.id,
+      content: result,
+    });
+  }
+
+  messages.push({ role: "user", content: toolResults });
+}
+```
+
+### Streaming Manual Loop
+
+Use `client.messages.stream()` + `finalMessage()` instead of `.create()` when you need streaming within a manual loop. Text deltas are streamed on each iteration; `finalMessage()` collects the complete `Message` so you can inspect `stop_reason` and extract tool-use blocks:
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic();
+const tools: Anthropic.Tool[] = [...];
+let messages: Anthropic.MessageParam[] = [{ role: "user", content: userInput }];
+
+while (true) {
+  const stream = client.messages.stream({
+    model: "claude-opus-4-6",
+    max_tokens: 64000,
+    tools,
+    messages,
+  });
+
+  // Stream text deltas on each iteration
+  stream.on("text", (delta) => {
+    process.stdout.write(delta);
+  });
+
+  // finalMessage() resolves with the complete Message — no need to
+  // manually wire up .on("message") / .on("error") / .on("abort")
+  const message = await stream.finalMessage();
+
+  if (message.stop_reason === "end_turn") break;
+
+  // Server-side tool hit iteration limit; append assistant turn and re-send to continue
+  if (message.stop_reason === "pause_turn") {
+    messages.push({ role: "assistant", content: message.content });
+    continue;
+  }
+
+  const toolUseBlocks = message.content.filter(
+    (b): b is Anthropic.ToolUseBlock => b.type === "tool_use",
+  );
+
+  messages.push({ role: "assistant", content: message.content });
+
+  const toolResults: Anthropic.ToolResultBlockParam[] = [];
+  for (const tool of toolUseBlocks) {
+    const result = await executeTool(tool.name, tool.input);
+    toolResults.push({
+      type: "tool_result",
+      tool_use_id: tool.id,
+      content: result,
+    });
+  }
+
+  messages.push({ role: "user", content: toolResults });
+}
+```
+
+> **Important:** Don't wrap `.on()` events in `new Promise()` to collect the final message — use `stream.finalMessage()` instead. The SDK handles all error/abort/completion states internally.
+
+> **Error handling in the loop:** Use the SDK's typed exceptions (e.g., `Anthropic.RateLimitError`, `Anthropic.APIError`) — see [Error Handling](./README.md#error-handling) for examples. Don't check error messages with string matching.
+
+> **SDK types:** Use `Anthropic.MessageParam`, `Anthropic.Tool`, `Anthropic.ToolUseBlock`, `Anthropic.ToolResultBlockParam`, `Anthropic.Message`, etc. for all API-related data structures. Don't redefine equivalent interfaces.
+
+---
+
+## Handling Tool Results
+
+```typescript
+const response = await client.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  tools: tools,
+  messages: [{ role: "user", content: "What's the weather in Paris?" }],
+});
+
+for (const block of response.content) {
+  if (block.type === "tool_use") {
+    const result = await executeTool(block.name, block.input);
+
+    const followup = await client.messages.create({
+      model: "claude-opus-4-6",
+      max_tokens: 16000,
+      tools: tools,
+      messages: [
+        { role: "user", content: "What's the weather in Paris?" },
+        { role: "assistant", content: response.content },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: block.id, content: result },
+          ],
+        },
+      ],
+    });
+  }
+}
+```
+
+---
+
+## Tool Choice
+
+```typescript
+const response = await client.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  tools: tools,
+  tool_choice: { type: "tool", name: "get_weather" },
+  messages: [{ role: "user", content: "What's the weather in Paris?" }],
+});
+```
+
+---
+
+## Server-Side Tools
+
+Version-suffixed `type` literals; `name` is fixed per interface. Pass plain object literals — the `ToolUnion` type is satisfied structurally. **The `name`/`type` pair must match the interface**: mixing `str_replace_based_edit_tool` (20250728 name) with `text_editor_20250124` (which expects `str_replace_editor`) is a TS2322.
+
+**Don't type-annotate as `Tool[]`** — `Tool` is just the custom-tool variant. Let structural typing infer from the `tools` param, or annotate as `Anthropic.Messages.ToolUnion[]` if you must:
+
+```typescript
+// ✓ let inference work — no annotation
+const response = await client.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  tools: [
+    { type: "text_editor_20250728", name: "str_replace_based_edit_tool" },
+    { type: "bash_20250124", name: "bash" },
+    { type: "web_search_20260209", name: "web_search" },
+    { type: "code_execution_20260120", name: "code_execution" },
+  ],
+  messages: [{ role: "user", content: "..." }],
+});
+
+// ✗ this is a TS2352 — Tool is the CUSTOM tool variant only
+// const tools: Anthropic.Tool[] = [{ type: "text_editor_20250728", ... }]
+```
+
+| Interface | `name` | `type` |
+|---|---|---|
+| `ToolTextEditor20250124` | `str_replace_editor` | `text_editor_20250124` |
+| `ToolTextEditor20250429` | `str_replace_based_edit_tool` | `text_editor_20250429` |
+| `ToolTextEditor20250728` | `str_replace_based_edit_tool` | `text_editor_20250728` |
+| `ToolBash20250124` | `bash` | `bash_20250124` |
+| `WebSearchTool20260209` | `web_search` | `web_search_20260209` |
+| `WebFetchTool20260209` | `web_fetch` | `web_fetch_20260209` |
+| `CodeExecutionTool20260120` | `code_execution` | `code_execution_20260120` |
+
+**Don't mix beta and non-beta types**: if you call `client.beta.messages.create()`, the response `content` is `BetaContentBlock[]` — you cannot pass that to a non-beta `ContentBlockParam[]` without narrowing each element.
+
+---
+
+
+## Code Execution
+
+### Basic Usage
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic();
+
+const response = await client.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  messages: [
+    {
+      role: "user",
+      content:
+        "Calculate the mean and standard deviation of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",
+    },
+  ],
+  tools: [{ type: "code_execution_20260120", name: "code_execution" }],
+});
+```
+
+### Reading Local Files (ESM note)
+
+`__dirname` doesn't exist in ES modules. For script-relative paths use `import.meta.url`:
+
+```typescript
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pdfBytes = readFileSync(join(__dirname, "sample.pdf"));
+```
+
+Or use a CWD-relative path if the script runs from a known directory: `readFileSync("./sample.pdf")`.
+
+### Upload Files for Analysis
+
+```typescript
+import Anthropic, { toFile } from "@anthropic-ai/sdk";
+import { createReadStream } from "fs";
+
+const client = new Anthropic();
+
+// 1. Upload a file
+const uploaded = await client.beta.files.upload({
+  file: await toFile(createReadStream("sales_data.csv"), undefined, {
+    type: "text/csv",
+  }),
+  betas: ["files-api-2025-04-14"],
+});
+
+// 2. Pass to code execution
+// Code execution is GA; Files API is still beta (pass via RequestOptions)
+const response = await client.messages.create(
+  {
+    model: "claude-opus-4-6",
+    max_tokens: 16000,
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Analyze this sales data. Show trends and create a visualization.",
+          },
+          { type: "container_upload", file_id: uploaded.id },
+        ],
+      },
+    ],
+    tools: [{ type: "code_execution_20260120", name: "code_execution" }],
+  },
+  { headers: { "anthropic-beta": "files-api-2025-04-14" } },
+);
+```
+
+### Retrieve Generated Files
+
+```typescript
+import path from "path";
+import fs from "fs";
+
+const OUTPUT_DIR = "./claude_outputs";
+await fs.promises.mkdir(OUTPUT_DIR, { recursive: true });
+
+for (const block of response.content) {
+  if (block.type === "bash_code_execution_tool_result") {
+    const result = block.content;
+    if (result.type === "bash_code_execution_result" && result.content) {
+      for (const fileRef of result.content) {
+        if (fileRef.type === "bash_code_execution_output") {
+          const metadata = await client.beta.files.retrieveMetadata(
+            fileRef.file_id,
+          );
+          const downloadResponse = await client.beta.files.download(fileRef.file_id);
+          const fileBytes = Buffer.from(await downloadResponse.arrayBuffer());
+          const safeName = path.basename(metadata.filename);
+          if (!safeName || safeName === "." || safeName === "..") {
+            console.warn(`Skipping invalid filename: ${metadata.filename}`);
+            continue;
+          }
+          const outputPath = path.join(OUTPUT_DIR, safeName);
+          await fs.promises.writeFile(outputPath, fileBytes);
+          console.log(`Saved: ${outputPath}`);
+        }
+      }
+    }
+  }
+}
+```
+
+### Container Reuse
+
+```typescript
+// First request: set up environment
+const response1 = await client.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  messages: [
+    {
+      role: "user",
+      content: "Install tabulate and create data.json with sample user data",
+    },
+  ],
+  tools: [{ type: "code_execution_20260120", name: "code_execution" }],
+});
+
+// Reuse container
+// container is nullable — set only when using server-side code execution
+const containerId = response1.container!.id;
+
+const response2 = await client.messages.create({
+  container: containerId,
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  messages: [
+    {
+      role: "user",
+      content: "Read data.json and display as a formatted table",
+    },
+  ],
+  tools: [{ type: "code_execution_20260120", name: "code_execution" }],
+});
+```
+
+---
+
+## Memory Tool
+
+### Basic Usage
+
+```typescript
+const response = await client.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  messages: [
+    {
+      role: "user",
+      content: "Remember that my preferred language is TypeScript.",
+    },
+  ],
+  tools: [{ type: "memory_20250818", name: "memory" }],
+});
+```
+
+### SDK Memory Helper
+
+Use `betaMemoryTool` with a `MemoryToolHandlers` implementation:
+
+```typescript
+import {
+  betaMemoryTool,
+  type MemoryToolHandlers,
+} from "@anthropic-ai/sdk/helpers/beta/memory";
+
+const handlers: MemoryToolHandlers = {
+  async view(command) { ... },
+  async create(command) { ... },
+  async str_replace(command) { ... },
+  async insert(command) { ... },
+  async delete(command) { ... },
+  async rename(command) { ... },
+};
+
+const memory = betaMemoryTool(handlers);
+
+const runner = client.beta.messages.toolRunner({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  tools: [memory],
+  messages: [{ role: "user", content: "Remember my preferences" }],
+});
+
+for await (const message of runner) {
+  console.log(message);
+}
+```
+
+For full implementation examples, use WebFetch:
+
+- `https://github.com/anthropics/anthropic-sdk-typescript/blob/main/examples/tools-helpers-memory.ts`
+
+---
+
+## Structured Outputs
+
+### JSON Outputs (Zod — Recommended)
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+import { z } from "zod";
+import { zodOutputFormat } from "@anthropic-ai/sdk/helpers/zod";
+
+const ContactInfoSchema = z.object({
+  name: z.string(),
+  email: z.string(),
+  plan: z.string(),
+  interests: z.array(z.string()),
+  demo_requested: z.boolean(),
+});
+
+const client = new Anthropic();
+
+const response = await client.messages.parse({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  messages: [
+    {
+      role: "user",
+      content:
+        "Extract: Jane Doe (jane@co.com) wants Enterprise, interested in API and SDKs, wants a demo.",
+    },
+  ],
+  output_config: {
+    format: zodOutputFormat(ContactInfoSchema),
+  },
+});
+
+// parsed_output is null if parsing failed — assert or guard
+console.log(response.parsed_output!.name); // "Jane Doe"
+```
+
+### Strict Tool Use
+
+```typescript
+const response = await client.messages.create({
+  model: "claude-opus-4-6",
+  max_tokens: 16000,
+  messages: [
+    {
+      role: "user",
+      content: "Book a flight to Tokyo for 2 passengers on March 15",
+    },
+  ],
+  tools: [
+    {
+      name: "book_flight",
+      description: "Book a flight to a destination",
+      strict: true,
+      input_schema: {
+        type: "object",
+        properties: {
+          destination: { type: "string" },
+          date: { type: "string", format: "date" },
+          passengers: {
+            type: "integer",
+            enum: [1, 2, 3, 4, 5, 6, 7, 8],
+          },
+        },
+        required: ["destination", "date", "passengers"],
+        additionalProperties: false,
+      },
+    },
+  ],
+});
+```

--- a/.claude/skills/claude-api/typescript/managed-agents/README.md
+++ b/.claude/skills/claude-api/typescript/managed-agents/README.md
@@ -1,0 +1,359 @@
+# Managed Agents — TypeScript
+
+> **Bindings not shown here:** This README covers the most common managed-agents flows for TypeScript. If you need a class, method, namespace, field, or behavior that isn't shown, WebFetch the TypeScript SDK repo **or the relevant docs page** from `shared/live-sources.md` rather than guess. Do not extrapolate from cURL shapes or another language's SDK.
+
+> **Agents are persistent — create once, reference by ID.** Store the agent ID returned by `agents.create` and pass it to every subsequent `sessions.create`; do not call `agents.create` in the request path. The Anthropic CLI is one convenient way to create agents and environments from version-controlled YAML — its URL is in `shared/live-sources.md`. The examples below show in-code creation for completeness; in production the create call belongs in setup, not in the request path.
+
+## Installation
+
+```bash
+npm install @anthropic-ai/sdk
+```
+
+## Client Initialization
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+// Default (uses ANTHROPIC_API_KEY env var)
+const client = new Anthropic();
+
+// Explicit API key
+const client = new Anthropic({ apiKey: "your-api-key" });
+```
+
+---
+
+## Create an Environment
+
+```typescript
+const environment = await client.beta.environments.create(
+  {
+    name: "my-dev-env",
+    config: {
+      type: "cloud",
+      networking: { type: "unrestricted" },
+    },
+  },
+);
+console.log(environment.id); // env_...
+```
+
+---
+
+## Create an Agent (required first step)
+
+> ⚠️ **There is no inline agent config.** `model`/`system`/`tools` live on the agent object, not the session. Always start with `agents.create()` — the session only takes `agent: { type: "agent", id: agent.id }`.
+
+### Minimal
+
+```typescript
+// 1. Create the agent (reusable, versioned)
+const agent = await client.beta.agents.create(
+  {
+    name: "Coding Assistant",
+    model: "claude-opus-4-6",
+    tools: [{ type: "agent_toolset_20260401", default_config: { enabled: true } }],
+  },
+);
+
+// 2. Start a session
+const session = await client.beta.sessions.create(
+  {
+    agent: { type: "agent", id: agent.id, version: agent.version },
+    environment_id: environment.id,
+  },
+);
+console.log(session.id, session.status);
+```
+
+### With system prompt and custom tools
+
+```typescript
+const agent = await client.beta.agents.create(
+  {
+    name: "Code Reviewer",
+    model: "claude-opus-4-6",
+    system: "You are a senior code reviewer.",
+    tools: [
+      { type: "agent_toolset_20260401", default_config: { enabled: true } },
+      {
+        type: "custom",
+        name: "run_tests",
+        description: "Run the test suite",
+        input_schema: {
+          type: "object",
+          properties: {
+            test_path: { type: "string", description: "Path to test file" },
+          },
+          required: ["test_path"],
+        },
+      },
+    ],
+  },
+);
+
+const session = await client.beta.sessions.create(
+  {
+    agent: { type: "agent", id: agent.id, version: agent.version },
+    environment_id: environment.id,
+    title: "Code review session",
+    resources: [
+      {
+        type: "github_repository",
+        url: "https://github.com/owner/repo",
+        mount_path: "/workspace/repo",
+        authorization_token: process.env.GITHUB_TOKEN,
+        branch: "main",
+      },
+    ],
+  },
+);
+```
+
+---
+
+## Send a User Message
+
+```typescript
+await client.beta.sessions.events.send(
+  session.id,
+  {
+    events: [
+      {
+        type: "user.message",
+        content: [{ type: "text", text: "Review the auth module" }],
+      },
+    ],
+  },
+);
+```
+
+> 💡 **Stream-first:** Open the stream *before* (or concurrently with) sending the message. The stream only delivers events that occur after it opens — stream-after-send means early events arrive buffered in one batch. See [Steering Patterns](../../shared/managed-agents-events.md#steering-patterns).
+
+---
+
+## Stream Events (SSE)
+
+```typescript
+// Stream-first: open stream and send concurrently
+const [events] = await Promise.all([
+  collectStream(session.id),
+  client.beta.sessions.events.send(
+    session.id,
+    { events: [{ type: "user.message", content: [{ type: "text", text: "..." }] }] },
+  ),
+]);
+
+// Standalone stream iteration:
+const stream = await client.beta.sessions.stream(
+  session.id,
+);
+
+for await (const event of stream) {
+  switch (event.type) {
+    case "agent.message":
+      for (const block of event.content) {
+        if (block.type === "text") {
+          process.stdout.write(block.text);
+        }
+      }
+      break;
+    case "agent.custom_tool_use":
+      // Custom tool invocation — session is now idle
+      console.log(`\nCustom tool call: ${event.tool_name}`);
+      console.log(`Input: ${JSON.stringify(event.input)}`);
+      break;
+    case "session.status_idle":
+      console.log("\n--- Agent idle ---");
+      break;
+    case "session.status_terminated":
+      console.log("\n--- Session terminated ---");
+      break;
+  }
+}
+```
+
+---
+
+## Provide Custom Tool Result
+
+```typescript
+await client.beta.sessions.events.send(
+  session.id,
+  {
+    events: [
+      {
+        type: "user.custom_tool_result",
+        custom_tool_use_id: "sevt_abc123",
+        content: [{ type: "text", text: "All 42 tests passed." }],
+      },
+    ],
+  },
+);
+```
+
+---
+
+## Poll Events
+
+```typescript
+const events = await client.beta.sessions.events.list(
+  session.id,
+);
+for (const event of events.data) {
+  console.log(`${event.type}: ${event.id}`);
+}
+```
+
+---
+
+## Full Streaming Loop with Custom Tools
+
+```typescript
+function runCustomTool(toolName: string, toolInput: unknown): string {
+  if (toolName === "run_tests") {
+    // Your tool implementation here
+    return "All tests passed.";
+  }
+  return `Unknown tool: ${toolName}`;
+}
+
+async function runSession(client: Anthropic, sessionId: string) {
+  while (true) {
+    const stream = await client.beta.sessions.stream(
+      sessionId,
+    );
+
+    const toolCalls: Array<{ custom_tool_use_id: string; tool_name: string; input: unknown }> = [];
+
+    for await (const event of stream) {
+      if (event.type === "agent.message") {
+        for (const block of event.content) {
+          if (block.type === "text") {
+            process.stdout.write(block.text);
+          }
+        }
+      } else if (event.type === "agent.custom_tool_use") {
+        toolCalls.push({
+          id: event.id,
+          tool_name: event.tool_name,
+          input: event.input,
+        });
+      } else if (event.type === "session.status_idle") {
+        break;
+      } else if (event.type === "session.status_terminated") {
+        return;
+      }
+    }
+
+    if (toolCalls.length === 0) break;
+
+    // Process custom tool calls
+    const results = toolCalls.map((call) => ({
+      type: "user.custom_tool_result" as const,
+      custom_tool_use_id: call.id,
+      content: [{ type: "text" as const, text: runCustomTool(call.tool_name, call.input) }],
+    }));
+
+    await client.beta.sessions.events.send(
+      sessionId,
+      { events: results },
+    );
+  }
+}
+```
+
+---
+
+## Upload a File
+
+```typescript
+import fs from "fs";
+
+const file = await client.beta.files.upload({
+  file: fs.createReadStream("data.csv"),
+  purpose: "agent",
+});
+
+// Use in a session
+const session = await client.beta.sessions.create(
+  {
+    agent: { type: "agent", id: agent.id, version: agent.version },
+    environment_id: environment.id,
+    resources: [{ type: "file", file_id: file.id, mount_path: "/workspace/data.csv" }],
+  },
+);
+```
+
+---
+
+## List and Download Session Files
+
+List files the agent wrote to `/mnt/session/outputs/` during a session, then download them.
+
+```typescript
+import fs from "fs";
+
+// List files associated with a session
+const files = await client.beta.files.list({
+  scope: session.id,
+});
+for (const f of files.data) {
+  console.log(f.filename, f.size_bytes);
+
+  // Download and save to disk
+  const resp = await client.beta.files.download(f.id);
+  const buffer = Buffer.from(await resp.arrayBuffer());
+  fs.writeFileSync(f.filename, buffer);
+}
+```
+
+> 💡 There's a brief indexing lag (~1–3s) between `session.status_idle` and output files appearing in `files.list`. Retry once or twice if the list is empty.
+
+---
+
+## Session Management
+
+```typescript
+// Get session details
+const session = await client.beta.sessions.retrieve("sess_abc123");
+console.log(session.status, session.usage);
+
+// List sessions
+const sessions = await client.beta.sessions.list();
+
+// Delete a session
+await client.beta.sessions.delete("sess_abc123");
+
+// Archive a session
+await client.beta.sessions.archive("sess_abc123");
+```
+
+---
+
+## MCP Server Integration
+
+```typescript
+// Agent declares MCP server (no auth here — auth goes in a vault)
+const agent = await client.beta.agents.create({
+  name: "MCP Agent",
+  model: "claude-opus-4-6",
+  mcp_servers: [
+    { type: "url", name: "my-tools", url: "https://my-mcp-server.example.com/sse" },
+  ],
+  tools: [
+    { type: "agent_toolset_20260401", default_config: { enabled: true } },
+    { type: "mcp_toolset", mcp_server_name: "my-tools" },
+  ],
+});
+
+// Session attaches vault(s) containing credentials for those MCP server URLs
+const session = await client.beta.sessions.create({
+  agent: agent.id,
+  environment_id: environment.id,
+  vault_ids: [vault.id],
+});
+```
+
+See `shared/managed-agents-tools.md` §Vaults for creating vaults and adding credentials.

--- a/.claude/skills/skill-creator/LICENSE.txt
+++ b/.claude/skills/skill-creator/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.claude/skills/skill-creator/SKILL.md
+++ b/.claude/skills/skill-creator/SKILL.md
@@ -1,0 +1,485 @@
+---
+name: skill-creator
+description: Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.
+---
+
+# Skill Creator
+
+A skill for creating new skills and iteratively improving them.
+
+At a high level, the process of creating a skill goes like this:
+
+- Decide what you want the skill to do and roughly how it should do it
+- Write a draft of the skill
+- Create a few test prompts and run claude-with-access-to-the-skill on them
+- Help the user evaluate the results both qualitatively and quantitatively
+  - While the runs happen in the background, draft some quantitative evals if there aren't any (if there are some, you can either use as is or modify if you feel something needs to change about them). Then explain them to the user (or if they already existed, explain the ones that already exist)
+  - Use the `eval-viewer/generate_review.py` script to show the user the results for them to look at, and also let them look at the quantitative metrics
+- Rewrite the skill based on feedback from the user's evaluation of the results (and also if there are any glaring flaws that become apparent from the quantitative benchmarks)
+- Repeat until you're satisfied
+- Expand the test set and try again at larger scale
+
+Your job when using this skill is to figure out where the user is in this process and then jump in and help them progress through these stages. So for instance, maybe they're like "I want to make a skill for X". You can help narrow down what they mean, write a draft, write the test cases, figure out how they want to evaluate, run all the prompts, and repeat.
+
+On the other hand, maybe they already have a draft of the skill. In this case you can go straight to the eval/iterate part of the loop.
+
+Of course, you should always be flexible and if the user is like "I don't need to run a bunch of evaluations, just vibe with me", you can do that instead.
+
+Then after the skill is done (but again, the order is flexible), you can also run the skill description improver, which we have a whole separate script for, to optimize the triggering of the skill.
+
+Cool? Cool.
+
+## Communicating with the user
+
+The skill creator is liable to be used by people across a wide range of familiarity with coding jargon. If you haven't heard (and how could you, it's only very recently that it started), there's a trend now where the power of Claude is inspiring plumbers to open up their terminals, parents and grandparents to google "how to install npm". On the other hand, the bulk of users are probably fairly computer-literate.
+
+So please pay attention to context cues to understand how to phrase your communication! In the default case, just to give you some idea:
+
+- "evaluation" and "benchmark" are borderline, but OK
+- for "JSON" and "assertion" you want to see serious cues from the user that they know what those things are before using them without explaining them
+
+It's OK to briefly explain terms if you're in doubt, and feel free to clarify terms with a short definition if you're unsure if the user will get it.
+
+---
+
+## Creating a skill
+
+### Capture Intent
+
+Start by understanding the user's intent. The current conversation might already contain a workflow the user wants to capture (e.g., they say "turn this into a skill"). If so, extract answers from the conversation history first — the tools used, the sequence of steps, corrections the user made, input/output formats observed. The user may need to fill the gaps, and should confirm before proceeding to the next step.
+
+1. What should this skill enable Claude to do?
+2. When should this skill trigger? (what user phrases/contexts)
+3. What's the expected output format?
+4. Should we set up test cases to verify the skill works? Skills with objectively verifiable outputs (file transforms, data extraction, code generation, fixed workflow steps) benefit from test cases. Skills with subjective outputs (writing style, art) often don't need them. Suggest the appropriate default based on the skill type, but let the user decide.
+
+### Interview and Research
+
+Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Wait to write test prompts until you've got this part ironed out.
+
+Check available MCPs - if useful for research (searching docs, finding similar skills, looking up best practices), research in parallel via subagents if available, otherwise inline. Come prepared with context to reduce burden on the user.
+
+### Write the SKILL.md
+
+Based on the user interview, fill in these components:
+
+- **name**: Skill identifier
+- **description**: When to trigger, what it does. This is the primary triggering mechanism - include both what the skill does AND specific contexts for when to use it. All "when to use" info goes here, not in the body. Note: currently Claude has a tendency to "undertrigger" skills -- to not use them when they'd be useful. To combat this, please make the skill descriptions a little bit "pushy". So for instance, instead of "How to build a simple fast dashboard to display internal Anthropic data.", you might write "How to build a simple fast dashboard to display internal Anthropic data. Make sure to use this skill whenever the user mentions dashboards, data visualization, internal metrics, or wants to display any kind of company data, even if they don't explicitly ask for a 'dashboard.'"
+- **compatibility**: Required tools, dependencies (optional, rarely needed)
+- **the rest of the skill :)**
+
+### Skill Writing Guide
+
+#### Anatomy of a Skill
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter (name, description required)
+│   └── Markdown instructions
+└── Bundled Resources (optional)
+    ├── scripts/    - Executable code for deterministic/repetitive tasks
+    ├── references/ - Docs loaded into context as needed
+    └── assets/     - Files used in output (templates, icons, fonts)
+```
+
+#### Progressive Disclosure
+
+Skills use a three-level loading system:
+1. **Metadata** (name + description) - Always in context (~100 words)
+2. **SKILL.md body** - In context whenever skill triggers (<500 lines ideal)
+3. **Bundled resources** - As needed (unlimited, scripts can execute without loading)
+
+These word counts are approximate and you can feel free to go longer if needed.
+
+**Key patterns:**
+- Keep SKILL.md under 500 lines; if you're approaching this limit, add an additional layer of hierarchy along with clear pointers about where the model using the skill should go next to follow up.
+- Reference files clearly from SKILL.md with guidance on when to read them
+- For large reference files (>300 lines), include a table of contents
+
+**Domain organization**: When a skill supports multiple domains/frameworks, organize by variant:
+```
+cloud-deploy/
+├── SKILL.md (workflow + selection)
+└── references/
+    ├── aws.md
+    ├── gcp.md
+    └── azure.md
+```
+Claude reads only the relevant reference file.
+
+#### Principle of Lack of Surprise
+
+This goes without saying, but skills must not contain malware, exploit code, or any content that could compromise system security. A skill's contents should not surprise the user in their intent if described. Don't go along with requests to create misleading skills or skills designed to facilitate unauthorized access, data exfiltration, or other malicious activities. Things like a "roleplay as an XYZ" are OK though.
+
+#### Writing Patterns
+
+Prefer using the imperative form in instructions.
+
+**Defining output formats** - You can do it like this:
+```markdown
+## Report structure
+ALWAYS use this exact template:
+# [Title]
+## Executive summary
+## Key findings
+## Recommendations
+```
+
+**Examples pattern** - It's useful to include examples. You can format them like this (but if "Input" and "Output" are in the examples you might want to deviate a little):
+```markdown
+## Commit message format
+**Example 1:**
+Input: Added user authentication with JWT tokens
+Output: feat(auth): implement JWT-based authentication
+```
+
+### Writing Style
+
+Try to explain to the model why things are important in lieu of heavy-handed musty MUSTs. Use theory of mind and try to make the skill general and not super-narrow to specific examples. Start by writing a draft and then look at it with fresh eyes and improve it.
+
+### Test Cases
+
+After writing the skill draft, come up with 2-3 realistic test prompts — the kind of thing a real user would actually say. Share them with the user: [you don't have to use this exact language] "Here are a few test cases I'd like to try. Do these look right, or do you want to add more?" Then run them.
+
+Save test cases to `evals/evals.json`. Don't write assertions yet — just the prompts. You'll draft assertions in the next step while the runs are in progress.
+
+```json
+{
+  "skill_name": "example-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "User's task prompt",
+      "expected_output": "Description of expected result",
+      "files": []
+    }
+  ]
+}
+```
+
+See `references/schemas.md` for the full schema (including the `assertions` field, which you'll add later).
+
+## Running and evaluating test cases
+
+This section is one continuous sequence — don't stop partway through. Do NOT use `/skill-test` or any other testing skill.
+
+Put results in `<skill-name>-workspace/` as a sibling to the skill directory. Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
+
+### Step 1: Spawn all runs (with-skill AND baseline) in the same turn
+
+For each test case, spawn two subagents in the same turn — one with the skill, one without. This is important: don't spawn the with-skill runs first and then come back for baselines later. Launch everything at once so it all finishes around the same time.
+
+**With-skill run:**
+
+```
+Execute this task:
+- Skill path: <path-to-skill>
+- Task: <eval prompt>
+- Input files: <eval files if any, or "none">
+- Save outputs to: <workspace>/iteration-<N>/eval-<ID>/with_skill/outputs/
+- Outputs to save: <what the user cares about — e.g., "the .docx file", "the final CSV">
+```
+
+**Baseline run** (same prompt, but the baseline depends on context):
+- **Creating a new skill**: no skill at all. Same prompt, no skill path, save to `without_skill/outputs/`.
+- **Improving an existing skill**: the old version. Before editing, snapshot the skill (`cp -r <skill-path> <workspace>/skill-snapshot/`), then point the baseline subagent at the snapshot. Save to `old_skill/outputs/`.
+
+Write an `eval_metadata.json` for each test case (assertions can be empty for now). Give each eval a descriptive name based on what it's testing — not just "eval-0". Use this name for the directory too. If this iteration uses new or modified eval prompts, create these files for each new eval directory — don't assume they carry over from previous iterations.
+
+```json
+{
+  "eval_id": 0,
+  "eval_name": "descriptive-name-here",
+  "prompt": "The user's task prompt",
+  "assertions": []
+}
+```
+
+### Step 2: While runs are in progress, draft assertions
+
+Don't just wait for the runs to finish — you can use this time productively. Draft quantitative assertions for each test case and explain them to the user. If assertions already exist in `evals/evals.json`, review them and explain what they check.
+
+Good assertions are objectively verifiable and have descriptive names — they should read clearly in the benchmark viewer so someone glancing at the results immediately understands what each one checks. Subjective skills (writing style, design quality) are better evaluated qualitatively — don't force assertions onto things that need human judgment.
+
+Update the `eval_metadata.json` files and `evals/evals.json` with the assertions once drafted. Also explain to the user what they'll see in the viewer — both the qualitative outputs and the quantitative benchmark.
+
+### Step 3: As runs complete, capture timing data
+
+When each subagent task completes, you receive a notification containing `total_tokens` and `duration_ms`. Save this data immediately to `timing.json` in the run directory:
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332,
+  "total_duration_seconds": 23.3
+}
+```
+
+This is the only opportunity to capture this data — it comes through the task notification and isn't persisted elsewhere. Process each notification as it arrives rather than trying to batch them.
+
+### Step 4: Grade, aggregate, and launch the viewer
+
+Once all runs are done:
+
+1. **Grade each run** — spawn a grader subagent (or grade inline) that reads `agents/grader.md` and evaluates each assertion against the outputs. Save results to `grading.json` in each run directory. The grading.json expectations array must use the fields `text`, `passed`, and `evidence` (not `name`/`met`/`details` or other variants) — the viewer depends on these exact field names. For assertions that can be checked programmatically, write and run a script rather than eyeballing it — scripts are faster, more reliable, and can be reused across iterations.
+
+2. **Aggregate into benchmark** — run the aggregation script from the skill-creator directory:
+   ```bash
+   python -m scripts.aggregate_benchmark <workspace>/iteration-N --skill-name <name>
+   ```
+   This produces `benchmark.json` and `benchmark.md` with pass_rate, time, and tokens for each configuration, with mean ± stddev and the delta. If generating benchmark.json manually, see `references/schemas.md` for the exact schema the viewer expects.
+Put each with_skill version before its baseline counterpart.
+
+3. **Do an analyst pass** — read the benchmark data and surface patterns the aggregate stats might hide. See `agents/analyzer.md` (the "Analyzing Benchmark Results" section) for what to look for — things like assertions that always pass regardless of skill (non-discriminating), high-variance evals (possibly flaky), and time/token tradeoffs.
+
+4. **Launch the viewer** with both qualitative outputs and quantitative data:
+   ```bash
+   nohup python <skill-creator-path>/eval-viewer/generate_review.py \
+     <workspace>/iteration-N \
+     --skill-name "my-skill" \
+     --benchmark <workspace>/iteration-N/benchmark.json \
+     > /dev/null 2>&1 &
+   VIEWER_PID=$!
+   ```
+   For iteration 2+, also pass `--previous-workspace <workspace>/iteration-<N-1>`.
+
+   **Cowork / headless environments:** If `webbrowser.open()` is not available or the environment has no display, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Feedback will be downloaded as a `feedback.json` file when the user clicks "Submit All Reviews". After download, copy `feedback.json` into the workspace directory for the next iteration to pick up.
+
+Note: please use generate_review.py to create the viewer; there's no need to write custom HTML.
+
+5. **Tell the user** something like: "I've opened the results in your browser. There are two tabs — 'Outputs' lets you click through each test case and leave feedback, 'Benchmark' shows the quantitative comparison. When you're done, come back here and let me know."
+
+### What the user sees in the viewer
+
+The "Outputs" tab shows one test case at a time:
+- **Prompt**: the task that was given
+- **Output**: the files the skill produced, rendered inline where possible
+- **Previous Output** (iteration 2+): collapsed section showing last iteration's output
+- **Formal Grades** (if grading was run): collapsed section showing assertion pass/fail
+- **Feedback**: a textbox that auto-saves as they type
+- **Previous Feedback** (iteration 2+): their comments from last time, shown below the textbox
+
+The "Benchmark" tab shows the stats summary: pass rates, timing, and token usage for each configuration, with per-eval breakdowns and analyst observations.
+
+Navigation is via prev/next buttons or arrow keys. When done, they click "Submit All Reviews" which saves all feedback to `feedback.json`.
+
+### Step 5: Read the feedback
+
+When the user tells you they're done, read `feedback.json`:
+
+```json
+{
+  "reviews": [
+    {"run_id": "eval-0-with_skill", "feedback": "the chart is missing axis labels", "timestamp": "..."},
+    {"run_id": "eval-1-with_skill", "feedback": "", "timestamp": "..."},
+    {"run_id": "eval-2-with_skill", "feedback": "perfect, love this", "timestamp": "..."}
+  ],
+  "status": "complete"
+}
+```
+
+Empty feedback means the user thought it was fine. Focus your improvements on the test cases where the user had specific complaints.
+
+Kill the viewer server when you're done with it:
+
+```bash
+kill $VIEWER_PID 2>/dev/null
+```
+
+---
+
+## Improving the skill
+
+This is the heart of the loop. You've run the test cases, the user has reviewed the results, and now you need to make the skill better based on their feedback.
+
+### How to think about improvements
+
+1. **Generalize from the feedback.** The big picture thing that's happening here is that we're trying to create skills that can be used a million times (maybe literally, maybe even more who knows) across many different prompts. Here you and the user are iterating on only a few examples over and over again because it helps move faster. The user knows these examples in and out and it's quick for them to assess new outputs. But if the skill you and the user are codeveloping works only for those examples, it's useless. Rather than put in fiddly overfitty changes, or oppressively constrictive MUSTs, if there's some stubborn issue, you might try branching out and using different metaphors, or recommending different patterns of working. It's relatively cheap to try and maybe you'll land on something great.
+
+2. **Keep the prompt lean.** Remove things that aren't pulling their weight. Make sure to read the transcripts, not just the final outputs — if it looks like the skill is making the model waste a bunch of time doing things that are unproductive, you can try getting rid of the parts of the skill that are making it do that and seeing what happens.
+
+3. **Explain the why.** Try hard to explain the **why** behind everything you're asking the model to do. Today's LLMs are *smart*. They have good theory of mind and when given a good harness can go beyond rote instructions and really make things happen. Even if the feedback from the user is terse or frustrated, try to actually understand the task and why the user is writing what they wrote, and what they actually wrote, and then transmit this understanding into the instructions. If you find yourself writing ALWAYS or NEVER in all caps, or using super rigid structures, that's a yellow flag — if possible, reframe and explain the reasoning so that the model understands why the thing you're asking for is important. That's a more humane, powerful, and effective approach.
+
+4. **Look for repeated work across test cases.** Read the transcripts from the test runs and notice if the subagents all independently wrote similar helper scripts or took the same multi-step approach to something. If all 3 test cases resulted in the subagent writing a `create_docx.py` or a `build_chart.py`, that's a strong signal the skill should bundle that script. Write it once, put it in `scripts/`, and tell the skill to use it. This saves every future invocation from reinventing the wheel.
+
+This task is pretty important (we are trying to create billions a year in economic value here!) and your thinking time is not the blocker; take your time and really mull things over. I'd suggest writing a draft revision and then looking at it anew and making improvements. Really do your best to get into the head of the user and understand what they want and need.
+
+### The iteration loop
+
+After improving the skill:
+
+1. Apply your improvements to the skill
+2. Rerun all test cases into a new `iteration-<N+1>/` directory, including baseline runs. If you're creating a new skill, the baseline is always `without_skill` (no skill) — that stays the same across iterations. If you're improving an existing skill, use your judgment on what makes sense as the baseline: the original version the user came in with, or the previous iteration.
+3. Launch the reviewer with `--previous-workspace` pointing at the previous iteration
+4. Wait for the user to review and tell you they're done
+5. Read the new feedback, improve again, repeat
+
+Keep going until:
+- The user says they're happy
+- The feedback is all empty (everything looks good)
+- You're not making meaningful progress
+
+---
+
+## Advanced: Blind comparison
+
+For situations where you want a more rigorous comparison between two versions of a skill (e.g., the user asks "is the new version actually better?"), there's a blind comparison system. Read `agents/comparator.md` and `agents/analyzer.md` for the details. The basic idea is: give two outputs to an independent agent without telling it which is which, and let it judge quality. Then analyze why the winner won.
+
+This is optional, requires subagents, and most users won't need it. The human review loop is usually sufficient.
+
+---
+
+## Description Optimization
+
+The description field in SKILL.md frontmatter is the primary mechanism that determines whether Claude invokes a skill. After creating or improving a skill, offer to optimize the description for better triggering accuracy.
+
+### Step 1: Generate trigger eval queries
+
+Create 20 eval queries — a mix of should-trigger and should-not-trigger. Save as JSON:
+
+```json
+[
+  {"query": "the user prompt", "should_trigger": true},
+  {"query": "another prompt", "should_trigger": false}
+]
+```
+
+The queries must be realistic and something a Claude Code or Claude.ai user would actually type. Not abstract requests, but requests that are concrete and specific and have a good amount of detail. For instance, file paths, personal context about the user's job or situation, column names and values, company names, URLs. A little bit of backstory. Some might be in lowercase or contain abbreviations or typos or casual speech. Use a mix of different lengths, and focus on edge cases rather than making them clear-cut (the user will get a chance to sign off on them).
+
+Bad: `"Format this data"`, `"Extract text from PDF"`, `"Create a chart"`
+
+Good: `"ok so my boss just sent me this xlsx file (its in my downloads, called something like 'Q4 sales final FINAL v2.xlsx') and she wants me to add a column that shows the profit margin as a percentage. The revenue is in column C and costs are in column D i think"`
+
+For the **should-trigger** queries (8-10), think about coverage. You want different phrasings of the same intent — some formal, some casual. Include cases where the user doesn't explicitly name the skill or file type but clearly needs it. Throw in some uncommon use cases and cases where this skill competes with another but should win.
+
+For the **should-not-trigger** queries (8-10), the most valuable ones are the near-misses — queries that share keywords or concepts with the skill but actually need something different. Think adjacent domains, ambiguous phrasing where a naive keyword match would trigger but shouldn't, and cases where the query touches on something the skill does but in a context where another tool is more appropriate.
+
+The key thing to avoid: don't make should-not-trigger queries obviously irrelevant. "Write a fibonacci function" as a negative test for a PDF skill is too easy — it doesn't test anything. The negative cases should be genuinely tricky.
+
+### Step 2: Review with user
+
+Present the eval set to the user for review using the HTML template:
+
+1. Read the template from `assets/eval_review.html`
+2. Replace the placeholders:
+   - `__EVAL_DATA_PLACEHOLDER__` → the JSON array of eval items (no quotes around it — it's a JS variable assignment)
+   - `__SKILL_NAME_PLACEHOLDER__` → the skill's name
+   - `__SKILL_DESCRIPTION_PLACEHOLDER__` → the skill's current description
+3. Write to a temp file (e.g., `/tmp/eval_review_<skill-name>.html`) and open it: `open /tmp/eval_review_<skill-name>.html`
+4. The user can edit queries, toggle should-trigger, add/remove entries, then click "Export Eval Set"
+5. The file downloads to `~/Downloads/eval_set.json` — check the Downloads folder for the most recent version in case there are multiple (e.g., `eval_set (1).json`)
+
+This step matters — bad eval queries lead to bad descriptions.
+
+### Step 3: Run the optimization loop
+
+Tell the user: "This will take some time — I'll run the optimization loop in the background and check on it periodically."
+
+Save the eval set to the workspace, then run in the background:
+
+```bash
+python -m scripts.run_loop \
+  --eval-set <path-to-trigger-eval.json> \
+  --skill-path <path-to-skill> \
+  --model <model-id-powering-this-session> \
+  --max-iterations 5 \
+  --verbose
+```
+
+Use the model ID from your system prompt (the one powering the current session) so the triggering test matches what the user actually experiences.
+
+While it runs, periodically tail the output to give the user updates on which iteration it's on and what the scores look like.
+
+This handles the full optimization loop automatically. It splits the eval set into 60% train and 40% held-out test, evaluates the current description (running each query 3 times to get a reliable trigger rate), then calls Claude to propose improvements based on what failed. It re-evaluates each new description on both train and test, iterating up to 5 times. When it's done, it opens an HTML report in the browser showing the results per iteration and returns JSON with `best_description` — selected by test score rather than train score to avoid overfitting.
+
+### How skill triggering works
+
+Understanding the triggering mechanism helps design better eval queries. Skills appear in Claude's `available_skills` list with their name + description, and Claude decides whether to consult a skill based on that description. The important thing to know is that Claude only consults skills for tasks it can't easily handle on its own — simple, one-step queries like "read this PDF" may not trigger a skill even if the description matches perfectly, because Claude can handle them directly with basic tools. Complex, multi-step, or specialized queries reliably trigger skills when the description matches.
+
+This means your eval queries should be substantive enough that Claude would actually benefit from consulting a skill. Simple queries like "read file X" are poor test cases — they won't trigger skills regardless of description quality.
+
+### Step 4: Apply the result
+
+Take `best_description` from the JSON output and update the skill's SKILL.md frontmatter. Show the user before/after and report the scores.
+
+---
+
+### Package and Present (only if `present_files` tool is available)
+
+Check whether you have access to the `present_files` tool. If you don't, skip this step. If you do, package the skill and present the .skill file to the user:
+
+```bash
+python -m scripts.package_skill <path/to/skill-folder>
+```
+
+After packaging, direct the user to the resulting `.skill` file path so they can install it.
+
+---
+
+## Claude.ai-specific instructions
+
+In Claude.ai, the core workflow is the same (draft → test → review → improve → repeat), but because Claude.ai doesn't have subagents, some mechanics change. Here's what to adapt:
+
+**Running test cases**: No subagents means no parallel execution. For each test case, read the skill's SKILL.md, then follow its instructions to accomplish the test prompt yourself. Do them one at a time. This is less rigorous than independent subagents (you wrote the skill and you're also running it, so you have full context), but it's a useful sanity check — and the human review step compensates. Skip the baseline runs — just use the skill to complete the task as requested.
+
+**Reviewing results**: If you can't open a browser (e.g., Claude.ai's VM has no display, or you're on a remote server), skip the browser reviewer entirely. Instead, present results directly in the conversation. For each test case, show the prompt and the output. If the output is a file the user needs to see (like a .docx or .xlsx), save it to the filesystem and tell them where it is so they can download and inspect it. Ask for feedback inline: "How does this look? Anything you'd change?"
+
+**Benchmarking**: Skip the quantitative benchmarking — it relies on baseline comparisons which aren't meaningful without subagents. Focus on qualitative feedback from the user.
+
+**The iteration loop**: Same as before — improve the skill, rerun the test cases, ask for feedback — just without the browser reviewer in the middle. You can still organize results into iteration directories on the filesystem if you have one.
+
+**Description optimization**: This section requires the `claude` CLI tool (specifically `claude -p`) which is only available in Claude Code. Skip it if you're on Claude.ai.
+
+**Blind comparison**: Requires subagents. Skip it.
+
+**Packaging**: The `package_skill.py` script works anywhere with Python and a filesystem. On Claude.ai, you can run it and the user can download the resulting `.skill` file.
+
+**Updating an existing skill**: The user might be asking you to update an existing skill, not create a new one. In this case:
+- **Preserve the original name.** Note the skill's directory name and `name` frontmatter field -- use them unchanged. E.g., if the installed skill is `research-helper`, output `research-helper.skill` (not `research-helper-v2`).
+- **Copy to a writeable location before editing.** The installed skill path may be read-only. Copy to `/tmp/skill-name/`, edit there, and package from the copy.
+- **If packaging manually, stage in `/tmp/` first**, then copy to the output directory -- direct writes may fail due to permissions.
+
+---
+
+## Cowork-Specific Instructions
+
+If you're in Cowork, the main things to know are:
+
+- You have subagents, so the main workflow (spawn test cases in parallel, run baselines, grade, etc.) all works. (However, if you run into severe problems with timeouts, it's OK to run the test prompts in series rather than parallel.)
+- You don't have a browser or display, so when generating the eval viewer, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Then proffer a link that the user can click to open the HTML in their browser.
+- For whatever reason, the Cowork setup seems to disincline Claude from generating the eval viewer after running the tests, so just to reiterate: whether you're in Cowork or in Claude Code, after running tests, you should always generate the eval viewer for the human to look at examples before revising the skill yourself and trying to make corrections, using `generate_review.py` (not writing your own boutique html code). Sorry in advance but I'm gonna go all caps here: GENERATE THE EVAL VIEWER *BEFORE* evaluating inputs yourself. You want to get them in front of the human ASAP!
+- Feedback works differently: since there's no running server, the viewer's "Submit All Reviews" button will download `feedback.json` as a file. You can then read it from there (you may have to request access first).
+- Packaging works — `package_skill.py` just needs Python and a filesystem.
+- Description optimization (`run_loop.py` / `run_eval.py`) should work in Cowork just fine since it uses `claude -p` via subprocess, not a browser, but please save it until you've fully finished making the skill and the user agrees it's in good shape.
+- **Updating an existing skill**: The user might be asking you to update an existing skill, not create a new one. Follow the update guidance in the claude.ai section above.
+
+---
+
+## Reference files
+
+The agents/ directory contains instructions for specialized subagents. Read them when you need to spawn the relevant subagent.
+
+- `agents/grader.md` — How to evaluate assertions against outputs
+- `agents/comparator.md` — How to do blind A/B comparison between two outputs
+- `agents/analyzer.md` — How to analyze why one version beat another
+
+The references/ directory has additional documentation:
+- `references/schemas.md` — JSON structures for evals.json, grading.json, etc.
+
+---
+
+Repeating one more time the core loop here for emphasis:
+
+- Figure out what the skill is about
+- Draft or edit the skill
+- Run claude-with-access-to-the-skill on test prompts
+- With the user, evaluate the outputs:
+  - Create benchmark.json and run `eval-viewer/generate_review.py` to help the user review them
+  - Run quantitative evals
+- Repeat until you and the user are satisfied
+- Package the final skill and return it to the user.
+
+Please add steps to your TodoList, if you have such a thing, to make sure you don't forget. If you're in Cowork, please specifically put "Create evals JSON and run `eval-viewer/generate_review.py` so human can review test cases" in your TodoList to make sure it happens.
+
+Good luck!

--- a/.claude/skills/skill-creator/agents/analyzer.md
+++ b/.claude/skills/skill-creator/agents/analyzer.md
@@ -1,0 +1,274 @@
+# Post-hoc Analyzer Agent
+
+Analyze blind comparison results to understand WHY the winner won and generate improvement suggestions.
+
+## Role
+
+After the blind comparator determines a winner, the Post-hoc Analyzer "unblids" the results by examining the skills and transcripts. The goal is to extract actionable insights: what made the winner better, and how can the loser be improved?
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **winner**: "A" or "B" (from blind comparison)
+- **winner_skill_path**: Path to the skill that produced the winning output
+- **winner_transcript_path**: Path to the execution transcript for the winner
+- **loser_skill_path**: Path to the skill that produced the losing output
+- **loser_transcript_path**: Path to the execution transcript for the loser
+- **comparison_result_path**: Path to the blind comparator's output JSON
+- **output_path**: Where to save the analysis results
+
+## Process
+
+### Step 1: Read Comparison Result
+
+1. Read the blind comparator's output at comparison_result_path
+2. Note the winning side (A or B), the reasoning, and any scores
+3. Understand what the comparator valued in the winning output
+
+### Step 2: Read Both Skills
+
+1. Read the winner skill's SKILL.md and key referenced files
+2. Read the loser skill's SKILL.md and key referenced files
+3. Identify structural differences:
+   - Instructions clarity and specificity
+   - Script/tool usage patterns
+   - Example coverage
+   - Edge case handling
+
+### Step 3: Read Both Transcripts
+
+1. Read the winner's transcript
+2. Read the loser's transcript
+3. Compare execution patterns:
+   - How closely did each follow their skill's instructions?
+   - What tools were used differently?
+   - Where did the loser diverge from optimal behavior?
+   - Did either encounter errors or make recovery attempts?
+
+### Step 4: Analyze Instruction Following
+
+For each transcript, evaluate:
+- Did the agent follow the skill's explicit instructions?
+- Did the agent use the skill's provided tools/scripts?
+- Were there missed opportunities to leverage skill content?
+- Did the agent add unnecessary steps not in the skill?
+
+Score instruction following 1-10 and note specific issues.
+
+### Step 5: Identify Winner Strengths
+
+Determine what made the winner better:
+- Clearer instructions that led to better behavior?
+- Better scripts/tools that produced better output?
+- More comprehensive examples that guided edge cases?
+- Better error handling guidance?
+
+Be specific. Quote from skills/transcripts where relevant.
+
+### Step 6: Identify Loser Weaknesses
+
+Determine what held the loser back:
+- Ambiguous instructions that led to suboptimal choices?
+- Missing tools/scripts that forced workarounds?
+- Gaps in edge case coverage?
+- Poor error handling that caused failures?
+
+### Step 7: Generate Improvement Suggestions
+
+Based on the analysis, produce actionable suggestions for improving the loser skill:
+- Specific instruction changes to make
+- Tools/scripts to add or modify
+- Examples to include
+- Edge cases to address
+
+Prioritize by impact. Focus on changes that would have changed the outcome.
+
+### Step 8: Write Analysis Results
+
+Save structured analysis to `{output_path}`.
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "comparison_summary": {
+    "winner": "A",
+    "winner_skill": "path/to/winner/skill",
+    "loser_skill": "path/to/loser/skill",
+    "comparator_reasoning": "Brief summary of why comparator chose winner"
+  },
+  "winner_strengths": [
+    "Clear step-by-step instructions for handling multi-page documents",
+    "Included validation script that caught formatting errors",
+    "Explicit guidance on fallback behavior when OCR fails"
+  ],
+  "loser_weaknesses": [
+    "Vague instruction 'process the document appropriately' led to inconsistent behavior",
+    "No script for validation, agent had to improvise and made errors",
+    "No guidance on OCR failure, agent gave up instead of trying alternatives"
+  ],
+  "instruction_following": {
+    "winner": {
+      "score": 9,
+      "issues": [
+        "Minor: skipped optional logging step"
+      ]
+    },
+    "loser": {
+      "score": 6,
+      "issues": [
+        "Did not use the skill's formatting template",
+        "Invented own approach instead of following step 3",
+        "Missed the 'always validate output' instruction"
+      ]
+    }
+  },
+  "improvement_suggestions": [
+    {
+      "priority": "high",
+      "category": "instructions",
+      "suggestion": "Replace 'process the document appropriately' with explicit steps: 1) Extract text, 2) Identify sections, 3) Format per template",
+      "expected_impact": "Would eliminate ambiguity that caused inconsistent behavior"
+    },
+    {
+      "priority": "high",
+      "category": "tools",
+      "suggestion": "Add validate_output.py script similar to winner skill's validation approach",
+      "expected_impact": "Would catch formatting errors before final output"
+    },
+    {
+      "priority": "medium",
+      "category": "error_handling",
+      "suggestion": "Add fallback instructions: 'If OCR fails, try: 1) different resolution, 2) image preprocessing, 3) manual extraction'",
+      "expected_impact": "Would prevent early failure on difficult documents"
+    }
+  ],
+  "transcript_insights": {
+    "winner_execution_pattern": "Read skill -> Followed 5-step process -> Used validation script -> Fixed 2 issues -> Produced output",
+    "loser_execution_pattern": "Read skill -> Unclear on approach -> Tried 3 different methods -> No validation -> Output had errors"
+  }
+}
+```
+
+## Guidelines
+
+- **Be specific**: Quote from skills and transcripts, don't just say "instructions were unclear"
+- **Be actionable**: Suggestions should be concrete changes, not vague advice
+- **Focus on skill improvements**: The goal is to improve the losing skill, not critique the agent
+- **Prioritize by impact**: Which changes would most likely have changed the outcome?
+- **Consider causation**: Did the skill weakness actually cause the worse output, or is it incidental?
+- **Stay objective**: Analyze what happened, don't editorialize
+- **Think about generalization**: Would this improvement help on other evals too?
+
+## Categories for Suggestions
+
+Use these categories to organize improvement suggestions:
+
+| Category | Description |
+|----------|-------------|
+| `instructions` | Changes to the skill's prose instructions |
+| `tools` | Scripts, templates, or utilities to add/modify |
+| `examples` | Example inputs/outputs to include |
+| `error_handling` | Guidance for handling failures |
+| `structure` | Reorganization of skill content |
+| `references` | External docs or resources to add |
+
+## Priority Levels
+
+- **high**: Would likely change the outcome of this comparison
+- **medium**: Would improve quality but may not change win/loss
+- **low**: Nice to have, marginal improvement
+
+---
+
+# Analyzing Benchmark Results
+
+When analyzing benchmark results, the analyzer's purpose is to **surface patterns and anomalies** across multiple runs, not suggest skill improvements.
+
+## Role
+
+Review all benchmark run results and generate freeform notes that help the user understand skill performance. Focus on patterns that wouldn't be visible from aggregate metrics alone.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **benchmark_data_path**: Path to the in-progress benchmark.json with all run results
+- **skill_path**: Path to the skill being benchmarked
+- **output_path**: Where to save the notes (as JSON array of strings)
+
+## Process
+
+### Step 1: Read Benchmark Data
+
+1. Read the benchmark.json containing all run results
+2. Note the configurations tested (with_skill, without_skill)
+3. Understand the run_summary aggregates already calculated
+
+### Step 2: Analyze Per-Assertion Patterns
+
+For each expectation across all runs:
+- Does it **always pass** in both configurations? (may not differentiate skill value)
+- Does it **always fail** in both configurations? (may be broken or beyond capability)
+- Does it **always pass with skill but fail without**? (skill clearly adds value here)
+- Does it **always fail with skill but pass without**? (skill may be hurting)
+- Is it **highly variable**? (flaky expectation or non-deterministic behavior)
+
+### Step 3: Analyze Cross-Eval Patterns
+
+Look for patterns across evals:
+- Are certain eval types consistently harder/easier?
+- Do some evals show high variance while others are stable?
+- Are there surprising results that contradict expectations?
+
+### Step 4: Analyze Metrics Patterns
+
+Look at time_seconds, tokens, tool_calls:
+- Does the skill significantly increase execution time?
+- Is there high variance in resource usage?
+- Are there outlier runs that skew the aggregates?
+
+### Step 5: Generate Notes
+
+Write freeform observations as a list of strings. Each note should:
+- State a specific observation
+- Be grounded in the data (not speculation)
+- Help the user understand something the aggregate metrics don't show
+
+Examples:
+- "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value"
+- "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure that may be flaky"
+- "Without-skill runs consistently fail on table extraction expectations (0% pass rate)"
+- "Skill adds 13s average execution time but improves pass rate by 50%"
+- "Token usage is 80% higher with skill, primarily due to script output parsing"
+- "All 3 without-skill runs for eval 1 produced empty output"
+
+### Step 6: Write Notes
+
+Save notes to `{output_path}` as a JSON array of strings:
+
+```json
+[
+  "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
+  "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure",
+  "Without-skill runs consistently fail on table extraction expectations",
+  "Skill adds 13s average execution time but improves pass rate by 50%"
+]
+```
+
+## Guidelines
+
+**DO:**
+- Report what you observe in the data
+- Be specific about which evals, expectations, or runs you're referring to
+- Note patterns that aggregate metrics would hide
+- Provide context that helps interpret the numbers
+
+**DO NOT:**
+- Suggest improvements to the skill (that's for the improvement step, not benchmarking)
+- Make subjective quality judgments ("the output was good/bad")
+- Speculate about causes without evidence
+- Repeat information already in the run_summary aggregates

--- a/.claude/skills/skill-creator/agents/comparator.md
+++ b/.claude/skills/skill-creator/agents/comparator.md
@@ -1,0 +1,202 @@
+# Blind Comparator Agent
+
+Compare two outputs WITHOUT knowing which skill produced them.
+
+## Role
+
+The Blind Comparator judges which output better accomplishes the eval task. You receive two outputs labeled A and B, but you do NOT know which skill produced which. This prevents bias toward a particular skill or approach.
+
+Your judgment is based purely on output quality and task completion.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **output_a_path**: Path to the first output file or directory
+- **output_b_path**: Path to the second output file or directory
+- **eval_prompt**: The original task/prompt that was executed
+- **expectations**: List of expectations to check (optional - may be empty)
+
+## Process
+
+### Step 1: Read Both Outputs
+
+1. Examine output A (file or directory)
+2. Examine output B (file or directory)
+3. Note the type, structure, and content of each
+4. If outputs are directories, examine all relevant files inside
+
+### Step 2: Understand the Task
+
+1. Read the eval_prompt carefully
+2. Identify what the task requires:
+   - What should be produced?
+   - What qualities matter (accuracy, completeness, format)?
+   - What would distinguish a good output from a poor one?
+
+### Step 3: Generate Evaluation Rubric
+
+Based on the task, generate a rubric with two dimensions:
+
+**Content Rubric** (what the output contains):
+| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+|-----------|----------|----------------|---------------|
+| Correctness | Major errors | Minor errors | Fully correct |
+| Completeness | Missing key elements | Mostly complete | All elements present |
+| Accuracy | Significant inaccuracies | Minor inaccuracies | Accurate throughout |
+
+**Structure Rubric** (how the output is organized):
+| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+|-----------|----------|----------------|---------------|
+| Organization | Disorganized | Reasonably organized | Clear, logical structure |
+| Formatting | Inconsistent/broken | Mostly consistent | Professional, polished |
+| Usability | Difficult to use | Usable with effort | Easy to use |
+
+Adapt criteria to the specific task. For example:
+- PDF form → "Field alignment", "Text readability", "Data placement"
+- Document → "Section structure", "Heading hierarchy", "Paragraph flow"
+- Data output → "Schema correctness", "Data types", "Completeness"
+
+### Step 4: Evaluate Each Output Against the Rubric
+
+For each output (A and B):
+
+1. **Score each criterion** on the rubric (1-5 scale)
+2. **Calculate dimension totals**: Content score, Structure score
+3. **Calculate overall score**: Average of dimension scores, scaled to 1-10
+
+### Step 5: Check Assertions (if provided)
+
+If expectations are provided:
+
+1. Check each expectation against output A
+2. Check each expectation against output B
+3. Count pass rates for each output
+4. Use expectation scores as secondary evidence (not the primary decision factor)
+
+### Step 6: Determine the Winner
+
+Compare A and B based on (in priority order):
+
+1. **Primary**: Overall rubric score (content + structure)
+2. **Secondary**: Assertion pass rates (if applicable)
+3. **Tiebreaker**: If truly equal, declare a TIE
+
+Be decisive - ties should be rare. One output is usually better, even if marginally.
+
+### Step 7: Write Comparison Results
+
+Save results to a JSON file at the path specified (or `comparison.json` if not specified).
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "winner": "A",
+  "reasoning": "Output A provides a complete solution with proper formatting and all required fields. Output B is missing the date field and has formatting inconsistencies.",
+  "rubric": {
+    "A": {
+      "content": {
+        "correctness": 5,
+        "completeness": 5,
+        "accuracy": 4
+      },
+      "structure": {
+        "organization": 4,
+        "formatting": 5,
+        "usability": 4
+      },
+      "content_score": 4.7,
+      "structure_score": 4.3,
+      "overall_score": 9.0
+    },
+    "B": {
+      "content": {
+        "correctness": 3,
+        "completeness": 2,
+        "accuracy": 3
+      },
+      "structure": {
+        "organization": 3,
+        "formatting": 2,
+        "usability": 3
+      },
+      "content_score": 2.7,
+      "structure_score": 2.7,
+      "overall_score": 5.4
+    }
+  },
+  "output_quality": {
+    "A": {
+      "score": 9,
+      "strengths": ["Complete solution", "Well-formatted", "All fields present"],
+      "weaknesses": ["Minor style inconsistency in header"]
+    },
+    "B": {
+      "score": 5,
+      "strengths": ["Readable output", "Correct basic structure"],
+      "weaknesses": ["Missing date field", "Formatting inconsistencies", "Partial data extraction"]
+    }
+  },
+  "expectation_results": {
+    "A": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.80,
+      "details": [
+        {"text": "Output includes name", "passed": true},
+        {"text": "Output includes date", "passed": true},
+        {"text": "Format is PDF", "passed": true},
+        {"text": "Contains signature", "passed": false},
+        {"text": "Readable text", "passed": true}
+      ]
+    },
+    "B": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.60,
+      "details": [
+        {"text": "Output includes name", "passed": true},
+        {"text": "Output includes date", "passed": false},
+        {"text": "Format is PDF", "passed": true},
+        {"text": "Contains signature", "passed": false},
+        {"text": "Readable text", "passed": true}
+      ]
+    }
+  }
+}
+```
+
+If no expectations were provided, omit the `expectation_results` field entirely.
+
+## Field Descriptions
+
+- **winner**: "A", "B", or "TIE"
+- **reasoning**: Clear explanation of why the winner was chosen (or why it's a tie)
+- **rubric**: Structured rubric evaluation for each output
+  - **content**: Scores for content criteria (correctness, completeness, accuracy)
+  - **structure**: Scores for structure criteria (organization, formatting, usability)
+  - **content_score**: Average of content criteria (1-5)
+  - **structure_score**: Average of structure criteria (1-5)
+  - **overall_score**: Combined score scaled to 1-10
+- **output_quality**: Summary quality assessment
+  - **score**: 1-10 rating (should match rubric overall_score)
+  - **strengths**: List of positive aspects
+  - **weaknesses**: List of issues or shortcomings
+- **expectation_results**: (Only if expectations provided)
+  - **passed**: Number of expectations that passed
+  - **total**: Total number of expectations
+  - **pass_rate**: Fraction passed (0.0 to 1.0)
+  - **details**: Individual expectation results
+
+## Guidelines
+
+- **Stay blind**: DO NOT try to infer which skill produced which output. Judge purely on output quality.
+- **Be specific**: Cite specific examples when explaining strengths and weaknesses.
+- **Be decisive**: Choose a winner unless outputs are genuinely equivalent.
+- **Output quality first**: Assertion scores are secondary to overall task completion.
+- **Be objective**: Don't favor outputs based on style preferences; focus on correctness and completeness.
+- **Explain your reasoning**: The reasoning field should make it clear why you chose the winner.
+- **Handle edge cases**: If both outputs fail, pick the one that fails less badly. If both are excellent, pick the one that's marginally better.

--- a/.claude/skills/skill-creator/agents/grader.md
+++ b/.claude/skills/skill-creator/agents/grader.md
@@ -1,0 +1,223 @@
+# Grader Agent
+
+Evaluate expectations against an execution transcript and outputs.
+
+## Role
+
+The Grader reviews a transcript and output files, then determines whether each expectation passes or fails. Provide clear evidence for each judgment.
+
+You have two jobs: grade the outputs, and critique the evals themselves. A passing grade on a weak assertion is worse than useless — it creates false confidence. When you notice an assertion that's trivially satisfied, or an important outcome that no assertion checks, say so.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **expectations**: List of expectations to evaluate (strings)
+- **transcript_path**: Path to the execution transcript (markdown file)
+- **outputs_dir**: Directory containing output files from execution
+
+## Process
+
+### Step 1: Read the Transcript
+
+1. Read the transcript file completely
+2. Note the eval prompt, execution steps, and final result
+3. Identify any issues or errors documented
+
+### Step 2: Examine Output Files
+
+1. List files in outputs_dir
+2. Read/examine each file relevant to the expectations. If outputs aren't plain text, use the inspection tools provided in your prompt — don't rely solely on what the transcript says the executor produced.
+3. Note contents, structure, and quality
+
+### Step 3: Evaluate Each Assertion
+
+For each expectation:
+
+1. **Search for evidence** in the transcript and outputs
+2. **Determine verdict**:
+   - **PASS**: Clear evidence the expectation is true AND the evidence reflects genuine task completion, not just surface-level compliance
+   - **FAIL**: No evidence, or evidence contradicts the expectation, or the evidence is superficial (e.g., correct filename but empty/wrong content)
+3. **Cite the evidence**: Quote the specific text or describe what you found
+
+### Step 4: Extract and Verify Claims
+
+Beyond the predefined expectations, extract implicit claims from the outputs and verify them:
+
+1. **Extract claims** from the transcript and outputs:
+   - Factual statements ("The form has 12 fields")
+   - Process claims ("Used pypdf to fill the form")
+   - Quality claims ("All fields were filled correctly")
+
+2. **Verify each claim**:
+   - **Factual claims**: Can be checked against the outputs or external sources
+   - **Process claims**: Can be verified from the transcript
+   - **Quality claims**: Evaluate whether the claim is justified
+
+3. **Flag unverifiable claims**: Note claims that cannot be verified with available information
+
+This catches issues that predefined expectations might miss.
+
+### Step 5: Read User Notes
+
+If `{outputs_dir}/user_notes.md` exists:
+1. Read it and note any uncertainties or issues flagged by the executor
+2. Include relevant concerns in the grading output
+3. These may reveal problems even when expectations pass
+
+### Step 6: Critique the Evals
+
+After grading, consider whether the evals themselves could be improved. Only surface suggestions when there's a clear gap.
+
+Good suggestions test meaningful outcomes — assertions that are hard to satisfy without actually doing the work correctly. Think about what makes an assertion *discriminating*: it passes when the skill genuinely succeeds and fails when it doesn't.
+
+Suggestions worth raising:
+- An assertion that passed but would also pass for a clearly wrong output (e.g., checking filename existence but not file content)
+- An important outcome you observed — good or bad — that no assertion covers at all
+- An assertion that can't actually be verified from the available outputs
+
+Keep the bar high. The goal is to flag things the eval author would say "good catch" about, not to nitpick every assertion.
+
+### Step 7: Write Grading Results
+
+Save results to `{outputs_dir}/../grading.json` (sibling to outputs_dir).
+
+## Grading Criteria
+
+**PASS when**:
+- The transcript or outputs clearly demonstrate the expectation is true
+- Specific evidence can be cited
+- The evidence reflects genuine substance, not just surface compliance (e.g., a file exists AND contains correct content, not just the right filename)
+
+**FAIL when**:
+- No evidence found for the expectation
+- Evidence contradicts the expectation
+- The expectation cannot be verified from available information
+- The evidence is superficial — the assertion is technically satisfied but the underlying task outcome is wrong or incomplete
+- The output appears to meet the assertion by coincidence rather than by actually doing the work
+
+**When uncertain**: The burden of proof to pass is on the expectation.
+
+### Step 8: Read Executor Metrics and Timing
+
+1. If `{outputs_dir}/metrics.json` exists, read it and include in grading output
+2. If `{outputs_dir}/../timing.json` exists, read it and include timing data
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "expectations": [
+    {
+      "text": "The output includes the name 'John Smith'",
+      "passed": true,
+      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
+    },
+    {
+      "text": "The spreadsheet has a SUM formula in cell B10",
+      "passed": false,
+      "evidence": "No spreadsheet was created. The output was a text file."
+    },
+    {
+      "text": "The assistant used the skill's OCR script",
+      "passed": true,
+      "evidence": "Transcript Step 2 shows: 'Tool: Bash - python ocr_script.py image.png'"
+    }
+  ],
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "total": 3,
+    "pass_rate": 0.67
+  },
+  "execution_metrics": {
+    "tool_calls": {
+      "Read": 5,
+      "Write": 2,
+      "Bash": 8
+    },
+    "total_tool_calls": 15,
+    "total_steps": 6,
+    "errors_encountered": 0,
+    "output_chars": 12450,
+    "transcript_chars": 3200
+  },
+  "timing": {
+    "executor_duration_seconds": 165.0,
+    "grader_duration_seconds": 26.0,
+    "total_duration_seconds": 191.0
+  },
+  "claims": [
+    {
+      "claim": "The form has 12 fillable fields",
+      "type": "factual",
+      "verified": true,
+      "evidence": "Counted 12 fields in field_info.json"
+    },
+    {
+      "claim": "All required fields were populated",
+      "type": "quality",
+      "verified": false,
+      "evidence": "Reference section was left blank despite data being available"
+    }
+  ],
+  "user_notes_summary": {
+    "uncertainties": ["Used 2023 data, may be stale"],
+    "needs_review": [],
+    "workarounds": ["Fell back to text overlay for non-fillable fields"]
+  },
+  "eval_feedback": {
+    "suggestions": [
+      {
+        "assertion": "The output includes the name 'John Smith'",
+        "reason": "A hallucinated document that mentions the name would also pass — consider checking it appears as the primary contact with matching phone and email from the input"
+      },
+      {
+        "reason": "No assertion checks whether the extracted phone numbers match the input — I observed incorrect numbers in the output that went uncaught"
+      }
+    ],
+    "overall": "Assertions check presence but not correctness. Consider adding content verification."
+  }
+}
+```
+
+## Field Descriptions
+
+- **expectations**: Array of graded expectations
+  - **text**: The original expectation text
+  - **passed**: Boolean - true if expectation passes
+  - **evidence**: Specific quote or description supporting the verdict
+- **summary**: Aggregate statistics
+  - **passed**: Count of passed expectations
+  - **failed**: Count of failed expectations
+  - **total**: Total expectations evaluated
+  - **pass_rate**: Fraction passed (0.0 to 1.0)
+- **execution_metrics**: Copied from executor's metrics.json (if available)
+  - **output_chars**: Total character count of output files (proxy for tokens)
+  - **transcript_chars**: Character count of transcript
+- **timing**: Wall clock timing from timing.json (if available)
+  - **executor_duration_seconds**: Time spent in executor subagent
+  - **total_duration_seconds**: Total elapsed time for the run
+- **claims**: Extracted and verified claims from the output
+  - **claim**: The statement being verified
+  - **type**: "factual", "process", or "quality"
+  - **verified**: Boolean - whether the claim holds
+  - **evidence**: Supporting or contradicting evidence
+- **user_notes_summary**: Issues flagged by the executor
+  - **uncertainties**: Things the executor wasn't sure about
+  - **needs_review**: Items requiring human attention
+  - **workarounds**: Places where the skill didn't work as expected
+- **eval_feedback**: Improvement suggestions for the evals (only when warranted)
+  - **suggestions**: List of concrete suggestions, each with a `reason` and optionally an `assertion` it relates to
+  - **overall**: Brief assessment — can be "No suggestions, evals look solid" if nothing to flag
+
+## Guidelines
+
+- **Be objective**: Base verdicts on evidence, not assumptions
+- **Be specific**: Quote the exact text that supports your verdict
+- **Be thorough**: Check both transcript and output files
+- **Be consistent**: Apply the same standard to each expectation
+- **Explain failures**: Make it clear why evidence was insufficient
+- **No partial credit**: Each expectation is pass or fail, not partial

--- a/.claude/skills/skill-creator/assets/eval_review.html
+++ b/.claude/skills/skill-creator/assets/eval_review.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Set Review - __SKILL_NAME_PLACEHOLDER__</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Lora', Georgia, serif; background: #faf9f5; padding: 2rem; color: #141413; }
+    h1 { font-family: 'Poppins', sans-serif; margin-bottom: 0.5rem; font-size: 1.5rem; }
+    .description { color: #b0aea5; margin-bottom: 1.5rem; font-style: italic; max-width: 900px; }
+    .controls { margin-bottom: 1rem; display: flex; gap: 0.5rem; }
+    .btn { font-family: 'Poppins', sans-serif; padding: 0.5rem 1rem; border: none; border-radius: 6px; cursor: pointer; font-size: 0.875rem; font-weight: 500; }
+    .btn-add { background: #6a9bcc; color: white; }
+    .btn-add:hover { background: #5889b8; }
+    .btn-export { background: #d97757; color: white; }
+    .btn-export:hover { background: #c4613f; }
+    table { width: 100%; max-width: 1100px; border-collapse: collapse; background: white; border-radius: 6px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+    th { font-family: 'Poppins', sans-serif; background: #141413; color: #faf9f5; padding: 0.75rem 1rem; text-align: left; font-size: 0.875rem; }
+    td { padding: 0.75rem 1rem; border-bottom: 1px solid #e8e6dc; vertical-align: top; }
+    tr:nth-child(even) td { background: #faf9f5; }
+    tr:hover td { background: #f3f1ea; }
+    .section-header td { background: #e8e6dc; font-family: 'Poppins', sans-serif; font-weight: 500; font-size: 0.8rem; color: #141413; text-transform: uppercase; letter-spacing: 0.05em; }
+    .query-input { width: 100%; padding: 0.4rem; border: 1px solid #e8e6dc; border-radius: 4px; font-size: 0.875rem; font-family: 'Lora', Georgia, serif; resize: vertical; min-height: 60px; }
+    .query-input:focus { outline: none; border-color: #d97757; box-shadow: 0 0 0 2px rgba(217,119,87,0.15); }
+    .toggle { position: relative; display: inline-block; width: 44px; height: 24px; }
+    .toggle input { opacity: 0; width: 0; height: 0; }
+    .toggle .slider { position: absolute; inset: 0; background: #b0aea5; border-radius: 24px; cursor: pointer; transition: 0.2s; }
+    .toggle .slider::before { content: ""; position: absolute; width: 18px; height: 18px; left: 3px; bottom: 3px; background: white; border-radius: 50%; transition: 0.2s; }
+    .toggle input:checked + .slider { background: #d97757; }
+    .toggle input:checked + .slider::before { transform: translateX(20px); }
+    .btn-delete { background: #c44; color: white; padding: 0.3rem 0.6rem; border: none; border-radius: 4px; cursor: pointer; font-size: 0.75rem; font-family: 'Poppins', sans-serif; }
+    .btn-delete:hover { background: #a33; }
+    .summary { margin-top: 1rem; color: #b0aea5; font-size: 0.875rem; }
+  </style>
+</head>
+<body>
+  <h1>Eval Set Review: <span id="skill-name">__SKILL_NAME_PLACEHOLDER__</span></h1>
+  <p class="description">Current description: <span id="skill-desc">__SKILL_DESCRIPTION_PLACEHOLDER__</span></p>
+
+  <div class="controls">
+    <button class="btn btn-add" onclick="addRow()">+ Add Query</button>
+    <button class="btn btn-export" onclick="exportEvalSet()">Export Eval Set</button>
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th style="width:65%">Query</th>
+        <th style="width:18%">Should Trigger</th>
+        <th style="width:10%">Actions</th>
+      </tr>
+    </thead>
+    <tbody id="eval-body"></tbody>
+  </table>
+
+  <p class="summary" id="summary"></p>
+
+  <script>
+    const EVAL_DATA = __EVAL_DATA_PLACEHOLDER__;
+
+    let evalItems = [...EVAL_DATA];
+
+    function render() {
+      const tbody = document.getElementById('eval-body');
+      tbody.innerHTML = '';
+
+      // Sort: should-trigger first, then should-not-trigger
+      const sorted = evalItems
+        .map((item, origIdx) => ({ ...item, origIdx }))
+        .sort((a, b) => (b.should_trigger ? 1 : 0) - (a.should_trigger ? 1 : 0));
+
+      let lastGroup = null;
+      sorted.forEach(item => {
+        const group = item.should_trigger ? 'trigger' : 'no-trigger';
+        if (group !== lastGroup) {
+          const headerRow = document.createElement('tr');
+          headerRow.className = 'section-header';
+          headerRow.innerHTML = `<td colspan="3">${item.should_trigger ? 'Should Trigger' : 'Should NOT Trigger'}</td>`;
+          tbody.appendChild(headerRow);
+          lastGroup = group;
+        }
+
+        const idx = item.origIdx;
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td><textarea class="query-input" onchange="updateQuery(${idx}, this.value)">${escapeHtml(item.query)}</textarea></td>
+          <td>
+            <label class="toggle">
+              <input type="checkbox" ${item.should_trigger ? 'checked' : ''} onchange="updateTrigger(${idx}, this.checked)">
+              <span class="slider"></span>
+            </label>
+            <span style="margin-left:8px;font-size:0.8rem;color:#b0aea5">${item.should_trigger ? 'Yes' : 'No'}</span>
+          </td>
+          <td><button class="btn-delete" onclick="deleteRow(${idx})">Delete</button></td>
+        `;
+        tbody.appendChild(tr);
+      });
+      updateSummary();
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement('div');
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    function updateQuery(idx, value) { evalItems[idx].query = value; updateSummary(); }
+    function updateTrigger(idx, value) { evalItems[idx].should_trigger = value; render(); }
+    function deleteRow(idx) { evalItems.splice(idx, 1); render(); }
+
+    function addRow() {
+      evalItems.push({ query: '', should_trigger: true });
+      render();
+      const inputs = document.querySelectorAll('.query-input');
+      inputs[inputs.length - 1].focus();
+    }
+
+    function updateSummary() {
+      const trigger = evalItems.filter(i => i.should_trigger).length;
+      const noTrigger = evalItems.filter(i => !i.should_trigger).length;
+      document.getElementById('summary').textContent =
+        `${evalItems.length} queries total: ${trigger} should trigger, ${noTrigger} should not trigger`;
+    }
+
+    function exportEvalSet() {
+      const valid = evalItems.filter(i => i.query.trim() !== '');
+      const data = valid.map(i => ({ query: i.query.trim(), should_trigger: i.should_trigger }));
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'eval_set.json';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }
+
+    render();
+  </script>
+</body>
+</html>

--- a/.claude/skills/skill-creator/eval-viewer/generate_review.py
+++ b/.claude/skills/skill-creator/eval-viewer/generate_review.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Generate and serve a review page for eval results.
+
+Reads the workspace directory, discovers runs (directories with outputs/),
+embeds all output data into a self-contained HTML page, and serves it via
+a tiny HTTP server. Feedback auto-saves to feedback.json in the workspace.
+
+Usage:
+    python generate_review.py <workspace-path> [--port PORT] [--skill-name NAME]
+    python generate_review.py <workspace-path> --previous-feedback /path/to/old/feedback.json
+
+No dependencies beyond the Python stdlib are required.
+"""
+
+import argparse
+import base64
+import json
+import mimetypes
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+import webbrowser
+from functools import partial
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+
+# Files to exclude from output listings
+METADATA_FILES = {"transcript.md", "user_notes.md", "metrics.json"}
+
+# Extensions we render as inline text
+TEXT_EXTENSIONS = {
+    ".txt", ".md", ".json", ".csv", ".py", ".js", ".ts", ".tsx", ".jsx",
+    ".yaml", ".yml", ".xml", ".html", ".css", ".sh", ".rb", ".go", ".rs",
+    ".java", ".c", ".cpp", ".h", ".hpp", ".sql", ".r", ".toml",
+}
+
+# Extensions we render as inline images
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"}
+
+# MIME type overrides for common types
+MIME_OVERRIDES = {
+    ".svg": "image/svg+xml",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+}
+
+
+def get_mime_type(path: Path) -> str:
+    ext = path.suffix.lower()
+    if ext in MIME_OVERRIDES:
+        return MIME_OVERRIDES[ext]
+    mime, _ = mimetypes.guess_type(str(path))
+    return mime or "application/octet-stream"
+
+
+def find_runs(workspace: Path) -> list[dict]:
+    """Recursively find directories that contain an outputs/ subdirectory."""
+    runs: list[dict] = []
+    _find_runs_recursive(workspace, workspace, runs)
+    runs.sort(key=lambda r: (r.get("eval_id", float("inf")), r["id"]))
+    return runs
+
+
+def _find_runs_recursive(root: Path, current: Path, runs: list[dict]) -> None:
+    if not current.is_dir():
+        return
+
+    outputs_dir = current / "outputs"
+    if outputs_dir.is_dir():
+        run = build_run(root, current)
+        if run:
+            runs.append(run)
+        return
+
+    skip = {"node_modules", ".git", "__pycache__", "skill", "inputs"}
+    for child in sorted(current.iterdir()):
+        if child.is_dir() and child.name not in skip:
+            _find_runs_recursive(root, child, runs)
+
+
+def build_run(root: Path, run_dir: Path) -> dict | None:
+    """Build a run dict with prompt, outputs, and grading data."""
+    prompt = ""
+    eval_id = None
+
+    # Try eval_metadata.json
+    for candidate in [run_dir / "eval_metadata.json", run_dir.parent / "eval_metadata.json"]:
+        if candidate.exists():
+            try:
+                metadata = json.loads(candidate.read_text())
+                prompt = metadata.get("prompt", "")
+                eval_id = metadata.get("eval_id")
+            except (json.JSONDecodeError, OSError):
+                pass
+            if prompt:
+                break
+
+    # Fall back to transcript.md
+    if not prompt:
+        for candidate in [run_dir / "transcript.md", run_dir / "outputs" / "transcript.md"]:
+            if candidate.exists():
+                try:
+                    text = candidate.read_text()
+                    match = re.search(r"## Eval Prompt\n\n([\s\S]*?)(?=\n##|$)", text)
+                    if match:
+                        prompt = match.group(1).strip()
+                except OSError:
+                    pass
+                if prompt:
+                    break
+
+    if not prompt:
+        prompt = "(No prompt found)"
+
+    run_id = str(run_dir.relative_to(root)).replace("/", "-").replace("\\", "-")
+
+    # Collect output files
+    outputs_dir = run_dir / "outputs"
+    output_files: list[dict] = []
+    if outputs_dir.is_dir():
+        for f in sorted(outputs_dir.iterdir()):
+            if f.is_file() and f.name not in METADATA_FILES:
+                output_files.append(embed_file(f))
+
+    # Load grading if present
+    grading = None
+    for candidate in [run_dir / "grading.json", run_dir.parent / "grading.json"]:
+        if candidate.exists():
+            try:
+                grading = json.loads(candidate.read_text())
+            except (json.JSONDecodeError, OSError):
+                pass
+            if grading:
+                break
+
+    return {
+        "id": run_id,
+        "prompt": prompt,
+        "eval_id": eval_id,
+        "outputs": output_files,
+        "grading": grading,
+    }
+
+
+def embed_file(path: Path) -> dict:
+    """Read a file and return an embedded representation."""
+    ext = path.suffix.lower()
+    mime = get_mime_type(path)
+
+    if ext in TEXT_EXTENSIONS:
+        try:
+            content = path.read_text(errors="replace")
+        except OSError:
+            content = "(Error reading file)"
+        return {
+            "name": path.name,
+            "type": "text",
+            "content": content,
+        }
+    elif ext in IMAGE_EXTENSIONS:
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "image",
+            "mime": mime,
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+    elif ext == ".pdf":
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "pdf",
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+    elif ext == ".xlsx":
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "xlsx",
+            "data_b64": b64,
+        }
+    else:
+        # Binary / unknown — base64 download link
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "binary",
+            "mime": mime,
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+
+
+def load_previous_iteration(workspace: Path) -> dict[str, dict]:
+    """Load previous iteration's feedback and outputs.
+
+    Returns a map of run_id -> {"feedback": str, "outputs": list[dict]}.
+    """
+    result: dict[str, dict] = {}
+
+    # Load feedback
+    feedback_map: dict[str, str] = {}
+    feedback_path = workspace / "feedback.json"
+    if feedback_path.exists():
+        try:
+            data = json.loads(feedback_path.read_text())
+            feedback_map = {
+                r["run_id"]: r["feedback"]
+                for r in data.get("reviews", [])
+                if r.get("feedback", "").strip()
+            }
+        except (json.JSONDecodeError, OSError, KeyError):
+            pass
+
+    # Load runs (to get outputs)
+    prev_runs = find_runs(workspace)
+    for run in prev_runs:
+        result[run["id"]] = {
+            "feedback": feedback_map.get(run["id"], ""),
+            "outputs": run.get("outputs", []),
+        }
+
+    # Also add feedback for run_ids that had feedback but no matching run
+    for run_id, fb in feedback_map.items():
+        if run_id not in result:
+            result[run_id] = {"feedback": fb, "outputs": []}
+
+    return result
+
+
+def generate_html(
+    runs: list[dict],
+    skill_name: str,
+    previous: dict[str, dict] | None = None,
+    benchmark: dict | None = None,
+) -> str:
+    """Generate the complete standalone HTML page with embedded data."""
+    template_path = Path(__file__).parent / "viewer.html"
+    template = template_path.read_text()
+
+    # Build previous_feedback and previous_outputs maps for the template
+    previous_feedback: dict[str, str] = {}
+    previous_outputs: dict[str, list[dict]] = {}
+    if previous:
+        for run_id, data in previous.items():
+            if data.get("feedback"):
+                previous_feedback[run_id] = data["feedback"]
+            if data.get("outputs"):
+                previous_outputs[run_id] = data["outputs"]
+
+    embedded = {
+        "skill_name": skill_name,
+        "runs": runs,
+        "previous_feedback": previous_feedback,
+        "previous_outputs": previous_outputs,
+    }
+    if benchmark:
+        embedded["benchmark"] = benchmark
+
+    data_json = json.dumps(embedded)
+
+    return template.replace("/*__EMBEDDED_DATA__*/", f"const EMBEDDED_DATA = {data_json};")
+
+
+# ---------------------------------------------------------------------------
+# HTTP server (stdlib only, zero dependencies)
+# ---------------------------------------------------------------------------
+
+def _kill_port(port: int) -> None:
+    """Kill any process listening on the given port."""
+    try:
+        result = subprocess.run(
+            ["lsof", "-ti", f":{port}"],
+            capture_output=True, text=True, timeout=5,
+        )
+        for pid_str in result.stdout.strip().split("\n"):
+            if pid_str.strip():
+                try:
+                    os.kill(int(pid_str.strip()), signal.SIGTERM)
+                except (ProcessLookupError, ValueError):
+                    pass
+        if result.stdout.strip():
+            time.sleep(0.5)
+    except subprocess.TimeoutExpired:
+        pass
+    except FileNotFoundError:
+        print("Note: lsof not found, cannot check if port is in use", file=sys.stderr)
+
+class ReviewHandler(BaseHTTPRequestHandler):
+    """Serves the review HTML and handles feedback saves.
+
+    Regenerates the HTML on each page load so that refreshing the browser
+    picks up new eval outputs without restarting the server.
+    """
+
+    def __init__(
+        self,
+        workspace: Path,
+        skill_name: str,
+        feedback_path: Path,
+        previous: dict[str, dict],
+        benchmark_path: Path | None,
+        *args,
+        **kwargs,
+    ):
+        self.workspace = workspace
+        self.skill_name = skill_name
+        self.feedback_path = feedback_path
+        self.previous = previous
+        self.benchmark_path = benchmark_path
+        super().__init__(*args, **kwargs)
+
+    def do_GET(self) -> None:
+        if self.path == "/" or self.path == "/index.html":
+            # Regenerate HTML on each request (re-scans workspace for new outputs)
+            runs = find_runs(self.workspace)
+            benchmark = None
+            if self.benchmark_path and self.benchmark_path.exists():
+                try:
+                    benchmark = json.loads(self.benchmark_path.read_text())
+                except (json.JSONDecodeError, OSError):
+                    pass
+            html = generate_html(runs, self.skill_name, self.previous, benchmark)
+            content = html.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
+        elif self.path == "/api/feedback":
+            data = b"{}"
+            if self.feedback_path.exists():
+                data = self.feedback_path.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+        else:
+            self.send_error(404)
+
+    def do_POST(self) -> None:
+        if self.path == "/api/feedback":
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            try:
+                data = json.loads(body)
+                if not isinstance(data, dict) or "reviews" not in data:
+                    raise ValueError("Expected JSON object with 'reviews' key")
+                self.feedback_path.write_text(json.dumps(data, indent=2) + "\n")
+                resp = b'{"ok":true}'
+                self.send_response(200)
+            except (json.JSONDecodeError, OSError, ValueError) as e:
+                resp = json.dumps({"error": str(e)}).encode()
+                self.send_response(500)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(resp)))
+            self.end_headers()
+            self.wfile.write(resp)
+        else:
+            self.send_error(404)
+
+    def log_message(self, format: str, *args: object) -> None:
+        # Suppress request logging to keep terminal clean
+        pass
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate and serve eval review")
+    parser.add_argument("workspace", type=Path, help="Path to workspace directory")
+    parser.add_argument("--port", "-p", type=int, default=3117, help="Server port (default: 3117)")
+    parser.add_argument("--skill-name", "-n", type=str, default=None, help="Skill name for header")
+    parser.add_argument(
+        "--previous-workspace", type=Path, default=None,
+        help="Path to previous iteration's workspace (shows old outputs and feedback as context)",
+    )
+    parser.add_argument(
+        "--benchmark", type=Path, default=None,
+        help="Path to benchmark.json to show in the Benchmark tab",
+    )
+    parser.add_argument(
+        "--static", "-s", type=Path, default=None,
+        help="Write standalone HTML to this path instead of starting a server",
+    )
+    args = parser.parse_args()
+
+    workspace = args.workspace.resolve()
+    if not workspace.is_dir():
+        print(f"Error: {workspace} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    runs = find_runs(workspace)
+    if not runs:
+        print(f"No runs found in {workspace}", file=sys.stderr)
+        sys.exit(1)
+
+    skill_name = args.skill_name or workspace.name.replace("-workspace", "")
+    feedback_path = workspace / "feedback.json"
+
+    previous: dict[str, dict] = {}
+    if args.previous_workspace:
+        previous = load_previous_iteration(args.previous_workspace.resolve())
+
+    benchmark_path = args.benchmark.resolve() if args.benchmark else None
+    benchmark = None
+    if benchmark_path and benchmark_path.exists():
+        try:
+            benchmark = json.loads(benchmark_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    if args.static:
+        html = generate_html(runs, skill_name, previous, benchmark)
+        args.static.parent.mkdir(parents=True, exist_ok=True)
+        args.static.write_text(html)
+        print(f"\n  Static viewer written to: {args.static}\n")
+        sys.exit(0)
+
+    # Kill any existing process on the target port
+    port = args.port
+    _kill_port(port)
+    handler = partial(ReviewHandler, workspace, skill_name, feedback_path, previous, benchmark_path)
+    try:
+        server = HTTPServer(("127.0.0.1", port), handler)
+    except OSError:
+        # Port still in use after kill attempt — find a free one
+        server = HTTPServer(("127.0.0.1", 0), handler)
+        port = server.server_address[1]
+
+    url = f"http://localhost:{port}"
+    print(f"\n  Eval Viewer")
+    print(f"  ─────────────────────────────────")
+    print(f"  URL:       {url}")
+    print(f"  Workspace: {workspace}")
+    print(f"  Feedback:  {feedback_path}")
+    if previous:
+        print(f"  Previous:  {args.previous_workspace} ({len(previous)} runs)")
+    if benchmark_path:
+        print(f"  Benchmark: {benchmark_path}")
+    print(f"\n  Press Ctrl+C to stop.\n")
+
+    webbrowser.open(url)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/eval-viewer/viewer.html
+++ b/.claude/skills/skill-creator/eval-viewer/viewer.html
@@ -1,0 +1,1325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Review</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+  <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js" integrity="sha384-EnyY0/GSHQGSxSgMwaIPzSESbqoOLSexfnSMN2AP+39Ckmn92stwABZynq1JyzdT" crossorigin="anonymous"></script>
+  <style>
+    :root {
+      --bg: #faf9f5;
+      --surface: #ffffff;
+      --border: #e8e6dc;
+      --text: #141413;
+      --text-muted: #b0aea5;
+      --accent: #d97757;
+      --accent-hover: #c4613f;
+      --green: #788c5d;
+      --green-bg: #eef2e8;
+      --red: #c44;
+      --red-bg: #fceaea;
+      --header-bg: #141413;
+      --header-text: #faf9f5;
+      --radius: 6px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Lora', Georgia, serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* ---- Header ---- */
+    .header {
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 1rem 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-shrink: 0;
+    }
+    .header h1 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+    .header .instructions {
+      font-size: 0.8rem;
+      opacity: 0.7;
+      margin-top: 0.25rem;
+    }
+    .header .progress {
+      font-size: 0.875rem;
+      opacity: 0.8;
+      text-align: right;
+    }
+
+    /* ---- Main content ---- */
+    .main {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1.5rem 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+    }
+
+    /* ---- Sections ---- */
+    .section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      flex-shrink: 0;
+    }
+    .section-header {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.75rem 1rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      border-bottom: 1px solid var(--border);
+      background: var(--bg);
+    }
+    .section-body {
+      padding: 1rem;
+    }
+
+    /* ---- Config badge ---- */
+    .config-badge {
+      display: inline-block;
+      padding: 0.2rem 0.625rem;
+      border-radius: 9999px;
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin-left: 0.75rem;
+      vertical-align: middle;
+    }
+    .config-badge.config-primary {
+      background: rgba(33, 150, 243, 0.12);
+      color: #1976d2;
+    }
+    .config-badge.config-baseline {
+      background: rgba(255, 193, 7, 0.15);
+      color: #f57f17;
+    }
+
+    /* ---- Prompt ---- */
+    .prompt-text {
+      white-space: pre-wrap;
+      font-size: 0.9375rem;
+      line-height: 1.6;
+    }
+
+    /* ---- Outputs ---- */
+    .output-file {
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .output-file + .output-file {
+      margin-top: 1rem;
+    }
+    .output-file-header {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .output-file-header .dl-btn {
+      font-size: 0.7rem;
+      color: var(--accent);
+      text-decoration: none;
+      cursor: pointer;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-weight: 500;
+      opacity: 0.8;
+    }
+    .output-file-header .dl-btn:hover {
+      opacity: 1;
+      text-decoration: underline;
+    }
+    .output-file-content {
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+    .output-file-content pre {
+      font-size: 0.8125rem;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+    }
+    .output-file-content img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+    }
+    .output-file-content iframe {
+      width: 100%;
+      height: 600px;
+      border: none;
+    }
+    .output-file-content table {
+      border-collapse: collapse;
+      font-size: 0.8125rem;
+      width: 100%;
+    }
+    .output-file-content table td,
+    .output-file-content table th {
+      border: 1px solid var(--border);
+      padding: 0.375rem 0.5rem;
+      text-align: left;
+    }
+    .output-file-content table th {
+      background: var(--bg);
+      font-weight: 600;
+    }
+    .output-file-content .download-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--accent);
+      text-decoration: none;
+      font-size: 0.875rem;
+      cursor: pointer;
+    }
+    .output-file-content .download-link:hover {
+      background: var(--border);
+    }
+    .empty-state {
+      color: var(--text-muted);
+      font-style: italic;
+      padding: 2rem;
+      text-align: center;
+    }
+
+    /* ---- Feedback ---- */
+    .prev-feedback {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 0.625rem 0.75rem;
+      margin-top: 0.75rem;
+      font-size: 0.8125rem;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+    .prev-feedback-label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin-bottom: 0.25rem;
+      color: var(--text-muted);
+    }
+    .feedback-textarea {
+      width: 100%;
+      min-height: 100px;
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      font-family: inherit;
+      font-size: 0.9375rem;
+      line-height: 1.5;
+      resize: vertical;
+      color: var(--text);
+    }
+    .feedback-textarea:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+    .feedback-status {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-top: 0.5rem;
+      min-height: 1.1em;
+    }
+
+    /* ---- Grades (collapsible) ---- */
+    .grades-toggle {
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      user-select: none;
+    }
+    .grades-toggle:hover {
+      color: var(--accent);
+    }
+    .grades-toggle .arrow {
+      margin-right: 0.5rem;
+      transition: transform 0.15s;
+      font-size: 0.75rem;
+    }
+    .grades-toggle .arrow.open {
+      transform: rotate(90deg);
+    }
+    .grades-content {
+      display: none;
+      margin-top: 0.75rem;
+    }
+    .grades-content.open {
+      display: block;
+    }
+    .grades-summary {
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .grade-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+    .grade-pass { background: var(--green-bg); color: var(--green); }
+    .grade-fail { background: var(--red-bg); color: var(--red); }
+    .assertion-list {
+      list-style: none;
+    }
+    .assertion-item {
+      padding: 0.625rem 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.8125rem;
+    }
+    .assertion-item:last-child { border-bottom: none; }
+    .assertion-status {
+      font-weight: 600;
+      margin-right: 0.5rem;
+    }
+    .assertion-status.pass { color: var(--green); }
+    .assertion-status.fail { color: var(--red); }
+    .assertion-evidence {
+      color: var(--text-muted);
+      font-size: 0.75rem;
+      margin-top: 0.25rem;
+      padding-left: 1.5rem;
+    }
+
+    /* ---- View tabs ---- */
+    .view-tabs {
+      display: flex;
+      gap: 0;
+      padding: 0 2rem;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .view-tab {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.625rem 1.25rem;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      background: none;
+      color: var(--text-muted);
+      border-bottom: 2px solid transparent;
+      transition: all 0.15s;
+    }
+    .view-tab:hover { color: var(--text); }
+    .view-tab.active {
+      color: var(--accent);
+      border-bottom-color: var(--accent);
+    }
+    .view-panel { display: none; }
+    .view-panel.active { display: flex; flex-direction: column; flex: 1; overflow: hidden; }
+
+    /* ---- Benchmark view ---- */
+    .benchmark-view {
+      padding: 1.5rem 2rem;
+      overflow-y: auto;
+      flex: 1;
+    }
+    .benchmark-table {
+      border-collapse: collapse;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      font-size: 0.8125rem;
+      width: 100%;
+      margin-bottom: 1.5rem;
+    }
+    .benchmark-table th, .benchmark-table td {
+      padding: 0.625rem 0.75rem;
+      text-align: left;
+      border: 1px solid var(--border);
+    }
+    .benchmark-table th {
+      font-family: 'Poppins', sans-serif;
+      background: var(--header-bg);
+      color: var(--header-text);
+      font-weight: 500;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .benchmark-table tr:hover { background: var(--bg); }
+    .benchmark-table tr.benchmark-row-with { background: rgba(33, 150, 243, 0.06); }
+    .benchmark-table tr.benchmark-row-without { background: rgba(255, 193, 7, 0.06); }
+    .benchmark-table tr.benchmark-row-with:hover { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-without:hover { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-table tr.benchmark-row-avg { font-weight: 600; border-top: 2px solid var(--border); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-with { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-without { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-delta-positive { color: var(--green); font-weight: 600; }
+    .benchmark-delta-negative { color: var(--red); font-weight: 600; }
+    .benchmark-notes {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+    }
+    .benchmark-notes h3 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+    }
+    .benchmark-notes ul {
+      list-style: disc;
+      padding-left: 1.25rem;
+    }
+    .benchmark-notes li {
+      font-size: 0.8125rem;
+      line-height: 1.6;
+      margin-bottom: 0.375rem;
+    }
+    .benchmark-empty {
+      color: var(--text-muted);
+      font-style: italic;
+      text-align: center;
+      padding: 3rem;
+    }
+
+    /* ---- Navigation ---- */
+    .nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 2rem;
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+      flex-shrink: 0;
+    }
+    .nav-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-btn:hover:not(:disabled) {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .nav-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+    .done-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.5rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: all 0.15s;
+    }
+    .done-btn:hover {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .done-btn.ready {
+      border: none;
+      background: var(--accent);
+      color: white;
+      font-weight: 600;
+    }
+    .done-btn.ready:hover {
+      background: var(--accent-hover);
+    }
+    /* ---- Done overlay ---- */
+    .done-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 100;
+      justify-content: center;
+      align-items: center;
+    }
+    .done-overlay.visible {
+      display: flex;
+    }
+    .done-card {
+      background: var(--surface);
+      border-radius: 12px;
+      padding: 2rem 3rem;
+      text-align: center;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+      max-width: 500px;
+    }
+    .done-card h2 {
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .done-card p {
+      color: var(--text-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.5;
+    }
+    .done-card .btn-row {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: center;
+    }
+    .done-card button {
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+    .done-card button:hover {
+      background: var(--bg);
+    }
+    /* ---- Toast ---- */
+    .toast {
+      position: fixed;
+      bottom: 5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 0.625rem 1.25rem;
+      border-radius: var(--radius);
+      font-size: 0.875rem;
+      opacity: 0;
+      transition: opacity 0.3s;
+      pointer-events: none;
+      z-index: 200;
+    }
+    .toast.visible {
+      opacity: 1;
+    }
+  </style>
+</head>
+<body>
+  <div id="app" style="height:100vh; display:flex; flex-direction:column;">
+    <div class="header">
+      <div>
+        <h1>Eval Review: <span id="skill-name"></span></h1>
+        <div class="instructions">Review each output and leave feedback below. Navigate with arrow keys or buttons. When done, copy feedback and paste into Claude Code.</div>
+      </div>
+      <div class="progress" id="progress"></div>
+    </div>
+
+    <!-- View tabs (only shown when benchmark data exists) -->
+    <div class="view-tabs" id="view-tabs" style="display:none;">
+      <button class="view-tab active" onclick="switchView('outputs')">Outputs</button>
+      <button class="view-tab" onclick="switchView('benchmark')">Benchmark</button>
+    </div>
+
+    <!-- Outputs panel (qualitative review) -->
+    <div class="view-panel active" id="panel-outputs">
+    <div class="main">
+      <!-- Prompt -->
+      <div class="section">
+        <div class="section-header">Prompt <span class="config-badge" id="config-badge" style="display:none;"></span></div>
+        <div class="section-body">
+          <div class="prompt-text" id="prompt-text"></div>
+        </div>
+      </div>
+
+      <!-- Outputs -->
+      <div class="section">
+        <div class="section-header">Output</div>
+        <div class="section-body" id="outputs-body">
+          <div class="empty-state">No output files found</div>
+        </div>
+      </div>
+
+      <!-- Previous Output (collapsible) -->
+      <div class="section" id="prev-outputs-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="togglePrevOutputs()">
+            <span class="arrow" id="prev-outputs-arrow">&#9654;</span>
+            Previous Output
+          </div>
+        </div>
+        <div class="grades-content" id="prev-outputs-content"></div>
+      </div>
+
+      <!-- Grades (collapsible) -->
+      <div class="section" id="grades-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="toggleGrades()">
+            <span class="arrow" id="grades-arrow">&#9654;</span>
+            Formal Grades
+          </div>
+        </div>
+        <div class="grades-content" id="grades-content"></div>
+      </div>
+
+      <!-- Feedback -->
+      <div class="section">
+        <div class="section-header">Your Feedback</div>
+        <div class="section-body">
+          <textarea
+            class="feedback-textarea"
+            id="feedback"
+            placeholder="What do you think of this output? Any issues, suggestions, or things that look great?"
+          ></textarea>
+          <div class="feedback-status" id="feedback-status"></div>
+          <div class="prev-feedback" id="prev-feedback" style="display:none;">
+            <div class="prev-feedback-label">Previous feedback</div>
+            <div id="prev-feedback-text"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="nav" id="outputs-nav">
+      <button class="nav-btn" id="prev-btn" onclick="navigate(-1)">&#8592; Previous</button>
+      <button class="done-btn" id="done-btn" onclick="showDoneDialog()">Submit All Reviews</button>
+      <button class="nav-btn" id="next-btn" onclick="navigate(1)">Next &#8594;</button>
+    </div>
+    </div><!-- end panel-outputs -->
+
+    <!-- Benchmark panel (quantitative stats) -->
+    <div class="view-panel" id="panel-benchmark">
+      <div class="benchmark-view" id="benchmark-content">
+        <div class="benchmark-empty">No benchmark data available. Run a benchmark to see quantitative results here.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Done overlay -->
+  <div class="done-overlay" id="done-overlay">
+    <div class="done-card">
+      <h2>Review Complete</h2>
+      <p>Your feedback has been saved. Go back to your Claude Code session and tell Claude you're done reviewing.</p>
+      <div class="btn-row">
+        <button onclick="closeDoneDialog()">OK</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Toast -->
+  <div class="toast" id="toast"></div>
+
+  <script>
+    // ---- Embedded data (injected by generate_review.py) ----
+    /*__EMBEDDED_DATA__*/
+
+    // ---- State ----
+    let feedbackMap = {};  // run_id -> feedback text
+    let currentIndex = 0;
+    let visitedRuns = new Set();
+
+    // ---- Init ----
+    async function init() {
+      // Load saved feedback from server — but only if this isn't a fresh
+      // iteration (indicated by previous_feedback being present). When
+      // previous feedback exists, the feedback.json on disk is stale from
+      // the prior iteration and should not pre-fill the textareas.
+      const hasPrevious = Object.keys(EMBEDDED_DATA.previous_feedback || {}).length > 0
+        || Object.keys(EMBEDDED_DATA.previous_outputs || {}).length > 0;
+      if (!hasPrevious) {
+        try {
+          const resp = await fetch("/api/feedback");
+          const data = await resp.json();
+          if (data.reviews) {
+            for (const r of data.reviews) feedbackMap[r.run_id] = r.feedback;
+          }
+        } catch { /* first run, no feedback yet */ }
+      }
+
+      document.getElementById("skill-name").textContent = EMBEDDED_DATA.skill_name;
+      showRun(0);
+
+      // Wire up feedback auto-save
+      const textarea = document.getElementById("feedback");
+      let saveTimeout = null;
+      textarea.addEventListener("input", () => {
+        clearTimeout(saveTimeout);
+        document.getElementById("feedback-status").textContent = "";
+        saveTimeout = setTimeout(() => saveCurrentFeedback(), 800);
+      });
+    }
+
+    // ---- Navigation ----
+    function navigate(delta) {
+      const newIndex = currentIndex + delta;
+      if (newIndex >= 0 && newIndex < EMBEDDED_DATA.runs.length) {
+        saveCurrentFeedback();
+        showRun(newIndex);
+      }
+    }
+
+    function updateNavButtons() {
+      document.getElementById("prev-btn").disabled = currentIndex === 0;
+      document.getElementById("next-btn").disabled =
+        currentIndex === EMBEDDED_DATA.runs.length - 1;
+    }
+
+    // ---- Show a run ----
+    function showRun(index) {
+      currentIndex = index;
+      const run = EMBEDDED_DATA.runs[index];
+
+      // Progress
+      document.getElementById("progress").textContent =
+        `${index + 1} of ${EMBEDDED_DATA.runs.length}`;
+
+      // Prompt
+      document.getElementById("prompt-text").textContent = run.prompt;
+
+      // Config badge
+      const badge = document.getElementById("config-badge");
+      const configMatch = run.id.match(/(with_skill|without_skill|new_skill|old_skill)/);
+      if (configMatch) {
+        const config = configMatch[1];
+        const isBaseline = config === "without_skill" || config === "old_skill";
+        badge.textContent = config.replace(/_/g, " ");
+        badge.className = "config-badge " + (isBaseline ? "config-baseline" : "config-primary");
+        badge.style.display = "inline-block";
+      } else {
+        badge.style.display = "none";
+      }
+
+      // Outputs
+      renderOutputs(run);
+
+      // Previous outputs
+      renderPrevOutputs(run);
+
+      // Grades
+      renderGrades(run);
+
+      // Previous feedback
+      const prevFb = (EMBEDDED_DATA.previous_feedback || {})[run.id];
+      const prevEl = document.getElementById("prev-feedback");
+      if (prevFb) {
+        document.getElementById("prev-feedback-text").textContent = prevFb;
+        prevEl.style.display = "block";
+      } else {
+        prevEl.style.display = "none";
+      }
+
+      // Feedback
+      document.getElementById("feedback").value = feedbackMap[run.id] || "";
+      document.getElementById("feedback-status").textContent = "";
+
+      updateNavButtons();
+
+      // Track visited runs and promote done button when all visited
+      visitedRuns.add(index);
+      const doneBtn = document.getElementById("done-btn");
+      if (visitedRuns.size >= EMBEDDED_DATA.runs.length) {
+        doneBtn.classList.add("ready");
+      }
+
+      // Scroll main content to top
+      document.querySelector(".main").scrollTop = 0;
+    }
+
+    // ---- Render outputs ----
+    function renderOutputs(run) {
+      const container = document.getElementById("outputs-body");
+      container.innerHTML = "";
+
+      const outputs = run.outputs || [];
+      if (outputs.length === 0) {
+        container.innerHTML = '<div class="empty-state">No output files</div>';
+        return;
+      }
+
+      for (const file of outputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        // Always show file header with download link
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const content = document.createElement("div");
+        content.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          content.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          content.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          content.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(content, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          content.appendChild(a);
+        } else if (file.type === "error") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          pre.style.color = "var(--red)";
+          content.appendChild(pre);
+        }
+
+        fileDiv.appendChild(content);
+        container.appendChild(fileDiv);
+      }
+    }
+
+    // ---- XLSX rendering via SheetJS ----
+    function renderXlsx(container, b64Data) {
+      try {
+        const raw = Uint8Array.from(atob(b64Data), c => c.charCodeAt(0));
+        const wb = XLSX.read(raw, { type: "array" });
+
+        for (let i = 0; i < wb.SheetNames.length; i++) {
+          const sheetName = wb.SheetNames[i];
+          const ws = wb.Sheets[sheetName];
+
+          if (wb.SheetNames.length > 1) {
+            const sheetLabel = document.createElement("div");
+            sheetLabel.style.cssText =
+              "font-weight:600; font-size:0.8rem; color:#b0aea5; margin-top:0.5rem; margin-bottom:0.25rem;";
+            sheetLabel.textContent = "Sheet: " + sheetName;
+            container.appendChild(sheetLabel);
+          }
+
+          const htmlStr = XLSX.utils.sheet_to_html(ws, { editable: false });
+          const wrapper = document.createElement("div");
+          wrapper.innerHTML = htmlStr;
+          container.appendChild(wrapper);
+        }
+      } catch (err) {
+        container.textContent = "Error rendering spreadsheet: " + err.message;
+      }
+    }
+
+    // ---- Grades ----
+    function renderGrades(run) {
+      const section = document.getElementById("grades-section");
+      const content = document.getElementById("grades-content");
+
+      if (!run.grading) {
+        section.style.display = "none";
+        return;
+      }
+
+      const grading = run.grading;
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("grades-arrow").classList.remove("open");
+
+      const summary = grading.summary || {};
+      const expectations = grading.expectations || [];
+
+      let html = '<div style="padding: 1rem;">';
+
+      // Summary line
+      const passRate = summary.pass_rate != null
+        ? Math.round(summary.pass_rate * 100) + "%"
+        : "?";
+      const badgeClass = summary.pass_rate >= 0.8 ? "grade-pass" : summary.pass_rate >= 0.5 ? "" : "grade-fail";
+      html += '<div class="grades-summary">';
+      html += '<span class="grade-badge ' + badgeClass + '">' + passRate + '</span>';
+      html += '<span>' + (summary.passed || 0) + ' passed, ' + (summary.failed || 0) + ' failed of ' + (summary.total || 0) + '</span>';
+      html += '</div>';
+
+      // Assertions list
+      html += '<ul class="assertion-list">';
+      for (const exp of expectations) {
+        const statusClass = exp.passed ? "pass" : "fail";
+        const statusIcon = exp.passed ? "\u2713" : "\u2717";
+        html += '<li class="assertion-item">';
+        html += '<span class="assertion-status ' + statusClass + '">' + statusIcon + '</span>';
+        html += '<span>' + escapeHtml(exp.text) + '</span>';
+        if (exp.evidence) {
+          html += '<div class="assertion-evidence">' + escapeHtml(exp.evidence) + '</div>';
+        }
+        html += '</li>';
+      }
+      html += '</ul>';
+
+      html += '</div>';
+      content.innerHTML = html;
+    }
+
+    function toggleGrades() {
+      const content = document.getElementById("grades-content");
+      const arrow = document.getElementById("grades-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Previous outputs (collapsible) ----
+    function renderPrevOutputs(run) {
+      const section = document.getElementById("prev-outputs-section");
+      const content = document.getElementById("prev-outputs-content");
+      const prevOutputs = (EMBEDDED_DATA.previous_outputs || {})[run.id];
+
+      if (!prevOutputs || prevOutputs.length === 0) {
+        section.style.display = "none";
+        return;
+      }
+
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("prev-outputs-arrow").classList.remove("open");
+
+      // Render the files into the content area
+      content.innerHTML = "";
+      const wrapper = document.createElement("div");
+      wrapper.style.padding = "1rem";
+
+      for (const file of prevOutputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const fc = document.createElement("div");
+        fc.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          fc.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          fc.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          fc.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(fc, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          fc.appendChild(a);
+        }
+
+        fileDiv.appendChild(fc);
+        wrapper.appendChild(fileDiv);
+      }
+
+      content.appendChild(wrapper);
+    }
+
+    function togglePrevOutputs() {
+      const content = document.getElementById("prev-outputs-content");
+      const arrow = document.getElementById("prev-outputs-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Feedback (saved to server -> feedback.json) ----
+    function saveCurrentFeedback() {
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // Build reviews array from map
+      const reviews = [];
+      for (const [run_id, feedback] of Object.entries(feedbackMap)) {
+        if (feedback.trim()) {
+          reviews.push({ run_id, feedback, timestamp: new Date().toISOString() });
+        }
+      }
+
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reviews, status: "in_progress" }),
+      }).then(() => {
+        document.getElementById("feedback-status").textContent = "Saved";
+      }).catch(() => {
+        // Static mode or server unavailable — no-op on auto-save,
+        // feedback will be downloaded on final submit
+        document.getElementById("feedback-status").textContent = "Will download on submit";
+      });
+    }
+
+    // ---- Done ----
+    function showDoneDialog() {
+      // Save current textarea to feedbackMap (but don't POST yet)
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // POST once with status: complete — include ALL runs so the model
+      // can distinguish "no feedback" (looks good) from "not reviewed"
+      const reviews = [];
+      const ts = new Date().toISOString();
+      for (const r of EMBEDDED_DATA.runs) {
+        reviews.push({ run_id: r.id, feedback: feedbackMap[r.id] || "", timestamp: ts });
+      }
+      const payload = JSON.stringify({ reviews, status: "complete" }, null, 2);
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload,
+      }).then(() => {
+        document.getElementById("done-overlay").classList.add("visible");
+      }).catch(() => {
+        // Server not available (static mode) — download as file
+        const blob = new Blob([payload], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "feedback.json";
+        a.click();
+        URL.revokeObjectURL(url);
+        document.getElementById("done-overlay").classList.add("visible");
+      });
+    }
+
+    function closeDoneDialog() {
+      // Reset status back to in_progress
+      saveCurrentFeedback();
+      document.getElementById("done-overlay").classList.remove("visible");
+    }
+
+    // ---- Toast ----
+    function showToast(message) {
+      const toast = document.getElementById("toast");
+      toast.textContent = message;
+      toast.classList.add("visible");
+      setTimeout(() => toast.classList.remove("visible"), 2000);
+    }
+
+    // ---- Keyboard nav ----
+    document.addEventListener("keydown", (e) => {
+      // Don't capture when typing in textarea
+      if (e.target.tagName === "TEXTAREA") return;
+
+      if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault();
+        navigate(-1);
+      } else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault();
+        navigate(1);
+      }
+    });
+
+    // ---- Util ----
+    function getDownloadUri(file) {
+      if (file.data_uri) return file.data_uri;
+      if (file.data_b64) return "data:application/octet-stream;base64," + file.data_b64;
+      if (file.type === "text") return "data:text/plain;charset=utf-8," + encodeURIComponent(file.content);
+      return "#";
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement("div");
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    // ---- View switching ----
+    function switchView(view) {
+      document.querySelectorAll(".view-tab").forEach(t => t.classList.remove("active"));
+      document.querySelectorAll(".view-panel").forEach(p => p.classList.remove("active"));
+      document.querySelector(`[onclick="switchView('${view}')"]`).classList.add("active");
+      document.getElementById("panel-" + view).classList.add("active");
+    }
+
+    // ---- Benchmark rendering ----
+    function renderBenchmark() {
+      const data = EMBEDDED_DATA.benchmark;
+      if (!data) return;
+
+      // Show the tabs
+      document.getElementById("view-tabs").style.display = "flex";
+
+      const container = document.getElementById("benchmark-content");
+      const summary = data.run_summary || {};
+      const metadata = data.metadata || {};
+      const notes = data.notes || [];
+
+      let html = "";
+
+      // Header
+      html += "<h2 style='font-family: Poppins, sans-serif; margin-bottom: 0.5rem;'>Benchmark Results</h2>";
+      html += "<p style='color: var(--text-muted); font-size: 0.875rem; margin-bottom: 1.25rem;'>";
+      if (metadata.skill_name) html += "<strong>" + escapeHtml(metadata.skill_name) + "</strong> &mdash; ";
+      if (metadata.timestamp) html += metadata.timestamp + " &mdash; ";
+      if (metadata.evals_run) html += "Evals: " + metadata.evals_run.join(", ") + " &mdash; ";
+      html += (metadata.runs_per_configuration || "?") + " runs per configuration";
+      html += "</p>";
+
+      // Summary table
+      html += '<table class="benchmark-table">';
+
+      function fmtStat(stat, pct) {
+        if (!stat) return "—";
+        const suffix = pct ? "%" : "";
+        const m = pct ? (stat.mean * 100).toFixed(0) : stat.mean.toFixed(1);
+        const s = pct ? (stat.stddev * 100).toFixed(0) : stat.stddev.toFixed(1);
+        return m + suffix + " ± " + s + suffix;
+      }
+
+      function deltaClass(val) {
+        if (!val) return "";
+        const n = parseFloat(val);
+        if (n > 0) return "benchmark-delta-positive";
+        if (n < 0) return "benchmark-delta-negative";
+        return "";
+      }
+
+      // Discover config names dynamically (everything except "delta")
+      const configs = Object.keys(summary).filter(k => k !== "delta");
+      const configA = configs[0] || "config_a";
+      const configB = configs[1] || "config_b";
+      const labelA = configA.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const labelB = configB.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const a = summary[configA] || {};
+      const b = summary[configB] || {};
+      const delta = summary.delta || {};
+
+      html += "<thead><tr><th>Metric</th><th>" + escapeHtml(labelA) + "</th><th>" + escapeHtml(labelB) + "</th><th>Delta</th></tr></thead>";
+      html += "<tbody>";
+
+      html += "<tr><td><strong>Pass Rate</strong></td>";
+      html += "<td>" + fmtStat(a.pass_rate, true) + "</td>";
+      html += "<td>" + fmtStat(b.pass_rate, true) + "</td>";
+      html += '<td class="' + deltaClass(delta.pass_rate) + '">' + (delta.pass_rate || "—") + "</td></tr>";
+
+      // Time (only show row if data exists)
+      if (a.time_seconds || b.time_seconds) {
+        html += "<tr><td><strong>Time (s)</strong></td>";
+        html += "<td>" + fmtStat(a.time_seconds, false) + "</td>";
+        html += "<td>" + fmtStat(b.time_seconds, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.time_seconds) + '">' + (delta.time_seconds ? delta.time_seconds + "s" : "—") + "</td></tr>";
+      }
+
+      // Tokens (only show row if data exists)
+      if (a.tokens || b.tokens) {
+        html += "<tr><td><strong>Tokens</strong></td>";
+        html += "<td>" + fmtStat(a.tokens, false) + "</td>";
+        html += "<td>" + fmtStat(b.tokens, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.tokens) + '">' + (delta.tokens || "—") + "</td></tr>";
+      }
+
+      html += "</tbody></table>";
+
+      // Per-eval breakdown (if runs data available)
+      const runs = data.runs || [];
+      if (runs.length > 0) {
+        const evalIds = [...new Set(runs.map(r => r.eval_id))].sort((a, b) => a - b);
+
+        html += "<h3 style='font-family: Poppins, sans-serif; margin-bottom: 0.75rem;'>Per-Eval Breakdown</h3>";
+
+        const hasTime = runs.some(r => r.result && r.result.time_seconds != null);
+        const hasErrors = runs.some(r => r.result && r.result.errors > 0);
+
+        for (const evalId of evalIds) {
+          const evalRuns = runs.filter(r => r.eval_id === evalId);
+          const evalName = evalRuns[0] && evalRuns[0].eval_name ? evalRuns[0].eval_name : "Eval " + evalId;
+
+          html += "<h4 style='font-family: Poppins, sans-serif; margin: 1rem 0 0.5rem; color: var(--text);'>" + escapeHtml(evalName) + "</h4>";
+          html += '<table class="benchmark-table">';
+          html += "<thead><tr><th>Config</th><th>Run</th><th>Pass Rate</th>";
+          if (hasTime) html += "<th>Time (s)</th>";
+          if (hasErrors) html += "<th>Crashes During Execution</th>";
+          html += "</tr></thead>";
+          html += "<tbody>";
+
+          // Group by config and render with average rows
+          const configGroups = [...new Set(evalRuns.map(r => r.configuration))];
+          for (let ci = 0; ci < configGroups.length; ci++) {
+            const config = configGroups[ci];
+            const configRuns = evalRuns.filter(r => r.configuration === config);
+            if (configRuns.length === 0) continue;
+
+            const rowClass = ci === 0 ? "benchmark-row-with" : "benchmark-row-without";
+            const configLabel = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+
+            for (const run of configRuns) {
+              const r = run.result || {};
+              const prClass = r.pass_rate >= 0.8 ? "benchmark-delta-positive" : r.pass_rate < 0.5 ? "benchmark-delta-negative" : "";
+              html += '<tr class="' + rowClass + '">';
+              html += "<td>" + configLabel + "</td>";
+              html += "<td>" + run.run_number + "</td>";
+              html += '<td class="' + prClass + '">' + ((r.pass_rate || 0) * 100).toFixed(0) + "% (" + (r.passed || 0) + "/" + (r.total || 0) + ")</td>";
+              if (hasTime) html += "<td>" + (r.time_seconds != null ? r.time_seconds.toFixed(1) : "—") + "</td>";
+              if (hasErrors) html += "<td>" + (r.errors || 0) + "</td>";
+              html += "</tr>";
+            }
+
+            // Average row
+            const rates = configRuns.map(r => (r.result || {}).pass_rate || 0);
+            const avgRate = rates.reduce((a, b) => a + b, 0) / rates.length;
+            const avgPrClass = avgRate >= 0.8 ? "benchmark-delta-positive" : avgRate < 0.5 ? "benchmark-delta-negative" : "";
+            html += '<tr class="benchmark-row-avg ' + rowClass + '">';
+            html += "<td>" + configLabel + "</td>";
+            html += "<td>Avg</td>";
+            html += '<td class="' + avgPrClass + '">' + (avgRate * 100).toFixed(0) + "%</td>";
+            if (hasTime) {
+              const times = configRuns.map(r => (r.result || {}).time_seconds).filter(t => t != null);
+              html += "<td>" + (times.length ? (times.reduce((a, b) => a + b, 0) / times.length).toFixed(1) : "—") + "</td>";
+            }
+            if (hasErrors) html += "<td></td>";
+            html += "</tr>";
+          }
+          html += "</tbody></table>";
+
+          // Per-assertion detail for this eval
+          const runsWithExpectations = {};
+          for (const config of configGroups) {
+            runsWithExpectations[config] = evalRuns.filter(r => r.configuration === config && r.expectations && r.expectations.length > 0);
+          }
+          const hasAnyExpectations = Object.values(runsWithExpectations).some(runs => runs.length > 0);
+          if (hasAnyExpectations) {
+            // Collect all unique assertion texts across all configs
+            const allAssertions = [];
+            const seen = new Set();
+            for (const config of configGroups) {
+              for (const run of runsWithExpectations[config]) {
+                for (const exp of (run.expectations || [])) {
+                  if (!seen.has(exp.text)) {
+                    seen.add(exp.text);
+                    allAssertions.push(exp.text);
+                  }
+                }
+              }
+            }
+
+            html += '<table class="benchmark-table" style="margin-top: 0.5rem;">';
+            html += "<thead><tr><th>Assertion</th>";
+            for (const config of configGroups) {
+              const label = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+              html += "<th>" + escapeHtml(label) + "</th>";
+            }
+            html += "</tr></thead><tbody>";
+
+            for (const assertionText of allAssertions) {
+              html += "<tr><td>" + escapeHtml(assertionText) + "</td>";
+
+              for (const config of configGroups) {
+                html += "<td>";
+                for (const run of runsWithExpectations[config]) {
+                  const exp = (run.expectations || []).find(e => e.text === assertionText);
+                  if (exp) {
+                    const cls = exp.passed ? "benchmark-delta-positive" : "benchmark-delta-negative";
+                    const icon = exp.passed ? "\u2713" : "\u2717";
+                    html += '<span class="' + cls + '" title="Run ' + run.run_number + ': ' + escapeHtml(exp.evidence || "") + '">' + icon + "</span> ";
+                  } else {
+                    html += "— ";
+                  }
+                }
+                html += "</td>";
+              }
+              html += "</tr>";
+            }
+            html += "</tbody></table>";
+          }
+        }
+      }
+
+      // Notes
+      if (notes.length > 0) {
+        html += '<div class="benchmark-notes">';
+        html += "<h3>Analysis Notes</h3>";
+        html += "<ul>";
+        for (const note of notes) {
+          html += "<li>" + escapeHtml(note) + "</li>";
+        }
+        html += "</ul></div>";
+      }
+
+      container.innerHTML = html;
+    }
+
+    // ---- Start ----
+    init();
+    renderBenchmark();
+  </script>
+</body>
+</html>

--- a/.claude/skills/skill-creator/references/schemas.md
+++ b/.claude/skills/skill-creator/references/schemas.md
@@ -1,0 +1,430 @@
+# JSON Schemas
+
+This document defines the JSON schemas used by skill-creator.
+
+---
+
+## evals.json
+
+Defines the evals for a skill. Located at `evals/evals.json` within the skill directory.
+
+```json
+{
+  "skill_name": "example-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "User's example prompt",
+      "expected_output": "Description of expected result",
+      "files": ["evals/files/sample1.pdf"],
+      "expectations": [
+        "The output includes X",
+        "The skill used script Y"
+      ]
+    }
+  ]
+}
+```
+
+**Fields:**
+- `skill_name`: Name matching the skill's frontmatter
+- `evals[].id`: Unique integer identifier
+- `evals[].prompt`: The task to execute
+- `evals[].expected_output`: Human-readable description of success
+- `evals[].files`: Optional list of input file paths (relative to skill root)
+- `evals[].expectations`: List of verifiable statements
+
+---
+
+## history.json
+
+Tracks version progression in Improve mode. Located at workspace root.
+
+```json
+{
+  "started_at": "2026-01-15T10:30:00Z",
+  "skill_name": "pdf",
+  "current_best": "v2",
+  "iterations": [
+    {
+      "version": "v0",
+      "parent": null,
+      "expectation_pass_rate": 0.65,
+      "grading_result": "baseline",
+      "is_current_best": false
+    },
+    {
+      "version": "v1",
+      "parent": "v0",
+      "expectation_pass_rate": 0.75,
+      "grading_result": "won",
+      "is_current_best": false
+    },
+    {
+      "version": "v2",
+      "parent": "v1",
+      "expectation_pass_rate": 0.85,
+      "grading_result": "won",
+      "is_current_best": true
+    }
+  ]
+}
+```
+
+**Fields:**
+- `started_at`: ISO timestamp of when improvement started
+- `skill_name`: Name of the skill being improved
+- `current_best`: Version identifier of the best performer
+- `iterations[].version`: Version identifier (v0, v1, ...)
+- `iterations[].parent`: Parent version this was derived from
+- `iterations[].expectation_pass_rate`: Pass rate from grading
+- `iterations[].grading_result`: "baseline", "won", "lost", or "tie"
+- `iterations[].is_current_best`: Whether this is the current best version
+
+---
+
+## grading.json
+
+Output from the grader agent. Located at `<run-dir>/grading.json`.
+
+```json
+{
+  "expectations": [
+    {
+      "text": "The output includes the name 'John Smith'",
+      "passed": true,
+      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
+    },
+    {
+      "text": "The spreadsheet has a SUM formula in cell B10",
+      "passed": false,
+      "evidence": "No spreadsheet was created. The output was a text file."
+    }
+  ],
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "total": 3,
+    "pass_rate": 0.67
+  },
+  "execution_metrics": {
+    "tool_calls": {
+      "Read": 5,
+      "Write": 2,
+      "Bash": 8
+    },
+    "total_tool_calls": 15,
+    "total_steps": 6,
+    "errors_encountered": 0,
+    "output_chars": 12450,
+    "transcript_chars": 3200
+  },
+  "timing": {
+    "executor_duration_seconds": 165.0,
+    "grader_duration_seconds": 26.0,
+    "total_duration_seconds": 191.0
+  },
+  "claims": [
+    {
+      "claim": "The form has 12 fillable fields",
+      "type": "factual",
+      "verified": true,
+      "evidence": "Counted 12 fields in field_info.json"
+    }
+  ],
+  "user_notes_summary": {
+    "uncertainties": ["Used 2023 data, may be stale"],
+    "needs_review": [],
+    "workarounds": ["Fell back to text overlay for non-fillable fields"]
+  },
+  "eval_feedback": {
+    "suggestions": [
+      {
+        "assertion": "The output includes the name 'John Smith'",
+        "reason": "A hallucinated document that mentions the name would also pass"
+      }
+    ],
+    "overall": "Assertions check presence but not correctness."
+  }
+}
+```
+
+**Fields:**
+- `expectations[]`: Graded expectations with evidence
+- `summary`: Aggregate pass/fail counts
+- `execution_metrics`: Tool usage and output size (from executor's metrics.json)
+- `timing`: Wall clock timing (from timing.json)
+- `claims`: Extracted and verified claims from the output
+- `user_notes_summary`: Issues flagged by the executor
+- `eval_feedback`: (optional) Improvement suggestions for the evals, only present when the grader identifies issues worth raising
+
+---
+
+## metrics.json
+
+Output from the executor agent. Located at `<run-dir>/outputs/metrics.json`.
+
+```json
+{
+  "tool_calls": {
+    "Read": 5,
+    "Write": 2,
+    "Bash": 8,
+    "Edit": 1,
+    "Glob": 2,
+    "Grep": 0
+  },
+  "total_tool_calls": 18,
+  "total_steps": 6,
+  "files_created": ["filled_form.pdf", "field_values.json"],
+  "errors_encountered": 0,
+  "output_chars": 12450,
+  "transcript_chars": 3200
+}
+```
+
+**Fields:**
+- `tool_calls`: Count per tool type
+- `total_tool_calls`: Sum of all tool calls
+- `total_steps`: Number of major execution steps
+- `files_created`: List of output files created
+- `errors_encountered`: Number of errors during execution
+- `output_chars`: Total character count of output files
+- `transcript_chars`: Character count of transcript
+
+---
+
+## timing.json
+
+Wall clock timing for a run. Located at `<run-dir>/timing.json`.
+
+**How to capture:** When a subagent task completes, the task notification includes `total_tokens` and `duration_ms`. Save these immediately — they are not persisted anywhere else and cannot be recovered after the fact.
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332,
+  "total_duration_seconds": 23.3,
+  "executor_start": "2026-01-15T10:30:00Z",
+  "executor_end": "2026-01-15T10:32:45Z",
+  "executor_duration_seconds": 165.0,
+  "grader_start": "2026-01-15T10:32:46Z",
+  "grader_end": "2026-01-15T10:33:12Z",
+  "grader_duration_seconds": 26.0
+}
+```
+
+---
+
+## benchmark.json
+
+Output from Benchmark mode. Located at `benchmarks/<timestamp>/benchmark.json`.
+
+```json
+{
+  "metadata": {
+    "skill_name": "pdf",
+    "skill_path": "/path/to/pdf",
+    "executor_model": "claude-sonnet-4-20250514",
+    "analyzer_model": "most-capable-model",
+    "timestamp": "2026-01-15T10:30:00Z",
+    "evals_run": [1, 2, 3],
+    "runs_per_configuration": 3
+  },
+
+  "runs": [
+    {
+      "eval_id": 1,
+      "eval_name": "Ocean",
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 0.85,
+        "passed": 6,
+        "failed": 1,
+        "total": 7,
+        "time_seconds": 42.5,
+        "tokens": 3800,
+        "tool_calls": 18,
+        "errors": 0
+      },
+      "expectations": [
+        {"text": "...", "passed": true, "evidence": "..."}
+      ],
+      "notes": [
+        "Used 2023 data, may be stale",
+        "Fell back to text overlay for non-fillable fields"
+      ]
+    }
+  ],
+
+  "run_summary": {
+    "with_skill": {
+      "pass_rate": {"mean": 0.85, "stddev": 0.05, "min": 0.80, "max": 0.90},
+      "time_seconds": {"mean": 45.0, "stddev": 12.0, "min": 32.0, "max": 58.0},
+      "tokens": {"mean": 3800, "stddev": 400, "min": 3200, "max": 4100}
+    },
+    "without_skill": {
+      "pass_rate": {"mean": 0.35, "stddev": 0.08, "min": 0.28, "max": 0.45},
+      "time_seconds": {"mean": 32.0, "stddev": 8.0, "min": 24.0, "max": 42.0},
+      "tokens": {"mean": 2100, "stddev": 300, "min": 1800, "max": 2500}
+    },
+    "delta": {
+      "pass_rate": "+0.50",
+      "time_seconds": "+13.0",
+      "tokens": "+1700"
+    }
+  },
+
+  "notes": [
+    "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
+    "Eval 3 shows high variance (50% ± 40%) - may be flaky or model-dependent",
+    "Without-skill runs consistently fail on table extraction expectations",
+    "Skill adds 13s average execution time but improves pass rate by 50%"
+  ]
+}
+```
+
+**Fields:**
+- `metadata`: Information about the benchmark run
+  - `skill_name`: Name of the skill
+  - `timestamp`: When the benchmark was run
+  - `evals_run`: List of eval names or IDs
+  - `runs_per_configuration`: Number of runs per config (e.g. 3)
+- `runs[]`: Individual run results
+  - `eval_id`: Numeric eval identifier
+  - `eval_name`: Human-readable eval name (used as section header in the viewer)
+  - `configuration`: Must be `"with_skill"` or `"without_skill"` (the viewer uses this exact string for grouping and color coding)
+  - `run_number`: Integer run number (1, 2, 3...)
+  - `result`: Nested object with `pass_rate`, `passed`, `total`, `time_seconds`, `tokens`, `errors`
+- `run_summary`: Statistical aggregates per configuration
+  - `with_skill` / `without_skill`: Each contains `pass_rate`, `time_seconds`, `tokens` objects with `mean` and `stddev` fields
+  - `delta`: Difference strings like `"+0.50"`, `"+13.0"`, `"+1700"`
+- `notes`: Freeform observations from the analyzer
+
+**Important:** The viewer reads these field names exactly. Using `config` instead of `configuration`, or putting `pass_rate` at the top level of a run instead of nested under `result`, will cause the viewer to show empty/zero values. Always reference this schema when generating benchmark.json manually.
+
+---
+
+## comparison.json
+
+Output from blind comparator. Located at `<grading-dir>/comparison-N.json`.
+
+```json
+{
+  "winner": "A",
+  "reasoning": "Output A provides a complete solution with proper formatting and all required fields. Output B is missing the date field and has formatting inconsistencies.",
+  "rubric": {
+    "A": {
+      "content": {
+        "correctness": 5,
+        "completeness": 5,
+        "accuracy": 4
+      },
+      "structure": {
+        "organization": 4,
+        "formatting": 5,
+        "usability": 4
+      },
+      "content_score": 4.7,
+      "structure_score": 4.3,
+      "overall_score": 9.0
+    },
+    "B": {
+      "content": {
+        "correctness": 3,
+        "completeness": 2,
+        "accuracy": 3
+      },
+      "structure": {
+        "organization": 3,
+        "formatting": 2,
+        "usability": 3
+      },
+      "content_score": 2.7,
+      "structure_score": 2.7,
+      "overall_score": 5.4
+    }
+  },
+  "output_quality": {
+    "A": {
+      "score": 9,
+      "strengths": ["Complete solution", "Well-formatted", "All fields present"],
+      "weaknesses": ["Minor style inconsistency in header"]
+    },
+    "B": {
+      "score": 5,
+      "strengths": ["Readable output", "Correct basic structure"],
+      "weaknesses": ["Missing date field", "Formatting inconsistencies", "Partial data extraction"]
+    }
+  },
+  "expectation_results": {
+    "A": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.80,
+      "details": [
+        {"text": "Output includes name", "passed": true}
+      ]
+    },
+    "B": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.60,
+      "details": [
+        {"text": "Output includes name", "passed": true}
+      ]
+    }
+  }
+}
+```
+
+---
+
+## analysis.json
+
+Output from post-hoc analyzer. Located at `<grading-dir>/analysis.json`.
+
+```json
+{
+  "comparison_summary": {
+    "winner": "A",
+    "winner_skill": "path/to/winner/skill",
+    "loser_skill": "path/to/loser/skill",
+    "comparator_reasoning": "Brief summary of why comparator chose winner"
+  },
+  "winner_strengths": [
+    "Clear step-by-step instructions for handling multi-page documents",
+    "Included validation script that caught formatting errors"
+  ],
+  "loser_weaknesses": [
+    "Vague instruction 'process the document appropriately' led to inconsistent behavior",
+    "No script for validation, agent had to improvise"
+  ],
+  "instruction_following": {
+    "winner": {
+      "score": 9,
+      "issues": ["Minor: skipped optional logging step"]
+    },
+    "loser": {
+      "score": 6,
+      "issues": [
+        "Did not use the skill's formatting template",
+        "Invented own approach instead of following step 3"
+      ]
+    }
+  },
+  "improvement_suggestions": [
+    {
+      "priority": "high",
+      "category": "instructions",
+      "suggestion": "Replace 'process the document appropriately' with explicit steps",
+      "expected_impact": "Would eliminate ambiguity that caused inconsistent behavior"
+    }
+  ],
+  "transcript_insights": {
+    "winner_execution_pattern": "Read skill -> Followed 5-step process -> Used validation script",
+    "loser_execution_pattern": "Read skill -> Unclear on approach -> Tried 3 different methods"
+  }
+}
+```

--- a/.claude/skills/skill-creator/scripts/aggregate_benchmark.py
+++ b/.claude/skills/skill-creator/scripts/aggregate_benchmark.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""
+Aggregate individual run results into benchmark summary statistics.
+
+Reads grading.json files from run directories and produces:
+- run_summary with mean, stddev, min, max for each metric
+- delta between with_skill and without_skill configurations
+
+Usage:
+    python aggregate_benchmark.py <benchmark_dir>
+
+Example:
+    python aggregate_benchmark.py benchmarks/2026-01-15T10-30-00/
+
+The script supports two directory layouts:
+
+    Workspace layout (from skill-creator iterations):
+    <benchmark_dir>/
+    └── eval-N/
+        ├── with_skill/
+        │   ├── run-1/grading.json
+        │   └── run-2/grading.json
+        └── without_skill/
+            ├── run-1/grading.json
+            └── run-2/grading.json
+
+    Legacy layout (with runs/ subdirectory):
+    <benchmark_dir>/
+    └── runs/
+        └── eval-N/
+            ├── with_skill/
+            │   └── run-1/grading.json
+            └── without_skill/
+                └── run-1/grading.json
+"""
+
+import argparse
+import json
+import math
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def calculate_stats(values: list[float]) -> dict:
+    """Calculate mean, stddev, min, max for a list of values."""
+    if not values:
+        return {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0}
+
+    n = len(values)
+    mean = sum(values) / n
+
+    if n > 1:
+        variance = sum((x - mean) ** 2 for x in values) / (n - 1)
+        stddev = math.sqrt(variance)
+    else:
+        stddev = 0.0
+
+    return {
+        "mean": round(mean, 4),
+        "stddev": round(stddev, 4),
+        "min": round(min(values), 4),
+        "max": round(max(values), 4)
+    }
+
+
+def load_run_results(benchmark_dir: Path) -> dict:
+    """
+    Load all run results from a benchmark directory.
+
+    Returns dict keyed by config name (e.g. "with_skill"/"without_skill",
+    or "new_skill"/"old_skill"), each containing a list of run results.
+    """
+    # Support both layouts: eval dirs directly under benchmark_dir, or under runs/
+    runs_dir = benchmark_dir / "runs"
+    if runs_dir.exists():
+        search_dir = runs_dir
+    elif list(benchmark_dir.glob("eval-*")):
+        search_dir = benchmark_dir
+    else:
+        print(f"No eval directories found in {benchmark_dir} or {benchmark_dir / 'runs'}")
+        return {}
+
+    results: dict[str, list] = {}
+
+    for eval_idx, eval_dir in enumerate(sorted(search_dir.glob("eval-*"))):
+        metadata_path = eval_dir / "eval_metadata.json"
+        if metadata_path.exists():
+            try:
+                with open(metadata_path) as mf:
+                    eval_id = json.load(mf).get("eval_id", eval_idx)
+            except (json.JSONDecodeError, OSError):
+                eval_id = eval_idx
+        else:
+            try:
+                eval_id = int(eval_dir.name.split("-")[1])
+            except ValueError:
+                eval_id = eval_idx
+
+        # Discover config directories dynamically rather than hardcoding names
+        for config_dir in sorted(eval_dir.iterdir()):
+            if not config_dir.is_dir():
+                continue
+            # Skip non-config directories (inputs, outputs, etc.)
+            if not list(config_dir.glob("run-*")):
+                continue
+            config = config_dir.name
+            if config not in results:
+                results[config] = []
+
+            for run_dir in sorted(config_dir.glob("run-*")):
+                run_number = int(run_dir.name.split("-")[1])
+                grading_file = run_dir / "grading.json"
+
+                if not grading_file.exists():
+                    print(f"Warning: grading.json not found in {run_dir}")
+                    continue
+
+                try:
+                    with open(grading_file) as f:
+                        grading = json.load(f)
+                except json.JSONDecodeError as e:
+                    print(f"Warning: Invalid JSON in {grading_file}: {e}")
+                    continue
+
+                # Extract metrics
+                result = {
+                    "eval_id": eval_id,
+                    "run_number": run_number,
+                    "pass_rate": grading.get("summary", {}).get("pass_rate", 0.0),
+                    "passed": grading.get("summary", {}).get("passed", 0),
+                    "failed": grading.get("summary", {}).get("failed", 0),
+                    "total": grading.get("summary", {}).get("total", 0),
+                }
+
+                # Extract timing — check grading.json first, then sibling timing.json
+                timing = grading.get("timing", {})
+                result["time_seconds"] = timing.get("total_duration_seconds", 0.0)
+                timing_file = run_dir / "timing.json"
+                if result["time_seconds"] == 0.0 and timing_file.exists():
+                    try:
+                        with open(timing_file) as tf:
+                            timing_data = json.load(tf)
+                        result["time_seconds"] = timing_data.get("total_duration_seconds", 0.0)
+                        result["tokens"] = timing_data.get("total_tokens", 0)
+                    except json.JSONDecodeError:
+                        pass
+
+                # Extract metrics if available
+                metrics = grading.get("execution_metrics", {})
+                result["tool_calls"] = metrics.get("total_tool_calls", 0)
+                if not result.get("tokens"):
+                    result["tokens"] = metrics.get("output_chars", 0)
+                result["errors"] = metrics.get("errors_encountered", 0)
+
+                # Extract expectations — viewer requires fields: text, passed, evidence
+                raw_expectations = grading.get("expectations", [])
+                for exp in raw_expectations:
+                    if "text" not in exp or "passed" not in exp:
+                        print(f"Warning: expectation in {grading_file} missing required fields (text, passed, evidence): {exp}")
+                result["expectations"] = raw_expectations
+
+                # Extract notes from user_notes_summary
+                notes_summary = grading.get("user_notes_summary", {})
+                notes = []
+                notes.extend(notes_summary.get("uncertainties", []))
+                notes.extend(notes_summary.get("needs_review", []))
+                notes.extend(notes_summary.get("workarounds", []))
+                result["notes"] = notes
+
+                results[config].append(result)
+
+    return results
+
+
+def aggregate_results(results: dict) -> dict:
+    """
+    Aggregate run results into summary statistics.
+
+    Returns run_summary with stats for each configuration and delta.
+    """
+    run_summary = {}
+    configs = list(results.keys())
+
+    for config in configs:
+        runs = results.get(config, [])
+
+        if not runs:
+            run_summary[config] = {
+                "pass_rate": {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0},
+                "time_seconds": {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0},
+                "tokens": {"mean": 0, "stddev": 0, "min": 0, "max": 0}
+            }
+            continue
+
+        pass_rates = [r["pass_rate"] for r in runs]
+        times = [r["time_seconds"] for r in runs]
+        tokens = [r.get("tokens", 0) for r in runs]
+
+        run_summary[config] = {
+            "pass_rate": calculate_stats(pass_rates),
+            "time_seconds": calculate_stats(times),
+            "tokens": calculate_stats(tokens)
+        }
+
+    # Calculate delta between the first two configs (if two exist)
+    if len(configs) >= 2:
+        primary = run_summary.get(configs[0], {})
+        baseline = run_summary.get(configs[1], {})
+    else:
+        primary = run_summary.get(configs[0], {}) if configs else {}
+        baseline = {}
+
+    delta_pass_rate = primary.get("pass_rate", {}).get("mean", 0) - baseline.get("pass_rate", {}).get("mean", 0)
+    delta_time = primary.get("time_seconds", {}).get("mean", 0) - baseline.get("time_seconds", {}).get("mean", 0)
+    delta_tokens = primary.get("tokens", {}).get("mean", 0) - baseline.get("tokens", {}).get("mean", 0)
+
+    run_summary["delta"] = {
+        "pass_rate": f"{delta_pass_rate:+.2f}",
+        "time_seconds": f"{delta_time:+.1f}",
+        "tokens": f"{delta_tokens:+.0f}"
+    }
+
+    return run_summary
+
+
+def generate_benchmark(benchmark_dir: Path, skill_name: str = "", skill_path: str = "") -> dict:
+    """
+    Generate complete benchmark.json from run results.
+    """
+    results = load_run_results(benchmark_dir)
+    run_summary = aggregate_results(results)
+
+    # Build runs array for benchmark.json
+    runs = []
+    for config in results:
+        for result in results[config]:
+            runs.append({
+                "eval_id": result["eval_id"],
+                "configuration": config,
+                "run_number": result["run_number"],
+                "result": {
+                    "pass_rate": result["pass_rate"],
+                    "passed": result["passed"],
+                    "failed": result["failed"],
+                    "total": result["total"],
+                    "time_seconds": result["time_seconds"],
+                    "tokens": result.get("tokens", 0),
+                    "tool_calls": result.get("tool_calls", 0),
+                    "errors": result.get("errors", 0)
+                },
+                "expectations": result["expectations"],
+                "notes": result["notes"]
+            })
+
+    # Determine eval IDs from results
+    eval_ids = sorted(set(
+        r["eval_id"]
+        for config in results.values()
+        for r in config
+    ))
+
+    benchmark = {
+        "metadata": {
+            "skill_name": skill_name or "<skill-name>",
+            "skill_path": skill_path or "<path/to/skill>",
+            "executor_model": "<model-name>",
+            "analyzer_model": "<model-name>",
+            "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "evals_run": eval_ids,
+            "runs_per_configuration": 3
+        },
+        "runs": runs,
+        "run_summary": run_summary,
+        "notes": []  # To be filled by analyzer
+    }
+
+    return benchmark
+
+
+def generate_markdown(benchmark: dict) -> str:
+    """Generate human-readable benchmark.md from benchmark data."""
+    metadata = benchmark["metadata"]
+    run_summary = benchmark["run_summary"]
+
+    # Determine config names (excluding "delta")
+    configs = [k for k in run_summary if k != "delta"]
+    config_a = configs[0] if len(configs) >= 1 else "config_a"
+    config_b = configs[1] if len(configs) >= 2 else "config_b"
+    label_a = config_a.replace("_", " ").title()
+    label_b = config_b.replace("_", " ").title()
+
+    lines = [
+        f"# Skill Benchmark: {metadata['skill_name']}",
+        "",
+        f"**Model**: {metadata['executor_model']}",
+        f"**Date**: {metadata['timestamp']}",
+        f"**Evals**: {', '.join(map(str, metadata['evals_run']))} ({metadata['runs_per_configuration']} runs each per configuration)",
+        "",
+        "## Summary",
+        "",
+        f"| Metric | {label_a} | {label_b} | Delta |",
+        "|--------|------------|---------------|-------|",
+    ]
+
+    a_summary = run_summary.get(config_a, {})
+    b_summary = run_summary.get(config_b, {})
+    delta = run_summary.get("delta", {})
+
+    # Format pass rate
+    a_pr = a_summary.get("pass_rate", {})
+    b_pr = b_summary.get("pass_rate", {})
+    lines.append(f"| Pass Rate | {a_pr.get('mean', 0)*100:.0f}% ± {a_pr.get('stddev', 0)*100:.0f}% | {b_pr.get('mean', 0)*100:.0f}% ± {b_pr.get('stddev', 0)*100:.0f}% | {delta.get('pass_rate', '—')} |")
+
+    # Format time
+    a_time = a_summary.get("time_seconds", {})
+    b_time = b_summary.get("time_seconds", {})
+    lines.append(f"| Time | {a_time.get('mean', 0):.1f}s ± {a_time.get('stddev', 0):.1f}s | {b_time.get('mean', 0):.1f}s ± {b_time.get('stddev', 0):.1f}s | {delta.get('time_seconds', '—')}s |")
+
+    # Format tokens
+    a_tokens = a_summary.get("tokens", {})
+    b_tokens = b_summary.get("tokens", {})
+    lines.append(f"| Tokens | {a_tokens.get('mean', 0):.0f} ± {a_tokens.get('stddev', 0):.0f} | {b_tokens.get('mean', 0):.0f} ± {b_tokens.get('stddev', 0):.0f} | {delta.get('tokens', '—')} |")
+
+    # Notes section
+    if benchmark.get("notes"):
+        lines.extend([
+            "",
+            "## Notes",
+            ""
+        ])
+        for note in benchmark["notes"]:
+            lines.append(f"- {note}")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Aggregate benchmark run results into summary statistics"
+    )
+    parser.add_argument(
+        "benchmark_dir",
+        type=Path,
+        help="Path to the benchmark directory"
+    )
+    parser.add_argument(
+        "--skill-name",
+        default="",
+        help="Name of the skill being benchmarked"
+    )
+    parser.add_argument(
+        "--skill-path",
+        default="",
+        help="Path to the skill being benchmarked"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        type=Path,
+        help="Output path for benchmark.json (default: <benchmark_dir>/benchmark.json)"
+    )
+
+    args = parser.parse_args()
+
+    if not args.benchmark_dir.exists():
+        print(f"Directory not found: {args.benchmark_dir}")
+        sys.exit(1)
+
+    # Generate benchmark
+    benchmark = generate_benchmark(args.benchmark_dir, args.skill_name, args.skill_path)
+
+    # Determine output paths
+    output_json = args.output or (args.benchmark_dir / "benchmark.json")
+    output_md = output_json.with_suffix(".md")
+
+    # Write benchmark.json
+    with open(output_json, "w") as f:
+        json.dump(benchmark, f, indent=2)
+    print(f"Generated: {output_json}")
+
+    # Write benchmark.md
+    markdown = generate_markdown(benchmark)
+    with open(output_md, "w") as f:
+        f.write(markdown)
+    print(f"Generated: {output_md}")
+
+    # Print summary
+    run_summary = benchmark["run_summary"]
+    configs = [k for k in run_summary if k != "delta"]
+    delta = run_summary.get("delta", {})
+
+    print(f"\nSummary:")
+    for config in configs:
+        pr = run_summary[config]["pass_rate"]["mean"]
+        label = config.replace("_", " ").title()
+        print(f"  {label}: {pr*100:.1f}% pass rate")
+    print(f"  Delta:         {delta.get('pass_rate', '—')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/scripts/generate_report.py
+++ b/.claude/skills/skill-creator/scripts/generate_report.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Generate an HTML report from run_loop.py output.
+
+Takes the JSON output from run_loop.py and generates a visual HTML report
+showing each description attempt with check/x for each test case.
+Distinguishes between train and test queries.
+"""
+
+import argparse
+import html
+import json
+import sys
+from pathlib import Path
+
+
+def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") -> str:
+    """Generate HTML report from loop output data. If auto_refresh is True, adds a meta refresh tag."""
+    history = data.get("history", [])
+    holdout = data.get("holdout", 0)
+    title_prefix = html.escape(skill_name + " \u2014 ") if skill_name else ""
+
+    # Get all unique queries from train and test sets, with should_trigger info
+    train_queries: list[dict] = []
+    test_queries: list[dict] = []
+    if history:
+        for r in history[0].get("train_results", history[0].get("results", [])):
+            train_queries.append({"query": r["query"], "should_trigger": r.get("should_trigger", True)})
+        if history[0].get("test_results"):
+            for r in history[0].get("test_results", []):
+                test_queries.append({"query": r["query"], "should_trigger": r.get("should_trigger", True)})
+
+    refresh_tag = '    <meta http-equiv="refresh" content="5">\n' if auto_refresh else ""
+
+    html_parts = ["""<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+""" + refresh_tag + """    <title>""" + title_prefix + """Skill Description Optimization</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Lora', Georgia, serif;
+            max-width: 100%;
+            margin: 0 auto;
+            padding: 20px;
+            background: #faf9f5;
+            color: #141413;
+        }
+        h1 { font-family: 'Poppins', sans-serif; color: #141413; }
+        .explainer {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            border: 1px solid #e8e6dc;
+            color: #b0aea5;
+            font-size: 0.875rem;
+            line-height: 1.6;
+        }
+        .summary {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            border: 1px solid #e8e6dc;
+        }
+        .summary p { margin: 5px 0; }
+        .best { color: #788c5d; font-weight: bold; }
+        .table-container {
+            overflow-x: auto;
+            width: 100%;
+        }
+        table {
+            border-collapse: collapse;
+            background: white;
+            border: 1px solid #e8e6dc;
+            border-radius: 6px;
+            font-size: 12px;
+            min-width: 100%;
+        }
+        th, td {
+            padding: 8px;
+            text-align: left;
+            border: 1px solid #e8e6dc;
+            white-space: normal;
+            word-wrap: break-word;
+        }
+        th {
+            font-family: 'Poppins', sans-serif;
+            background: #141413;
+            color: #faf9f5;
+            font-weight: 500;
+        }
+        th.test-col {
+            background: #6a9bcc;
+        }
+        th.query-col { min-width: 200px; }
+        td.description {
+            font-family: monospace;
+            font-size: 11px;
+            word-wrap: break-word;
+            max-width: 400px;
+        }
+        td.result {
+            text-align: center;
+            font-size: 16px;
+            min-width: 40px;
+        }
+        td.test-result {
+            background: #f0f6fc;
+        }
+        .pass { color: #788c5d; }
+        .fail { color: #c44; }
+        .rate {
+            font-size: 9px;
+            color: #b0aea5;
+            display: block;
+        }
+        tr:hover { background: #faf9f5; }
+        .score {
+            display: inline-block;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-weight: bold;
+            font-size: 11px;
+        }
+        .score-good { background: #eef2e8; color: #788c5d; }
+        .score-ok { background: #fef3c7; color: #d97706; }
+        .score-bad { background: #fceaea; color: #c44; }
+        .train-label { color: #b0aea5; font-size: 10px; }
+        .test-label { color: #6a9bcc; font-size: 10px; font-weight: bold; }
+        .best-row { background: #f5f8f2; }
+        th.positive-col { border-bottom: 3px solid #788c5d; }
+        th.negative-col { border-bottom: 3px solid #c44; }
+        th.test-col.positive-col { border-bottom: 3px solid #788c5d; }
+        th.test-col.negative-col { border-bottom: 3px solid #c44; }
+        .legend { font-family: 'Poppins', sans-serif; display: flex; gap: 20px; margin-bottom: 10px; font-size: 13px; align-items: center; }
+        .legend-item { display: flex; align-items: center; gap: 6px; }
+        .legend-swatch { width: 16px; height: 16px; border-radius: 3px; display: inline-block; }
+        .swatch-positive { background: #141413; border-bottom: 3px solid #788c5d; }
+        .swatch-negative { background: #141413; border-bottom: 3px solid #c44; }
+        .swatch-test { background: #6a9bcc; }
+        .swatch-train { background: #141413; }
+    </style>
+</head>
+<body>
+    <h1>""" + title_prefix + """Skill Description Optimization</h1>
+    <div class="explainer">
+        <strong>Optimizing your skill's description.</strong> This page updates automatically as Claude tests different versions of your skill's description. Each row is an iteration — a new description attempt. The columns show test queries: green checkmarks mean the skill triggered correctly (or correctly didn't trigger), red crosses mean it got it wrong. The "Train" score shows performance on queries used to improve the description; the "Test" score shows performance on held-out queries the optimizer hasn't seen. When it's done, Claude will apply the best-performing description to your skill.
+    </div>
+"""]
+
+    # Summary section
+    best_test_score = data.get('best_test_score')
+    best_train_score = data.get('best_train_score')
+    html_parts.append(f"""
+    <div class="summary">
+        <p><strong>Original:</strong> {html.escape(data.get('original_description', 'N/A'))}</p>
+        <p class="best"><strong>Best:</strong> {html.escape(data.get('best_description', 'N/A'))}</p>
+        <p><strong>Best Score:</strong> {data.get('best_score', 'N/A')} {'(test)' if best_test_score else '(train)'}</p>
+        <p><strong>Iterations:</strong> {data.get('iterations_run', 0)} | <strong>Train:</strong> {data.get('train_size', '?')} | <strong>Test:</strong> {data.get('test_size', '?')}</p>
+    </div>
+""")
+
+    # Legend
+    html_parts.append("""
+    <div class="legend">
+        <span style="font-weight:600">Query columns:</span>
+        <span class="legend-item"><span class="legend-swatch swatch-positive"></span> Should trigger</span>
+        <span class="legend-item"><span class="legend-swatch swatch-negative"></span> Should NOT trigger</span>
+        <span class="legend-item"><span class="legend-swatch swatch-train"></span> Train</span>
+        <span class="legend-item"><span class="legend-swatch swatch-test"></span> Test</span>
+    </div>
+""")
+
+    # Table header
+    html_parts.append("""
+    <div class="table-container">
+    <table>
+        <thead>
+            <tr>
+                <th>Iter</th>
+                <th>Train</th>
+                <th>Test</th>
+                <th class="query-col">Description</th>
+""")
+
+    # Add column headers for train queries
+    for qinfo in train_queries:
+        polarity = "positive-col" if qinfo["should_trigger"] else "negative-col"
+        html_parts.append(f'                <th class="{polarity}">{html.escape(qinfo["query"])}</th>\n')
+
+    # Add column headers for test queries (different color)
+    for qinfo in test_queries:
+        polarity = "positive-col" if qinfo["should_trigger"] else "negative-col"
+        html_parts.append(f'                <th class="test-col {polarity}">{html.escape(qinfo["query"])}</th>\n')
+
+    html_parts.append("""            </tr>
+        </thead>
+        <tbody>
+""")
+
+    # Find best iteration for highlighting
+    if test_queries:
+        best_iter = max(history, key=lambda h: h.get("test_passed") or 0).get("iteration")
+    else:
+        best_iter = max(history, key=lambda h: h.get("train_passed", h.get("passed", 0))).get("iteration")
+
+    # Add rows for each iteration
+    for h in history:
+        iteration = h.get("iteration", "?")
+        train_passed = h.get("train_passed", h.get("passed", 0))
+        train_total = h.get("train_total", h.get("total", 0))
+        test_passed = h.get("test_passed")
+        test_total = h.get("test_total")
+        description = h.get("description", "")
+        train_results = h.get("train_results", h.get("results", []))
+        test_results = h.get("test_results", [])
+
+        # Create lookups for results by query
+        train_by_query = {r["query"]: r for r in train_results}
+        test_by_query = {r["query"]: r for r in test_results} if test_results else {}
+
+        # Compute aggregate correct/total runs across all retries
+        def aggregate_runs(results: list[dict]) -> tuple[int, int]:
+            correct = 0
+            total = 0
+            for r in results:
+                runs = r.get("runs", 0)
+                triggers = r.get("triggers", 0)
+                total += runs
+                if r.get("should_trigger", True):
+                    correct += triggers
+                else:
+                    correct += runs - triggers
+            return correct, total
+
+        train_correct, train_runs = aggregate_runs(train_results)
+        test_correct, test_runs = aggregate_runs(test_results)
+
+        # Determine score classes
+        def score_class(correct: int, total: int) -> str:
+            if total > 0:
+                ratio = correct / total
+                if ratio >= 0.8:
+                    return "score-good"
+                elif ratio >= 0.5:
+                    return "score-ok"
+            return "score-bad"
+
+        train_class = score_class(train_correct, train_runs)
+        test_class = score_class(test_correct, test_runs)
+
+        row_class = "best-row" if iteration == best_iter else ""
+
+        html_parts.append(f"""            <tr class="{row_class}">
+                <td>{iteration}</td>
+                <td><span class="score {train_class}">{train_correct}/{train_runs}</span></td>
+                <td><span class="score {test_class}">{test_correct}/{test_runs}</span></td>
+                <td class="description">{html.escape(description)}</td>
+""")
+
+        # Add result for each train query
+        for qinfo in train_queries:
+            r = train_by_query.get(qinfo["query"], {})
+            did_pass = r.get("pass", False)
+            triggers = r.get("triggers", 0)
+            runs = r.get("runs", 0)
+
+            icon = "✓" if did_pass else "✗"
+            css_class = "pass" if did_pass else "fail"
+
+            html_parts.append(f'                <td class="result {css_class}">{icon}<span class="rate">{triggers}/{runs}</span></td>\n')
+
+        # Add result for each test query (with different background)
+        for qinfo in test_queries:
+            r = test_by_query.get(qinfo["query"], {})
+            did_pass = r.get("pass", False)
+            triggers = r.get("triggers", 0)
+            runs = r.get("runs", 0)
+
+            icon = "✓" if did_pass else "✗"
+            css_class = "pass" if did_pass else "fail"
+
+            html_parts.append(f'                <td class="result test-result {css_class}">{icon}<span class="rate">{triggers}/{runs}</span></td>\n')
+
+        html_parts.append("            </tr>\n")
+
+    html_parts.append("""        </tbody>
+    </table>
+    </div>
+""")
+
+    html_parts.append("""
+</body>
+</html>
+""")
+
+    return "".join(html_parts)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate HTML report from run_loop output")
+    parser.add_argument("input", help="Path to JSON output from run_loop.py (or - for stdin)")
+    parser.add_argument("-o", "--output", default=None, help="Output HTML file (default: stdout)")
+    parser.add_argument("--skill-name", default="", help="Skill name to include in the report title")
+    args = parser.parse_args()
+
+    if args.input == "-":
+        data = json.load(sys.stdin)
+    else:
+        data = json.loads(Path(args.input).read_text())
+
+    html_output = generate_html(data, skill_name=args.skill_name)
+
+    if args.output:
+        Path(args.output).write_text(html_output)
+        print(f"Report written to {args.output}", file=sys.stderr)
+    else:
+        print(html_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/scripts/improve_description.py
+++ b/.claude/skills/skill-creator/scripts/improve_description.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Improve a skill description based on eval results.
+
+Takes eval results (from run_eval.py) and generates an improved description
+by calling `claude -p` as a subprocess (same auth pattern as run_eval.py —
+uses the session's Claude Code auth, no separate ANTHROPIC_API_KEY needed).
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.utils import parse_skill_md
+
+
+def _call_claude(prompt: str, model: str | None, timeout: int = 300) -> str:
+    """Run `claude -p` with the prompt on stdin and return the text response.
+
+    Prompt goes over stdin (not argv) because it embeds the full SKILL.md
+    body and can easily exceed comfortable argv length.
+    """
+    cmd = ["claude", "-p", "--output-format", "text"]
+    if model:
+        cmd.extend(["--model", model])
+
+    # Remove CLAUDECODE env var to allow nesting claude -p inside a
+    # Claude Code session. The guard is for interactive terminal conflicts;
+    # programmatic subprocess usage is safe. Same pattern as run_eval.py.
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+    result = subprocess.run(
+        cmd,
+        input=prompt,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"claude -p exited {result.returncode}\nstderr: {result.stderr}"
+        )
+    return result.stdout
+
+
+def improve_description(
+    skill_name: str,
+    skill_content: str,
+    current_description: str,
+    eval_results: dict,
+    history: list[dict],
+    model: str,
+    test_results: dict | None = None,
+    log_dir: Path | None = None,
+    iteration: int | None = None,
+) -> str:
+    """Call Claude to improve the description based on eval results."""
+    failed_triggers = [
+        r for r in eval_results["results"]
+        if r["should_trigger"] and not r["pass"]
+    ]
+    false_triggers = [
+        r for r in eval_results["results"]
+        if not r["should_trigger"] and not r["pass"]
+    ]
+
+    # Build scores summary
+    train_score = f"{eval_results['summary']['passed']}/{eval_results['summary']['total']}"
+    if test_results:
+        test_score = f"{test_results['summary']['passed']}/{test_results['summary']['total']}"
+        scores_summary = f"Train: {train_score}, Test: {test_score}"
+    else:
+        scores_summary = f"Train: {train_score}"
+
+    prompt = f"""You are optimizing a skill description for a Claude Code skill called "{skill_name}". A "skill" is sort of like a prompt, but with progressive disclosure -- there's a title and description that Claude sees when deciding whether to use the skill, and then if it does use the skill, it reads the .md file which has lots more details and potentially links to other resources in the skill folder like helper files and scripts and additional documentation or examples.
+
+The description appears in Claude's "available_skills" list. When a user sends a query, Claude decides whether to invoke the skill based solely on the title and on this description. Your goal is to write a description that triggers for relevant queries, and doesn't trigger for irrelevant ones.
+
+Here's the current description:
+<current_description>
+"{current_description}"
+</current_description>
+
+Current scores ({scores_summary}):
+<scores_summary>
+"""
+    if failed_triggers:
+        prompt += "FAILED TO TRIGGER (should have triggered but didn't):\n"
+        for r in failed_triggers:
+            prompt += f'  - "{r["query"]}" (triggered {r["triggers"]}/{r["runs"]} times)\n'
+        prompt += "\n"
+
+    if false_triggers:
+        prompt += "FALSE TRIGGERS (triggered but shouldn't have):\n"
+        for r in false_triggers:
+            prompt += f'  - "{r["query"]}" (triggered {r["triggers"]}/{r["runs"]} times)\n'
+        prompt += "\n"
+
+    if history:
+        prompt += "PREVIOUS ATTEMPTS (do NOT repeat these — try something structurally different):\n\n"
+        for h in history:
+            train_s = f"{h.get('train_passed', h.get('passed', 0))}/{h.get('train_total', h.get('total', 0))}"
+            test_s = f"{h.get('test_passed', '?')}/{h.get('test_total', '?')}" if h.get('test_passed') is not None else None
+            score_str = f"train={train_s}" + (f", test={test_s}" if test_s else "")
+            prompt += f'<attempt {score_str}>\n'
+            prompt += f'Description: "{h["description"]}"\n'
+            if "results" in h:
+                prompt += "Train results:\n"
+                for r in h["results"]:
+                    status = "PASS" if r["pass"] else "FAIL"
+                    prompt += f'  [{status}] "{r["query"][:80]}" (triggered {r["triggers"]}/{r["runs"]})\n'
+            if h.get("note"):
+                prompt += f'Note: {h["note"]}\n'
+            prompt += "</attempt>\n\n"
+
+    prompt += f"""</scores_summary>
+
+Skill content (for context on what the skill does):
+<skill_content>
+{skill_content}
+</skill_content>
+
+Based on the failures, write a new and improved description that is more likely to trigger correctly. When I say "based on the failures", it's a bit of a tricky line to walk because we don't want to overfit to the specific cases you're seeing. So what I DON'T want you to do is produce an ever-expanding list of specific queries that this skill should or shouldn't trigger for. Instead, try to generalize from the failures to broader categories of user intent and situations where this skill would be useful or not useful. The reason for this is twofold:
+
+1. Avoid overfitting
+2. The list might get loooong and it's injected into ALL queries and there might be a lot of skills, so we don't want to blow too much space on any given description.
+
+Concretely, your description should not be more than about 100-200 words, even if that comes at the cost of accuracy. There is a hard limit of 1024 characters — descriptions over that will be truncated, so stay comfortably under it.
+
+Here are some tips that we've found to work well in writing these descriptions:
+- The skill should be phrased in the imperative -- "Use this skill for" rather than "this skill does"
+- The skill description should focus on the user's intent, what they are trying to achieve, vs. the implementation details of how the skill works.
+- The description competes with other skills for Claude's attention — make it distinctive and immediately recognizable.
+- If you're getting lots of failures after repeated attempts, change things up. Try different sentence structures or wordings.
+
+I'd encourage you to be creative and mix up the style in different iterations since you'll have multiple opportunities to try different approaches and we'll just grab the highest-scoring one at the end. 
+
+Please respond with only the new description text in <new_description> tags, nothing else."""
+
+    text = _call_claude(prompt, model)
+
+    match = re.search(r"<new_description>(.*?)</new_description>", text, re.DOTALL)
+    description = match.group(1).strip().strip('"') if match else text.strip().strip('"')
+
+    transcript: dict = {
+        "iteration": iteration,
+        "prompt": prompt,
+        "response": text,
+        "parsed_description": description,
+        "char_count": len(description),
+        "over_limit": len(description) > 1024,
+    }
+
+    # Safety net: the prompt already states the 1024-char hard limit, but if
+    # the model blew past it anyway, make one fresh single-turn call that
+    # quotes the too-long version and asks for a shorter rewrite. (The old
+    # SDK path did this as a true multi-turn; `claude -p` is one-shot, so we
+    # inline the prior output into the new prompt instead.)
+    if len(description) > 1024:
+        shorten_prompt = (
+            f"{prompt}\n\n"
+            f"---\n\n"
+            f"A previous attempt produced this description, which at "
+            f"{len(description)} characters is over the 1024-character hard limit:\n\n"
+            f'"{description}"\n\n'
+            f"Rewrite it to be under 1024 characters while keeping the most "
+            f"important trigger words and intent coverage. Respond with only "
+            f"the new description in <new_description> tags."
+        )
+        shorten_text = _call_claude(shorten_prompt, model)
+        match = re.search(r"<new_description>(.*?)</new_description>", shorten_text, re.DOTALL)
+        shortened = match.group(1).strip().strip('"') if match else shorten_text.strip().strip('"')
+
+        transcript["rewrite_prompt"] = shorten_prompt
+        transcript["rewrite_response"] = shorten_text
+        transcript["rewrite_description"] = shortened
+        transcript["rewrite_char_count"] = len(shortened)
+        description = shortened
+
+    transcript["final_description"] = description
+
+    if log_dir:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / f"improve_iter_{iteration or 'unknown'}.json"
+        log_file.write_text(json.dumps(transcript, indent=2))
+
+    return description
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Improve a skill description based on eval results")
+    parser.add_argument("--eval-results", required=True, help="Path to eval results JSON (from run_eval.py)")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--history", default=None, help="Path to history JSON (previous attempts)")
+    parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--verbose", action="store_true", help="Print thinking to stderr")
+    args = parser.parse_args()
+
+    skill_path = Path(args.skill_path)
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    eval_results = json.loads(Path(args.eval_results).read_text())
+    history = []
+    if args.history:
+        history = json.loads(Path(args.history).read_text())
+
+    name, _, content = parse_skill_md(skill_path)
+    current_description = eval_results["description"]
+
+    if args.verbose:
+        print(f"Current: {current_description}", file=sys.stderr)
+        print(f"Score: {eval_results['summary']['passed']}/{eval_results['summary']['total']}", file=sys.stderr)
+
+    new_description = improve_description(
+        skill_name=name,
+        skill_content=content,
+        current_description=current_description,
+        eval_results=eval_results,
+        history=history,
+        model=args.model,
+    )
+
+    if args.verbose:
+        print(f"Improved: {new_description}", file=sys.stderr)
+
+    # Output as JSON with both the new description and updated history
+    output = {
+        "description": new_description,
+        "history": history + [{
+            "description": current_description,
+            "passed": eval_results["summary"]["passed"],
+            "failed": eval_results["summary"]["failed"],
+            "total": eval_results["summary"]["total"],
+            "results": eval_results["results"],
+        }],
+    }
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/scripts/package_skill.py
+++ b/.claude/skills/skill-creator/scripts/package_skill.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Skill Packager - Creates a distributable .skill file of a skill folder
+
+Usage:
+    python utils/package_skill.py <path/to/skill-folder> [output-directory]
+
+Example:
+    python utils/package_skill.py skills/public/my-skill
+    python utils/package_skill.py skills/public/my-skill ./dist
+"""
+
+import fnmatch
+import sys
+import zipfile
+from pathlib import Path
+from scripts.quick_validate import validate_skill
+
+# Patterns to exclude when packaging skills.
+EXCLUDE_DIRS = {"__pycache__", "node_modules"}
+EXCLUDE_GLOBS = {"*.pyc"}
+EXCLUDE_FILES = {".DS_Store"}
+# Directories excluded only at the skill root (not when nested deeper).
+ROOT_EXCLUDE_DIRS = {"evals"}
+
+
+def should_exclude(rel_path: Path) -> bool:
+    """Check if a path should be excluded from packaging."""
+    parts = rel_path.parts
+    if any(part in EXCLUDE_DIRS for part in parts):
+        return True
+    # rel_path is relative to skill_path.parent, so parts[0] is the skill
+    # folder name and parts[1] (if present) is the first subdir.
+    if len(parts) > 1 and parts[1] in ROOT_EXCLUDE_DIRS:
+        return True
+    name = rel_path.name
+    if name in EXCLUDE_FILES:
+        return True
+    return any(fnmatch.fnmatch(name, pat) for pat in EXCLUDE_GLOBS)
+
+
+def package_skill(skill_path, output_dir=None):
+    """
+    Package a skill folder into a .skill file.
+
+    Args:
+        skill_path: Path to the skill folder
+        output_dir: Optional output directory for the .skill file (defaults to current directory)
+
+    Returns:
+        Path to the created .skill file, or None if error
+    """
+    skill_path = Path(skill_path).resolve()
+
+    # Validate skill folder exists
+    if not skill_path.exists():
+        print(f"❌ Error: Skill folder not found: {skill_path}")
+        return None
+
+    if not skill_path.is_dir():
+        print(f"❌ Error: Path is not a directory: {skill_path}")
+        return None
+
+    # Validate SKILL.md exists
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        print(f"❌ Error: SKILL.md not found in {skill_path}")
+        return None
+
+    # Run validation before packaging
+    print("🔍 Validating skill...")
+    valid, message = validate_skill(skill_path)
+    if not valid:
+        print(f"❌ Validation failed: {message}")
+        print("   Please fix the validation errors before packaging.")
+        return None
+    print(f"✅ {message}\n")
+
+    # Determine output location
+    skill_name = skill_path.name
+    if output_dir:
+        output_path = Path(output_dir).resolve()
+        output_path.mkdir(parents=True, exist_ok=True)
+    else:
+        output_path = Path.cwd()
+
+    skill_filename = output_path / f"{skill_name}.skill"
+
+    # Create the .skill file (zip format)
+    try:
+        with zipfile.ZipFile(skill_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
+            # Walk through the skill directory, excluding build artifacts
+            for file_path in skill_path.rglob('*'):
+                if not file_path.is_file():
+                    continue
+                arcname = file_path.relative_to(skill_path.parent)
+                if should_exclude(arcname):
+                    print(f"  Skipped: {arcname}")
+                    continue
+                zipf.write(file_path, arcname)
+                print(f"  Added: {arcname}")
+
+        print(f"\n✅ Successfully packaged skill to: {skill_filename}")
+        return skill_filename
+
+    except Exception as e:
+        print(f"❌ Error creating .skill file: {e}")
+        return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python utils/package_skill.py <path/to/skill-folder> [output-directory]")
+        print("\nExample:")
+        print("  python utils/package_skill.py skills/public/my-skill")
+        print("  python utils/package_skill.py skills/public/my-skill ./dist")
+        sys.exit(1)
+
+    skill_path = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else None
+
+    print(f"📦 Packaging skill: {skill_path}")
+    if output_dir:
+        print(f"   Output directory: {output_dir}")
+    print()
+
+    result = package_skill(skill_path, output_dir)
+
+    if result:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/scripts/quick_validate.py
+++ b/.claude/skills/skill-creator/scripts/quick_validate.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Quick validation script for skills - minimal version
+"""
+
+import sys
+import os
+import re
+import yaml
+from pathlib import Path
+
+def validate_skill(skill_path):
+    """Basic validation of a skill"""
+    skill_path = Path(skill_path)
+
+    # Check SKILL.md exists
+    skill_md = skill_path / 'SKILL.md'
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    # Read and validate frontmatter
+    content = skill_md.read_text()
+    if not content.startswith('---'):
+        return False, "No YAML frontmatter found"
+
+    # Extract frontmatter
+    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+
+    frontmatter_text = match.group(1)
+
+    # Parse YAML frontmatter
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+        if not isinstance(frontmatter, dict):
+            return False, "Frontmatter must be a YAML dictionary"
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML in frontmatter: {e}"
+
+    # Define allowed properties
+    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
+
+    # Check for unexpected properties (excluding nested keys under metadata)
+    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+    if unexpected_keys:
+        return False, (
+            f"Unexpected key(s) in SKILL.md frontmatter: {', '.join(sorted(unexpected_keys))}. "
+            f"Allowed properties are: {', '.join(sorted(ALLOWED_PROPERTIES))}"
+        )
+
+    # Check required fields
+    if 'name' not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if 'description' not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    # Extract name for validation
+    name = frontmatter.get('name', '')
+    if not isinstance(name, str):
+        return False, f"Name must be a string, got {type(name).__name__}"
+    name = name.strip()
+    if name:
+        # Check naming convention (kebab-case: lowercase with hyphens)
+        if not re.match(r'^[a-z0-9-]+$', name):
+            return False, f"Name '{name}' should be kebab-case (lowercase letters, digits, and hyphens only)"
+        if name.startswith('-') or name.endswith('-') or '--' in name:
+            return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+        # Check name length (max 64 characters per spec)
+        if len(name) > 64:
+            return False, f"Name is too long ({len(name)} characters). Maximum is 64 characters."
+
+    # Extract and validate description
+    description = frontmatter.get('description', '')
+    if not isinstance(description, str):
+        return False, f"Description must be a string, got {type(description).__name__}"
+    description = description.strip()
+    if description:
+        # Check for angle brackets
+        if '<' in description or '>' in description:
+            return False, "Description cannot contain angle brackets (< or >)"
+        # Check description length (max 1024 characters per spec)
+        if len(description) > 1024:
+            return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
+
+    # Validate compatibility field if present (optional)
+    compatibility = frontmatter.get('compatibility', '')
+    if compatibility:
+        if not isinstance(compatibility, str):
+            return False, f"Compatibility must be a string, got {type(compatibility).__name__}"
+        if len(compatibility) > 500:
+            return False, f"Compatibility is too long ({len(compatibility)} characters). Maximum is 500 characters."
+
+    return True, "Skill is valid!"
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill_directory>")
+        sys.exit(1)
+    
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)

--- a/.claude/skills/skill-creator/scripts/run_eval.py
+++ b/.claude/skills/skill-creator/scripts/run_eval.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Run trigger evaluation for a skill description.
+
+Tests whether a skill's description causes Claude to trigger (read the skill)
+for a set of queries. Outputs results as JSON.
+"""
+
+import argparse
+import json
+import os
+import select
+import subprocess
+import sys
+import time
+import uuid
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+from scripts.utils import parse_skill_md
+
+
+def find_project_root() -> Path:
+    """Find the project root by walking up from cwd looking for .claude/.
+
+    Mimics how Claude Code discovers its project root, so the command file
+    we create ends up where claude -p will look for it.
+    """
+    current = Path.cwd()
+    for parent in [current, *current.parents]:
+        if (parent / ".claude").is_dir():
+            return parent
+    return current
+
+
+def run_single_query(
+    query: str,
+    skill_name: str,
+    skill_description: str,
+    timeout: int,
+    project_root: str,
+    model: str | None = None,
+) -> bool:
+    """Run a single query and return whether the skill was triggered.
+
+    Creates a command file in .claude/commands/ so it appears in Claude's
+    available_skills list, then runs `claude -p` with the raw query.
+    Uses --include-partial-messages to detect triggering early from
+    stream events (content_block_start) rather than waiting for the
+    full assistant message, which only arrives after tool execution.
+    """
+    unique_id = uuid.uuid4().hex[:8]
+    clean_name = f"{skill_name}-skill-{unique_id}"
+    project_commands_dir = Path(project_root) / ".claude" / "commands"
+    command_file = project_commands_dir / f"{clean_name}.md"
+
+    try:
+        project_commands_dir.mkdir(parents=True, exist_ok=True)
+        # Use YAML block scalar to avoid breaking on quotes in description
+        indented_desc = "\n  ".join(skill_description.split("\n"))
+        command_content = (
+            f"---\n"
+            f"description: |\n"
+            f"  {indented_desc}\n"
+            f"---\n\n"
+            f"# {skill_name}\n\n"
+            f"This skill handles: {skill_description}\n"
+        )
+        command_file.write_text(command_content)
+
+        cmd = [
+            "claude",
+            "-p", query,
+            "--output-format", "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+        ]
+        if model:
+            cmd.extend(["--model", model])
+
+        # Remove CLAUDECODE env var to allow nesting claude -p inside a
+        # Claude Code session. The guard is for interactive terminal conflicts;
+        # programmatic subprocess usage is safe.
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            cwd=project_root,
+            env=env,
+        )
+
+        triggered = False
+        start_time = time.time()
+        buffer = ""
+        # Track state for stream event detection
+        pending_tool_name = None
+        accumulated_json = ""
+
+        try:
+            while time.time() - start_time < timeout:
+                if process.poll() is not None:
+                    remaining = process.stdout.read()
+                    if remaining:
+                        buffer += remaining.decode("utf-8", errors="replace")
+                    break
+
+                ready, _, _ = select.select([process.stdout], [], [], 1.0)
+                if not ready:
+                    continue
+
+                chunk = os.read(process.stdout.fileno(), 8192)
+                if not chunk:
+                    break
+                buffer += chunk.decode("utf-8", errors="replace")
+
+                while "\n" in buffer:
+                    line, buffer = buffer.split("\n", 1)
+                    line = line.strip()
+                    if not line:
+                        continue
+
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    # Early detection via stream events
+                    if event.get("type") == "stream_event":
+                        se = event.get("event", {})
+                        se_type = se.get("type", "")
+
+                        if se_type == "content_block_start":
+                            cb = se.get("content_block", {})
+                            if cb.get("type") == "tool_use":
+                                tool_name = cb.get("name", "")
+                                if tool_name in ("Skill", "Read"):
+                                    pending_tool_name = tool_name
+                                    accumulated_json = ""
+                                else:
+                                    return False
+
+                        elif se_type == "content_block_delta" and pending_tool_name:
+                            delta = se.get("delta", {})
+                            if delta.get("type") == "input_json_delta":
+                                accumulated_json += delta.get("partial_json", "")
+                                if clean_name in accumulated_json:
+                                    return True
+
+                        elif se_type in ("content_block_stop", "message_stop"):
+                            if pending_tool_name:
+                                return clean_name in accumulated_json
+                            if se_type == "message_stop":
+                                return False
+
+                    # Fallback: full assistant message
+                    elif event.get("type") == "assistant":
+                        message = event.get("message", {})
+                        for content_item in message.get("content", []):
+                            if content_item.get("type") != "tool_use":
+                                continue
+                            tool_name = content_item.get("name", "")
+                            tool_input = content_item.get("input", {})
+                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
+                                triggered = True
+                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
+                                triggered = True
+                            return triggered
+
+                    elif event.get("type") == "result":
+                        return triggered
+        finally:
+            # Clean up process on any exit path (return, exception, timeout)
+            if process.poll() is None:
+                process.kill()
+                process.wait()
+
+        return triggered
+    finally:
+        if command_file.exists():
+            command_file.unlink()
+
+
+def run_eval(
+    eval_set: list[dict],
+    skill_name: str,
+    description: str,
+    num_workers: int,
+    timeout: int,
+    project_root: Path,
+    runs_per_query: int = 1,
+    trigger_threshold: float = 0.5,
+    model: str | None = None,
+) -> dict:
+    """Run the full eval set and return results."""
+    results = []
+
+    with ProcessPoolExecutor(max_workers=num_workers) as executor:
+        future_to_info = {}
+        for item in eval_set:
+            for run_idx in range(runs_per_query):
+                future = executor.submit(
+                    run_single_query,
+                    item["query"],
+                    skill_name,
+                    description,
+                    timeout,
+                    str(project_root),
+                    model,
+                )
+                future_to_info[future] = (item, run_idx)
+
+        query_triggers: dict[str, list[bool]] = {}
+        query_items: dict[str, dict] = {}
+        for future in as_completed(future_to_info):
+            item, _ = future_to_info[future]
+            query = item["query"]
+            query_items[query] = item
+            if query not in query_triggers:
+                query_triggers[query] = []
+            try:
+                query_triggers[query].append(future.result())
+            except Exception as e:
+                print(f"Warning: query failed: {e}", file=sys.stderr)
+                query_triggers[query].append(False)
+
+    for query, triggers in query_triggers.items():
+        item = query_items[query]
+        trigger_rate = sum(triggers) / len(triggers)
+        should_trigger = item["should_trigger"]
+        if should_trigger:
+            did_pass = trigger_rate >= trigger_threshold
+        else:
+            did_pass = trigger_rate < trigger_threshold
+        results.append({
+            "query": query,
+            "should_trigger": should_trigger,
+            "trigger_rate": trigger_rate,
+            "triggers": sum(triggers),
+            "runs": len(triggers),
+            "pass": did_pass,
+        })
+
+    passed = sum(1 for r in results if r["pass"])
+    total = len(results)
+
+    return {
+        "skill_name": skill_name,
+        "description": description,
+        "results": results,
+        "summary": {
+            "total": total,
+            "passed": passed,
+            "failed": total - passed,
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run trigger evaluation for a skill description")
+    parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--description", default=None, help="Override description to test")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
+    parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
+    parser.add_argument("--model", default=None, help="Model to use for claude -p (default: user's configured model)")
+    parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    args = parser.parse_args()
+
+    eval_set = json.loads(Path(args.eval_set).read_text())
+    skill_path = Path(args.skill_path)
+
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    name, original_description, content = parse_skill_md(skill_path)
+    description = args.description or original_description
+    project_root = find_project_root()
+
+    if args.verbose:
+        print(f"Evaluating: {description}", file=sys.stderr)
+
+    output = run_eval(
+        eval_set=eval_set,
+        skill_name=name,
+        description=description,
+        num_workers=args.num_workers,
+        timeout=args.timeout,
+        project_root=project_root,
+        runs_per_query=args.runs_per_query,
+        trigger_threshold=args.trigger_threshold,
+        model=args.model,
+    )
+
+    if args.verbose:
+        summary = output["summary"]
+        print(f"Results: {summary['passed']}/{summary['total']} passed", file=sys.stderr)
+        for r in output["results"]:
+            status = "PASS" if r["pass"] else "FAIL"
+            rate_str = f"{r['triggers']}/{r['runs']}"
+            print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:70]}", file=sys.stderr)
+
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/scripts/run_loop.py
+++ b/.claude/skills/skill-creator/scripts/run_loop.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Run the eval + improve loop until all pass or max iterations reached.
+
+Combines run_eval.py and improve_description.py in a loop, tracking history
+and returning the best description found. Supports train/test split to prevent
+overfitting.
+"""
+
+import argparse
+import json
+import random
+import sys
+import tempfile
+import time
+import webbrowser
+from pathlib import Path
+
+from scripts.generate_report import generate_html
+from scripts.improve_description import improve_description
+from scripts.run_eval import find_project_root, run_eval
+from scripts.utils import parse_skill_md
+
+
+def split_eval_set(eval_set: list[dict], holdout: float, seed: int = 42) -> tuple[list[dict], list[dict]]:
+    """Split eval set into train and test sets, stratified by should_trigger."""
+    random.seed(seed)
+
+    # Separate by should_trigger
+    trigger = [e for e in eval_set if e["should_trigger"]]
+    no_trigger = [e for e in eval_set if not e["should_trigger"]]
+
+    # Shuffle each group
+    random.shuffle(trigger)
+    random.shuffle(no_trigger)
+
+    # Calculate split points
+    n_trigger_test = max(1, int(len(trigger) * holdout))
+    n_no_trigger_test = max(1, int(len(no_trigger) * holdout))
+
+    # Split
+    test_set = trigger[:n_trigger_test] + no_trigger[:n_no_trigger_test]
+    train_set = trigger[n_trigger_test:] + no_trigger[n_no_trigger_test:]
+
+    return train_set, test_set
+
+
+def run_loop(
+    eval_set: list[dict],
+    skill_path: Path,
+    description_override: str | None,
+    num_workers: int,
+    timeout: int,
+    max_iterations: int,
+    runs_per_query: int,
+    trigger_threshold: float,
+    holdout: float,
+    model: str,
+    verbose: bool,
+    live_report_path: Path | None = None,
+    log_dir: Path | None = None,
+) -> dict:
+    """Run the eval + improvement loop."""
+    project_root = find_project_root()
+    name, original_description, content = parse_skill_md(skill_path)
+    current_description = description_override or original_description
+
+    # Split into train/test if holdout > 0
+    if holdout > 0:
+        train_set, test_set = split_eval_set(eval_set, holdout)
+        if verbose:
+            print(f"Split: {len(train_set)} train, {len(test_set)} test (holdout={holdout})", file=sys.stderr)
+    else:
+        train_set = eval_set
+        test_set = []
+
+    history = []
+    exit_reason = "unknown"
+
+    for iteration in range(1, max_iterations + 1):
+        if verbose:
+            print(f"\n{'='*60}", file=sys.stderr)
+            print(f"Iteration {iteration}/{max_iterations}", file=sys.stderr)
+            print(f"Description: {current_description}", file=sys.stderr)
+            print(f"{'='*60}", file=sys.stderr)
+
+        # Evaluate train + test together in one batch for parallelism
+        all_queries = train_set + test_set
+        t0 = time.time()
+        all_results = run_eval(
+            eval_set=all_queries,
+            skill_name=name,
+            description=current_description,
+            num_workers=num_workers,
+            timeout=timeout,
+            project_root=project_root,
+            runs_per_query=runs_per_query,
+            trigger_threshold=trigger_threshold,
+            model=model,
+        )
+        eval_elapsed = time.time() - t0
+
+        # Split results back into train/test by matching queries
+        train_queries_set = {q["query"] for q in train_set}
+        train_result_list = [r for r in all_results["results"] if r["query"] in train_queries_set]
+        test_result_list = [r for r in all_results["results"] if r["query"] not in train_queries_set]
+
+        train_passed = sum(1 for r in train_result_list if r["pass"])
+        train_total = len(train_result_list)
+        train_summary = {"passed": train_passed, "failed": train_total - train_passed, "total": train_total}
+        train_results = {"results": train_result_list, "summary": train_summary}
+
+        if test_set:
+            test_passed = sum(1 for r in test_result_list if r["pass"])
+            test_total = len(test_result_list)
+            test_summary = {"passed": test_passed, "failed": test_total - test_passed, "total": test_total}
+            test_results = {"results": test_result_list, "summary": test_summary}
+        else:
+            test_results = None
+            test_summary = None
+
+        history.append({
+            "iteration": iteration,
+            "description": current_description,
+            "train_passed": train_summary["passed"],
+            "train_failed": train_summary["failed"],
+            "train_total": train_summary["total"],
+            "train_results": train_results["results"],
+            "test_passed": test_summary["passed"] if test_summary else None,
+            "test_failed": test_summary["failed"] if test_summary else None,
+            "test_total": test_summary["total"] if test_summary else None,
+            "test_results": test_results["results"] if test_results else None,
+            # For backward compat with report generator
+            "passed": train_summary["passed"],
+            "failed": train_summary["failed"],
+            "total": train_summary["total"],
+            "results": train_results["results"],
+        })
+
+        # Write live report if path provided
+        if live_report_path:
+            partial_output = {
+                "original_description": original_description,
+                "best_description": current_description,
+                "best_score": "in progress",
+                "iterations_run": len(history),
+                "holdout": holdout,
+                "train_size": len(train_set),
+                "test_size": len(test_set),
+                "history": history,
+            }
+            live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name))
+
+        if verbose:
+            def print_eval_stats(label, results, elapsed):
+                pos = [r for r in results if r["should_trigger"]]
+                neg = [r for r in results if not r["should_trigger"]]
+                tp = sum(r["triggers"] for r in pos)
+                pos_runs = sum(r["runs"] for r in pos)
+                fn = pos_runs - tp
+                fp = sum(r["triggers"] for r in neg)
+                neg_runs = sum(r["runs"] for r in neg)
+                tn = neg_runs - fp
+                total = tp + tn + fp + fn
+                precision = tp / (tp + fp) if (tp + fp) > 0 else 1.0
+                recall = tp / (tp + fn) if (tp + fn) > 0 else 1.0
+                accuracy = (tp + tn) / total if total > 0 else 0.0
+                print(f"{label}: {tp+tn}/{total} correct, precision={precision:.0%} recall={recall:.0%} accuracy={accuracy:.0%} ({elapsed:.1f}s)", file=sys.stderr)
+                for r in results:
+                    status = "PASS" if r["pass"] else "FAIL"
+                    rate_str = f"{r['triggers']}/{r['runs']}"
+                    print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:60]}", file=sys.stderr)
+
+            print_eval_stats("Train", train_results["results"], eval_elapsed)
+            if test_summary:
+                print_eval_stats("Test ", test_results["results"], 0)
+
+        if train_summary["failed"] == 0:
+            exit_reason = f"all_passed (iteration {iteration})"
+            if verbose:
+                print(f"\nAll train queries passed on iteration {iteration}!", file=sys.stderr)
+            break
+
+        if iteration == max_iterations:
+            exit_reason = f"max_iterations ({max_iterations})"
+            if verbose:
+                print(f"\nMax iterations reached ({max_iterations}).", file=sys.stderr)
+            break
+
+        # Improve the description based on train results
+        if verbose:
+            print(f"\nImproving description...", file=sys.stderr)
+
+        t0 = time.time()
+        # Strip test scores from history so improvement model can't see them
+        blinded_history = [
+            {k: v for k, v in h.items() if not k.startswith("test_")}
+            for h in history
+        ]
+        new_description = improve_description(
+            skill_name=name,
+            skill_content=content,
+            current_description=current_description,
+            eval_results=train_results,
+            history=blinded_history,
+            model=model,
+            log_dir=log_dir,
+            iteration=iteration,
+        )
+        improve_elapsed = time.time() - t0
+
+        if verbose:
+            print(f"Proposed ({improve_elapsed:.1f}s): {new_description}", file=sys.stderr)
+
+        current_description = new_description
+
+    # Find the best iteration by TEST score (or train if no test set)
+    if test_set:
+        best = max(history, key=lambda h: h["test_passed"] or 0)
+        best_score = f"{best['test_passed']}/{best['test_total']}"
+    else:
+        best = max(history, key=lambda h: h["train_passed"])
+        best_score = f"{best['train_passed']}/{best['train_total']}"
+
+    if verbose:
+        print(f"\nExit reason: {exit_reason}", file=sys.stderr)
+        print(f"Best score: {best_score} (iteration {best['iteration']})", file=sys.stderr)
+
+    return {
+        "exit_reason": exit_reason,
+        "original_description": original_description,
+        "best_description": best["description"],
+        "best_score": best_score,
+        "best_train_score": f"{best['train_passed']}/{best['train_total']}",
+        "best_test_score": f"{best['test_passed']}/{best['test_total']}" if test_set else None,
+        "final_description": current_description,
+        "iterations_run": len(history),
+        "holdout": holdout,
+        "train_size": len(train_set),
+        "test_size": len(test_set),
+        "history": history,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run eval + improve loop")
+    parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--description", default=None, help="Override starting description")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--max-iterations", type=int, default=5, help="Max improvement iterations")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
+    parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
+    parser.add_argument("--holdout", type=float, default=0.4, help="Fraction of eval set to hold out for testing (0 to disable)")
+    parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    parser.add_argument("--report", default="auto", help="Generate HTML report at this path (default: 'auto' for temp file, 'none' to disable)")
+    parser.add_argument("--results-dir", default=None, help="Save all outputs (results.json, report.html, log.txt) to a timestamped subdirectory here")
+    args = parser.parse_args()
+
+    eval_set = json.loads(Path(args.eval_set).read_text())
+    skill_path = Path(args.skill_path)
+
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    name, _, _ = parse_skill_md(skill_path)
+
+    # Set up live report path
+    if args.report != "none":
+        if args.report == "auto":
+            timestamp = time.strftime("%Y%m%d_%H%M%S")
+            live_report_path = Path(tempfile.gettempdir()) / f"skill_description_report_{skill_path.name}_{timestamp}.html"
+        else:
+            live_report_path = Path(args.report)
+        # Open the report immediately so the user can watch
+        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>")
+        webbrowser.open(str(live_report_path))
+    else:
+        live_report_path = None
+
+    # Determine output directory (create before run_loop so logs can be written)
+    if args.results_dir:
+        timestamp = time.strftime("%Y-%m-%d_%H%M%S")
+        results_dir = Path(args.results_dir) / timestamp
+        results_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        results_dir = None
+
+    log_dir = results_dir / "logs" if results_dir else None
+
+    output = run_loop(
+        eval_set=eval_set,
+        skill_path=skill_path,
+        description_override=args.description,
+        num_workers=args.num_workers,
+        timeout=args.timeout,
+        max_iterations=args.max_iterations,
+        runs_per_query=args.runs_per_query,
+        trigger_threshold=args.trigger_threshold,
+        holdout=args.holdout,
+        model=args.model,
+        verbose=args.verbose,
+        live_report_path=live_report_path,
+        log_dir=log_dir,
+    )
+
+    # Save JSON output
+    json_output = json.dumps(output, indent=2)
+    print(json_output)
+    if results_dir:
+        (results_dir / "results.json").write_text(json_output)
+
+    # Write final HTML report (without auto-refresh)
+    if live_report_path:
+        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        print(f"\nReport: {live_report_path}", file=sys.stderr)
+
+    if results_dir and live_report_path:
+        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name))
+
+    if results_dir:
+        print(f"Results saved to: {results_dir}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/scripts/utils.py
+++ b/.claude/skills/skill-creator/scripts/utils.py
@@ -1,0 +1,47 @@
+"""Shared utilities for skill-creator scripts."""
+
+from pathlib import Path
+
+
+
+def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
+    """Parse a SKILL.md file, returning (name, description, full_content)."""
+    content = (skill_path / "SKILL.md").read_text()
+    lines = content.split("\n")
+
+    if lines[0].strip() != "---":
+        raise ValueError("SKILL.md missing frontmatter (no opening ---)")
+
+    end_idx = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_idx = i
+            break
+
+    if end_idx is None:
+        raise ValueError("SKILL.md missing frontmatter (no closing ---)")
+
+    name = ""
+    description = ""
+    frontmatter_lines = lines[1:end_idx]
+    i = 0
+    while i < len(frontmatter_lines):
+        line = frontmatter_lines[i]
+        if line.startswith("name:"):
+            name = line[len("name:"):].strip().strip('"').strip("'")
+        elif line.startswith("description:"):
+            value = line[len("description:"):].strip()
+            # Handle YAML multiline indicators (>, |, >-, |-)
+            if value in (">", "|", ">-", "|-"):
+                continuation_lines: list[str] = []
+                i += 1
+                while i < len(frontmatter_lines) and (frontmatter_lines[i].startswith("  ") or frontmatter_lines[i].startswith("\t")):
+                    continuation_lines.append(frontmatter_lines[i].strip())
+                    i += 1
+                description = " ".join(continuation_lines)
+                continue
+            else:
+                description = value.strip('"').strip("'")
+        i += 1
+
+    return name, description, content

--- a/.claude/skills/webapp-testing/LICENSE.txt
+++ b/.claude/skills/webapp-testing/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.claude/skills/webapp-testing/SKILL.md
+++ b/.claude/skills/webapp-testing/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: webapp-testing
+description: Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.
+license: Complete terms in LICENSE.txt
+---
+
+# Web Application Testing
+
+To test local web applications, write native Python Playwright scripts.
+
+**Helper Scripts Available**:
+- `scripts/with_server.py` - Manages server lifecycle (supports multiple servers)
+
+**Always run scripts with `--help` first** to see usage. DO NOT read the source until you try running the script first and find that a customized solution is abslutely necessary. These scripts can be very large and thus pollute your context window. They exist to be called directly as black-box scripts rather than ingested into your context window.
+
+## Decision Tree: Choosing Your Approach
+
+```
+User task → Is it static HTML?
+    ├─ Yes → Read HTML file directly to identify selectors
+    │         ├─ Success → Write Playwright script using selectors
+    │         └─ Fails/Incomplete → Treat as dynamic (below)
+    │
+    └─ No (dynamic webapp) → Is the server already running?
+        ├─ No → Run: python scripts/with_server.py --help
+        │        Then use the helper + write simplified Playwright script
+        │
+        └─ Yes → Reconnaissance-then-action:
+            1. Navigate and wait for networkidle
+            2. Take screenshot or inspect DOM
+            3. Identify selectors from rendered state
+            4. Execute actions with discovered selectors
+```
+
+## Example: Using with_server.py
+
+To start a server, run `--help` first, then use the helper:
+
+**Single server:**
+```bash
+python scripts/with_server.py --server "npm run dev" --port 5173 -- python your_automation.py
+```
+
+**Multiple servers (e.g., backend + frontend):**
+```bash
+python scripts/with_server.py \
+  --server "cd backend && python server.py" --port 3000 \
+  --server "cd frontend && npm run dev" --port 5173 \
+  -- python your_automation.py
+```
+
+To create an automation script, include only Playwright logic (servers are managed automatically):
+```python
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True) # Always launch chromium in headless mode
+    page = browser.new_page()
+    page.goto('http://localhost:5173') # Server already running and ready
+    page.wait_for_load_state('networkidle') # CRITICAL: Wait for JS to execute
+    # ... your automation logic
+    browser.close()
+```
+
+## Reconnaissance-Then-Action Pattern
+
+1. **Inspect rendered DOM**:
+   ```python
+   page.screenshot(path='/tmp/inspect.png', full_page=True)
+   content = page.content()
+   page.locator('button').all()
+   ```
+
+2. **Identify selectors** from inspection results
+
+3. **Execute actions** using discovered selectors
+
+## Common Pitfall
+
+❌ **Don't** inspect the DOM before waiting for `networkidle` on dynamic apps
+✅ **Do** wait for `page.wait_for_load_state('networkidle')` before inspection
+
+## Best Practices
+
+- **Use bundled scripts as black boxes** - To accomplish a task, consider whether one of the scripts available in `scripts/` can help. These scripts handle common, complex workflows reliably without cluttering the context window. Use `--help` to see usage, then invoke directly. 
+- Use `sync_playwright()` for synchronous scripts
+- Always close the browser when done
+- Use descriptive selectors: `text=`, `role=`, CSS selectors, or IDs
+- Add appropriate waits: `page.wait_for_selector()` or `page.wait_for_timeout()`
+
+## Reference Files
+
+- **examples/** - Examples showing common patterns:
+  - `element_discovery.py` - Discovering buttons, links, and inputs on a page
+  - `static_html_automation.py` - Using file:// URLs for local HTML
+  - `console_logging.py` - Capturing console logs during automation

--- a/.claude/skills/webapp-testing/examples/console_logging.py
+++ b/.claude/skills/webapp-testing/examples/console_logging.py
@@ -1,0 +1,35 @@
+from playwright.sync_api import sync_playwright
+
+# Example: Capturing console logs during browser automation
+
+url = 'http://localhost:5173'  # Replace with your URL
+
+console_logs = []
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page(viewport={'width': 1920, 'height': 1080})
+
+    # Set up console log capture
+    def handle_console_message(msg):
+        console_logs.append(f"[{msg.type}] {msg.text}")
+        print(f"Console: [{msg.type}] {msg.text}")
+
+    page.on("console", handle_console_message)
+
+    # Navigate to page
+    page.goto(url)
+    page.wait_for_load_state('networkidle')
+
+    # Interact with the page (triggers console logs)
+    page.click('text=Dashboard')
+    page.wait_for_timeout(1000)
+
+    browser.close()
+
+# Save console logs to file
+with open('/mnt/user-data/outputs/console.log', 'w') as f:
+    f.write('\n'.join(console_logs))
+
+print(f"\nCaptured {len(console_logs)} console messages")
+print(f"Logs saved to: /mnt/user-data/outputs/console.log")

--- a/.claude/skills/webapp-testing/examples/element_discovery.py
+++ b/.claude/skills/webapp-testing/examples/element_discovery.py
@@ -1,0 +1,40 @@
+from playwright.sync_api import sync_playwright
+
+# Example: Discovering buttons and other elements on a page
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page()
+
+    # Navigate to page and wait for it to fully load
+    page.goto('http://localhost:5173')
+    page.wait_for_load_state('networkidle')
+
+    # Discover all buttons on the page
+    buttons = page.locator('button').all()
+    print(f"Found {len(buttons)} buttons:")
+    for i, button in enumerate(buttons):
+        text = button.inner_text() if button.is_visible() else "[hidden]"
+        print(f"  [{i}] {text}")
+
+    # Discover links
+    links = page.locator('a[href]').all()
+    print(f"\nFound {len(links)} links:")
+    for link in links[:5]:  # Show first 5
+        text = link.inner_text().strip()
+        href = link.get_attribute('href')
+        print(f"  - {text} -> {href}")
+
+    # Discover input fields
+    inputs = page.locator('input, textarea, select').all()
+    print(f"\nFound {len(inputs)} input fields:")
+    for input_elem in inputs:
+        name = input_elem.get_attribute('name') or input_elem.get_attribute('id') or "[unnamed]"
+        input_type = input_elem.get_attribute('type') or 'text'
+        print(f"  - {name} ({input_type})")
+
+    # Take screenshot for visual reference
+    page.screenshot(path='/tmp/page_discovery.png', full_page=True)
+    print("\nScreenshot saved to /tmp/page_discovery.png")
+
+    browser.close()

--- a/.claude/skills/webapp-testing/examples/static_html_automation.py
+++ b/.claude/skills/webapp-testing/examples/static_html_automation.py
@@ -1,0 +1,33 @@
+from playwright.sync_api import sync_playwright
+import os
+
+# Example: Automating interaction with static HTML files using file:// URLs
+
+html_file_path = os.path.abspath('path/to/your/file.html')
+file_url = f'file://{html_file_path}'
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page(viewport={'width': 1920, 'height': 1080})
+
+    # Navigate to local HTML file
+    page.goto(file_url)
+
+    # Take screenshot
+    page.screenshot(path='/mnt/user-data/outputs/static_page.png', full_page=True)
+
+    # Interact with elements
+    page.click('text=Click Me')
+    page.fill('#name', 'John Doe')
+    page.fill('#email', 'john@example.com')
+
+    # Submit form
+    page.click('button[type="submit"]')
+    page.wait_for_timeout(500)
+
+    # Take final screenshot
+    page.screenshot(path='/mnt/user-data/outputs/after_submit.png', full_page=True)
+
+    browser.close()
+
+print("Static HTML automation completed!")

--- a/.claude/skills/webapp-testing/scripts/with_server.py
+++ b/.claude/skills/webapp-testing/scripts/with_server.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Start one or more servers, wait for them to be ready, run a command, then clean up.
+
+Usage:
+    # Single server
+    python scripts/with_server.py --server "npm run dev" --port 5173 -- python automation.py
+    python scripts/with_server.py --server "npm start" --port 3000 -- python test.py
+
+    # Multiple servers
+    python scripts/with_server.py \
+      --server "cd backend && python server.py" --port 3000 \
+      --server "cd frontend && npm run dev" --port 5173 \
+      -- python test.py
+"""
+
+import subprocess
+import socket
+import time
+import sys
+import argparse
+
+def is_server_ready(port, timeout=30):
+    """Wait for server to be ready by polling the port."""
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            with socket.create_connection(('localhost', port), timeout=1):
+                return True
+        except (socket.error, ConnectionRefusedError):
+            time.sleep(0.5)
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run command with one or more servers')
+    parser.add_argument('--server', action='append', dest='servers', required=True, help='Server command (can be repeated)')
+    parser.add_argument('--port', action='append', dest='ports', type=int, required=True, help='Port for each server (must match --server count)')
+    parser.add_argument('--timeout', type=int, default=30, help='Timeout in seconds per server (default: 30)')
+    parser.add_argument('command', nargs=argparse.REMAINDER, help='Command to run after server(s) ready')
+
+    args = parser.parse_args()
+
+    # Remove the '--' separator if present
+    if args.command and args.command[0] == '--':
+        args.command = args.command[1:]
+
+    if not args.command:
+        print("Error: No command specified to run")
+        sys.exit(1)
+
+    # Parse server configurations
+    if len(args.servers) != len(args.ports):
+        print("Error: Number of --server and --port arguments must match")
+        sys.exit(1)
+
+    servers = []
+    for cmd, port in zip(args.servers, args.ports):
+        servers.append({'cmd': cmd, 'port': port})
+
+    server_processes = []
+
+    try:
+        # Start all servers
+        for i, server in enumerate(servers):
+            print(f"Starting server {i+1}/{len(servers)}: {server['cmd']}")
+
+            # Use shell=True to support commands with cd and &&
+            process = subprocess.Popen(
+                server['cmd'],
+                shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
+            server_processes.append(process)
+
+            # Wait for this server to be ready
+            print(f"Waiting for server on port {server['port']}...")
+            if not is_server_ready(server['port'], timeout=args.timeout):
+                raise RuntimeError(f"Server failed to start on port {server['port']} within {args.timeout}s")
+
+            print(f"Server ready on port {server['port']}")
+
+        print(f"\nAll {len(servers)} server(s) ready")
+
+        # Run the command
+        print(f"Running: {' '.join(args.command)}\n")
+        result = subprocess.run(args.command)
+        sys.exit(result.returncode)
+
+    finally:
+        # Clean up all servers
+        print(f"\nStopping {len(server_processes)} server(s)...")
+        for i, process in enumerate(server_processes):
+            try:
+                process.terminate()
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+            print(f"Server {i+1} stopped")
+        print("All servers stopped")
+
+
+if __name__ == '__main__':
+    main()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,94 +1,88 @@
-# Instructions for Claude
+# Instructions for Claude — Preploy monorepo
 
-After making code change, recommend a commit message for that specific changes, if you made code changes significant enough. 
+## Monorepo layout
 
-When referred to a **task**, go to **Tasks.md** and read through the stories and task descriptions. When you finish a task, always refer back to the **Tasks.md** and mark it as complete.
-
-## Testing Requirements
-
-When implementing a new feature or modifying existing logic, always write tests alongside the code. Aim for these coverage targets:
-
-- **Pure logic** (`lib/`, `services/`, `stores/`, utils): **80%+ line coverage**. These are the highest-value tests.
-- **API routes**: Write integration tests for any new or modified route handler.
-- **Interactive components** (setup forms, feedback dashboard, expandable cards): Write component tests for components with meaningful user interaction (state changes, conditional rendering, expand/collapse). Place `*.test.tsx` next to the component. Mock Zustand stores and `next/navigation` using `vi.hoisted()` + `vi.mock()`. Use `getAllByText` instead of `getByText` since shadcn components may render elements multiple times in jsdom.
-- **Skip testing**: Purely presentational components (shadcn wrappers, badges), Three.js/avatar components, and components that primarily fetch data (better covered by E2E later).
-
-### Where to put tests
-
-- **Web unit tests**: Place `*.test.ts` / `*.test.tsx` next to the source file being tested (e.g., `lib/prompts.test.ts`).
-- **Web integration tests**: Place `*.integration.test.ts` next to the route handler (e.g., `app/api/sessions/route.integration.test.ts`). These run against a real Docker Postgres test DB.
-  - **Never mock the database.** All DB interactions must run against the real Docker test DB. This is the whole point of integration tests — mocked DB queries can't catch real SQL/schema issues.
-  - Mock `@/lib/auth` (for auth simulation) and external APIs (OpenAI, etc.) — these are the only things that should be mocked.
-  - Mock `@/lib/db` to point at `getTestDb()` from `tests/setup-db.ts` — this redirects all DB calls to the Docker test DB (this is **not** mocking the DB; it's pointing to the test instance).
-  - Use `beforeAll` to seed test data (e.g., test users), `beforeEach` to clean tables between tests, `afterAll` to cleanup/teardown.
-- **Python tests**: Place `test_*.py` in `apps/api/tests/`. Mock external API calls (OpenAI) with `unittest.mock.patch`; test everything else for real.
-
-### How to run
-
-```bash
-turbo test                                          # All unit tests
-cd apps/web && npm run test:integration             # Integration tests (requires: docker compose up -d test-db)
-cd apps/web && npm run test:coverage                # Unit tests with coverage
-cd apps/api && npm run test:coverage                # Python tests with coverage
+```
+apps/
+  web/      Next.js 16 (App Router) + Drizzle ORM + Vitest        → see apps/web/CLAUDE.md
+  api/      FastAPI Python service (GPT analysis)                  → see apps/api/CLAUDE.md
+packages/
+  shared/   Shared TypeScript types and constants
 ```
 
-### Logging
+When working inside `apps/web` or `apps/api`, the per-app `CLAUDE.md` is the
+source of truth — read it first.
 
-Use structured logging instead of `console.log`/`console.error` in all server-side code:
+## Workflow
 
-- **API routes (Next.js)**: Use `logger` or `createRequestLogger()` from `@/lib/logger`. The `createRequestLogger` auto-generates a `requestId` for tracing.
-  ```ts
-  import { createRequestLogger } from "@/lib/logger";
-  const log = createRequestLogger({ route: "POST /api/example", userId });
-  log.info("Processing request");
-  log.error({ err }, "Something failed");
-  ```
-- **Python (FastAPI)**: Use `logging.getLogger(__name__)` — already configured with JSON output in production.
-- **Client-side code** (hooks, components, session pages): `console.error` is fine — Pino doesn't run in the browser.
+When asked about a **task**, read `Tasks.md`, find the relevant story, and follow
+its acceptance criteria. When the task is complete, update `Tasks.md` to mark
+it done.
 
-### Pre-commit checklist
+When asked about a **new feature idea**, read `Backlog.md` first to see whether
+it is already planned.
 
-Before marking any story or task as complete, run **all** of the following:
+After making code changes significant enough to be a unit of work, recommend a
+commit message for those specific changes.
+
+## Pre-commit checklist (mandatory)
+
+Before marking any story or task complete, run **all** of:
 
 ```bash
-npx turbo lint typecheck test          # Lint (ESLint + ruff) + typecheck + unit/component tests
-cd apps/web && npm run test:integration # Integration tests (requires Docker test-db)
+npx turbo lint typecheck test           # ESLint + ruff + tsc + unit/component tests
+cd apps/web && npm run test:integration # Real Postgres integration tests
 ```
 
-If any of these fail, fix the issue before committing. CI will reject the push otherwise.
+If any of these fail, fix the issue before committing — CI will reject the push.
+The Stop hook in `.claude/settings.json` runs the first command automatically
+when Claude finishes a turn that touched source files; you should still run the
+integration suite manually before pushing.
 
-### Database schema changes
+## Skills available in this repo
 
-When modifying `lib/schema.ts`, always use versioned migrations:
+The skills below live in `.claude/skills/` and trigger automatically when
+relevant. You don't need to invoke them by name.
+
+- **`webapp-testing`** — Playwright browser testing. Use whenever you need to
+  click through the running web app, verify rendered UI, or capture screenshots.
+- **`claude-api`** — Anthropic SDK reference. Use only when a story explicitly
+  asks to add or modify Claude API calls. The web app currently uses OpenAI;
+  do not silently swap providers.
+- **`skill-creator`** — Use only when the user asks to create or improve a
+  project-specific skill.
+
+## Subagents (the autonomous-loop roles)
+
+The `.claude/agents/` directory holds specialized roles:
+
+- `pm-proposer` — reads `Backlog.md` + `Tasks.md`, proposes the next stories
+- `tech-lead-planner` — reads the codebase and drafts an implementation plan
+- `feature-implementer` — writes the code + tests
+- `qa-tester` — runs the test suites and uses `webapp-testing` to exercise the UI
+- `pr-reviewer` — diffs against `main`, checks the rules in this file, drafts a PR
+
+The `/standup` slash command runs them in sequence with approval gates between
+each role.
+
+## Database schema changes
+
+When modifying `apps/web/lib/schema.ts`, always use versioned migrations:
 
 ```bash
 cd apps/web
-npm run db:generate   # Generate SQL migration file from schema diff
-# Review the generated SQL in drizzle/
-npm run db:migrate    # Apply migration to your local database
+npm run db:generate   # Generate SQL migration
+# review the generated SQL in drizzle/
+npm run db:migrate    # Apply locally
 ```
 
-- **Never use `db:push` in production.** It modifies the schema directly without an audit trail.
-- `db:push` is acceptable for local development iteration, but always generate a migration before committing.
-- Commit the generated SQL files in `drizzle/` — they are the source of truth for the schema.
-- Integration tests automatically apply migrations via `tests/global-setup.ts`.
+**Never** use `db:push` for committed work. Commit the generated SQL files in
+`drizzle/` — they are the source of truth.
 
-### Key principles
+## Other repo-wide rules
 
-After finishing a feature, run `turbo test` to ensure nothing is broken. If adding a new API route or modifying an existing one, add or update the corresponding integration test. If adding pure logic, add a unit test.
-
-### API route integration test checklist
-
-Every API route change **must** have integration tests covering:
-
-1. **Auth**: 401 when unauthenticated
-2. **Authorization**: 404 when accessing another user's resource (never leak existence)
-3. **Validation**: 400 for invalid/missing required fields
-4. **Happy path**: Correct status code + response shape for each HTTP method
-5. **Query params/filters**: If the route accepts query params (pagination, filters, etc.), test each param individually AND in combination. This includes:
-   - Pagination: page boundaries, totalCount accuracy with filters applied
-   - Filters: each filter alone, multiple filters combined, empty result sets
-6. **Response shape changes**: If you change what an endpoint returns (e.g., wrapping an array in `{ data, pagination }`), update **every consumer** — other routes, frontend fetch calls, sidebar, dashboard — AND their tests
-7. **Branching logic**: If a route behaves differently based on data (e.g., behavioral vs technical), test both branches
-
-**When modifying an existing route**: always re-read the existing integration test file first. If your change adds a new query param, filter, response field, or behavioral branch, add corresponding test cases before considering the work done.
+- Conventional Commits style (`feat:`, `fix:`, `chore:`, `refactor:`, `docs:`).
+- Branch naming: `feature/{story-number}-{short-description}` for feature work.
+- Never use `console.log` in server-side code (Next.js API routes or FastAPI
+  endpoints). See per-app CLAUDE.md for the structured logger pattern.
+- Never commit secrets or files containing them (`.env`, `credentials.json`).

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -1,0 +1,71 @@
+# apps/api — FastAPI conventions
+
+This file scopes Claude's instructions to the Python service. The root
+`CLAUDE.md` covers monorepo-wide rules.
+
+## Stack
+
+- FastAPI + Uvicorn (Python 3.12)
+- SQLAlchemy 2 + psycopg2
+- Pydantic v2 + pydantic-settings
+- OpenAI SDK (`openai>=1.70`)
+- Sentry SDK
+- pytest + pytest-asyncio + httpx for tests
+- ruff for lint (`E`, `F`, `I` rule sets)
+
+## Logging
+
+Use `logging.getLogger(__name__)` — JSON output is configured globally in
+production. **Never** use `print()` in service code.
+
+```python
+import logging
+log = logging.getLogger(__name__)
+log.info("processing request", extra={"user_id": user_id})
+log.exception("openai call failed")
+```
+
+## Tests
+
+- Place `test_*.py` in `apps/api/tests/`.
+- Mock external API calls (OpenAI) with `unittest.mock.patch`.
+- Test everything else for real — no DB mocking, no HTTP server mocking.
+- Async tests: pytest-asyncio is in `auto` mode, just write `async def test_...`.
+- Use `httpx.AsyncClient` against the FastAPI app for endpoint tests.
+
+### Run tests
+
+```bash
+cd apps/api
+.venv/bin/pytest                # Run all tests
+.venv/bin/pytest --cov          # With coverage
+```
+
+### Coverage targets
+
+- Pure logic (services, prompt builders, parsers): 80%+ line coverage.
+- Endpoints: at least one test per route covering the happy path + one error case.
+
+## Lint and typecheck
+
+```bash
+.venv/bin/ruff check .          # Lint
+.venv/bin/ruff format .         # Format
+```
+
+The root `npx turbo lint` runs ruff via the `lint` script in `package.json`.
+
+## Environment
+
+- Python venv lives at `apps/api/.venv` — bootstrap with:
+  ```bash
+  python -m venv .venv
+  .venv/bin/pip install -e ".[dev]"
+  ```
+- Settings load from `.env` via `pydantic-settings`. Never hardcode secrets.
+
+## Skills available
+
+- **`claude-api`** — reference for Anthropic SDK usage *if* a story explicitly
+  asks to add Claude alongside or instead of OpenAI. Do not silently swap
+  providers.

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,0 +1,145 @@
+# apps/web — Next.js + Drizzle conventions
+
+This file scopes Claude's instructions to the Next.js app. The root `CLAUDE.md`
+covers monorepo-wide rules (Tasks.md workflow, pre-commit checklist).
+
+## Stack
+
+- Next.js 16 (App Router) + React 19
+- Drizzle ORM + Postgres (`postgres` driver)
+- NextAuth v5 (`@/lib/auth`)
+- Vitest + Testing Library + jsdom for unit/component tests
+- Vitest + real Docker Postgres for integration tests
+- Tailwind v4 + shadcn/ui components
+- Pino structured logging (`@/lib/logger`)
+
+## API routes
+
+- Place in `app/api/{resource}/route.ts`.
+- **Always** check `auth()` first; return 401 if unauthenticated.
+- Validate input with Zod schemas from `@/lib/validations`.
+- Use `checkRateLimit(session.user.id)` from `@/lib/api-utils` for expensive endpoints.
+- Use `createRequestLogger({ route, userId })` from `@/lib/logger` — never `console.log` server-side.
+- On 404 for another user's resource, never leak existence (return 404, not 403).
+
+## Database
+
+- Schema lives in `lib/schema.ts`. Relations are defined in the same file.
+- After modifying the schema, run:
+  ```bash
+  npm run db:generate    # Generate SQL migration
+  # review the SQL in drizzle/
+  npm run db:migrate     # Apply locally
+  ```
+- **Never** use `npm run db:push` for committed work — it bypasses the audit trail.
+  It is acceptable for throwaway local iteration only.
+- Commit the generated SQL files in `drizzle/`. They are the source of truth.
+- Integration tests apply migrations automatically via `tests/global-setup.ts`.
+
+## Pages
+
+- Place in `app/{route}/page.tsx`. Use `"use client"` for interactive pages.
+- Add new protected routes to `middleware.ts` matcher.
+- Add navigation links in `components/shared/Sidebar.tsx` (and `Header.tsx` if top-level).
+- Page containers: `max-w-6xl`. Two-column layouts: `md:grid-cols-2`.
+- Always render a loading skeleton while data fetches.
+
+## Styling
+
+- Tailwind v4 + shadcn/ui (`Card`, `CardHeader`, `CardTitle`, `CardContent`).
+- Dark mode: use `dark:` variants for custom colors.
+- Score colors: `getScoreColor()` from `@/lib/utils`.
+
+## Tests
+
+### Unit tests (`lib/*.test.ts`)
+
+- Co-locate next to the source file (e.g., `lib/prompts.test.ts`).
+- Target 80%+ line coverage on `lib/`, `services/`, `stores/`.
+- Cover happy path, edge cases, error cases, boundary values, empty/null inputs.
+
+### Component tests (`components/**/*.test.tsx`)
+
+- Only for **interactive** components (state changes, conditional rendering, expand/collapse).
+- Skip purely presentational components (shadcn wrappers, badges, icons).
+- Skip Three.js/avatar components — better covered by E2E later.
+- Use `getAllByText`, not `getByText` (shadcn renders multiple times in jsdom).
+- Mock Zustand stores and `next/navigation` with `vi.hoisted()` + `vi.mock()`.
+- For async data: mock `global.fetch` in `beforeEach`, restore in `afterEach`.
+
+### Integration tests (`app/api/**/*.integration.test.ts`)
+
+These run against a **real** Docker Postgres test DB. Start it with:
+
+```bash
+docker compose up -d test-db
+npm run test:integration
+```
+
+**Never mock the database.** That's the whole point of integration tests.
+
+The only things you may mock:
+- `@/lib/auth` — to simulate authenticated requests
+- External APIs (OpenAI, Anthropic, etc.)
+- `@/lib/db` — pointed at `getTestDb()` from `tests/setup-db.ts` (this is *redirection*, not mocking)
+
+**Standard template:**
+
+```typescript
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
+import { NextRequest } from "next/server";
+import { cleanupTestDb, teardownTestDb, getTestDb } from "../../../../tests/setup-db";
+import { users } from "@/lib/schema";
+
+const mockAuth = vi.fn();
+vi.mock("@/lib/auth", () => ({ auth: () => mockAuth() }));
+vi.mock("@/lib/db", () => ({ get db() { return getTestDb(); } }));
+
+import { GET, POST } from "./route";
+
+const TEST_USER = {
+  id: "00000000-0000-0000-0000-000000000001",
+  email: "test@example.com",
+  name: "Test User",
+};
+
+describe("API /api/your-route (integration)", () => {
+  beforeAll(async () => { /* seed users */ });
+  beforeEach(async () => { vi.clearAllMocks(); /* clean tables */ });
+  afterAll(async () => { await cleanupTestDb(); await teardownTestDb(); });
+
+  it("returns 401 when unauthenticated", async () => { /* ... */ });
+  it("returns 404 for another user's resource", async () => { /* ... */ });
+  it("returns 400 for invalid input", async () => { /* ... */ });
+  it("happy path returns correct data", async () => { /* ... */ });
+});
+```
+
+### Integration test checklist (mandatory for every route change)
+
+1. **Auth**: 401 when unauthenticated
+2. **Authorization**: 404 when accessing another user's resource (never leak existence)
+3. **Validation**: 400 for invalid/missing required fields
+4. **Happy path**: correct status code + response shape for each HTTP method
+5. **Query params/filters**: each individually AND in combination — pagination boundaries, totalCount with filters, empty result sets
+6. **Response shape changes**: update **every consumer** (other routes, frontend fetch calls, sidebar, dashboard) AND their tests
+7. **Branching logic**: test both branches (e.g., behavioral vs technical)
+8. **Persistence**: after POST/PATCH, verify with a real SELECT query
+
+When modifying an existing route, **always re-read** its integration test file first and add cases for any new param/field/branch.
+
+## Logging
+
+```ts
+import { createRequestLogger } from "@/lib/logger";
+const log = createRequestLogger({ route: "POST /api/example", userId });
+log.info("processing request");
+log.error({ err }, "something failed");
+```
+
+Client-side `console.error` is fine — Pino doesn't run in the browser.
+
+## Skills available in this project
+
+- **`webapp-testing`** — Playwright for browser tests. Use this when asked to "click through", "exercise the UI", or "verify the avatar renders". Prefer this over writing component tests for Three.js or animation-heavy code.
+- **`claude-api`** — reference this only if the story touches Anthropic SDK code. The web app currently uses OpenAI; do not "convert" OpenAI calls to Anthropic without explicit instruction.


### PR DESCRIPTION
## Summary

Turns this repo into a Claude Code "max-capability" harness so a human can sit at the top of the dev loop and only say yes/no between phases. Adds three official Anthropic skills, splits CLAUDE.md into per-app files, wires up a 5-role autonomous development loop with approval gates, and installs a deterministic pre-commit Stop hook.

No application code is touched — every change is in `.claude/`, `CLAUDE.md`, `apps/*/CLAUDE.md`.

## What's in this PR (5 commits)

### 1. `beceafe` — Official Anthropic skills imported into `.claude/skills/`

Three skills from [anthropics/skills](https://github.com/anthropics/skills), each with upstream LICENSE preserved:

- **`webapp-testing`** (36 KB) — Playwright browser testing. Fills the E2E gap called out in CLAUDE.md for Three.js/avatar components and interactive setup forms.
- **`claude-api`** (487 KB) — per-language (TS, Python, Go, Ruby, Java, PHP, C#, curl) Anthropic SDK references plus prompt-caching, tool-use, batches, streaming docs.
- **`skill-creator`** (248 KB) — meta-skill for authoring future project-specific skills.

Total ~770 KB, 63 files.

### 2. `bde693c` — Per-app CLAUDE.md split

- `apps/web/CLAUDE.md` — Next.js + Drizzle conventions, integration test template, 8-point checklist, `getAllByText` gotcha, middleware/sidebar update rules
- `apps/api/CLAUDE.md` — FastAPI + ruff + pytest conventions
- Root `CLAUDE.md` — slimmed to a monorepo index (Tasks.md workflow, pre-commit checklist, skills, subagents)

Drops irrelevant context per session and eliminates duplication between root and app-specific rules.

### 3. `92666f6` — 5-role autonomous development loop

**Roles** (`.claude/agents/`):
- `pm-proposer` — reads Backlog.md + Tasks.md, proposes 1–3 stories with acceptance criteria
- `tech-lead-planner` — reads the codebase, drafts a step-by-step implementation plan
- `feature-implementer` — existing; writes code + tests
- `qa-tester` — runs lint/typecheck/unit/integration + UI smoke via the `webapp-testing` skill
- `pr-reviewer` — diffs against main, audits CLAUDE.md rules, drafts PR title + body

**Slash commands** (`.claude/commands/`):
- `/standup` — runs the full 5-role loop with approval gates between each role
- `/task <id>` — picks up a story from Tasks.md, plans, implements, marks done
- `/precommit` — runs lint + typecheck + unit + integration tests, fixes failures until green
- `/migrate` — generates a Drizzle migration, reviews the SQL, applies it

**Shared settings** (`.claude/settings.json`) — checked in so the team and CI both inherit:
- Deny rules: `git push --force`, `git reset --hard`, `rm -rf /`, `db:push`
- `Stop` hook: `.claude/hooks/precommit-gate.sh` — auto-runs `turbo lint typecheck test` scoped to changed packages after every Claude turn that touched source

### 4. `09a731c` — Tighten test enforcement across the loop

Closes three gaps in the original loop:

1. **PM** proposals now require a "How we'll prove it works" section with concrete unit / integration / UI scenarios. If the PM can't name a concrete assertion, the story is too vague.
2. **Tech Lead** plans now map every PM scenario to a specific test (story-trace).
3. **QA**'s coverage check is now *semantic*, not just structural: it reads each new test file and rejects `describe.skip`, `it.skip`, `it.todo`, or commented-out assertions; verifies integration tests cover all 8 checklist points; and cross-references the PM's scenarios against assertions in the diff.

QA also now produces a structured `Fix-list` that feeds back into the implementer on failure. The 3-attempt circuit breaker produces a structured handoff to the user with attempt history and root-blocker hypothesis.

### 5. `bd807e9` — Fix precommit-gate.sh bugs

Two bugs in the Stop hook from commit 3:
1. Wrong turbo filter: hardcoded `interview-assistant-api` but the actual workspace name is `@interview-assistant/api`.
2. Wrong redirect order: `2>&1 >file` silently drops stderr; the correct form is `>file 2>&1`.

Verified: hook now runs `npx turbo lint typecheck test --filter=@interview-assistant/api` against a dirty tree and exits 0 cleanly (49 pytest tests pass).

## What this enables tomorrow morning

Open Claude Code and type just `/standup`. You'll see:

1. PM proposes the next 1–3 stories from Backlog.md / Tasks.md → **you say yes/no**
2. Tech Lead drafts an implementation plan → **you say yes/no**
3. Developer writes code + tests autonomously (no gate)
4. QA runs the full test gauntlet + UI smoke (no user gate — automated, feeds back to developer on failure)
5. Reviewer drafts a PR title + body → **you say yes/no**

Three yes/no decisions per story. Everything else is automated.

## Known issues (not blocking this PR)

- **Web test suite exits 1 on baseline** due to pre-existing uncaught "window is not defined" exceptions during React 19 / jsdom async cleanup in several component test files (`FeedbackDashboard.test.tsx`, `BehavioralSetupForm.test.tsx`, `TechnicalSetupForm.test.tsx`, etc.). 276/276 assertions pass — only the process exit code is broken. This exists on `main` and is unrelated to this PR. Should be filed as a separate Backlog item.

## Test plan

- [x] `npx turbo lint typecheck test --filter=@interview-assistant/api` — 49 pytest tests pass, ruff clean
- [x] `.claude/hooks/precommit-gate.sh` — exits 0 on a dirty tree with valid changes
- [x] Skills import: each `SKILL.md` frontmatter validated; LICENSEs preserved
- [x] All agent and command markdown files have valid YAML frontmatter (`---` on line 1)
- [ ] Reviewer approves
- [ ] Smoke test: open a fresh Claude Code session, run `/standup` on a real story

## Notes for reviewer

- The `feature-implementer.md` agent already existed before this PR and is unchanged — it's referenced by the new `/standup` command but no edits to it are in this diff.
- `settings.local.json` is gitignored and unchanged. Only the new checked-in `settings.json` is in this PR.
- The `.claude/skills/` directory is ~770 KB. If that's too large to commit long-term, alternatives are documented in the commit message of `beceafe` (sparse-checkout / submodule / user-scope install).
