### PR TITLE
refactor: port behavioral + technical analysis to Next.js routes

### DIFF
--- a/apps/web/app/api/analysis/__fixtures__/behavioral-gpt-response.json
+++ b/apps/web/app/api/analysis/__fixtures__/behavioral-gpt-response.json
@@ -1,0 +1,35 @@
+{
+  "overall_score": 7.5,
+  "summary": "The candidate showed good leadership skills with concrete examples.",
+  "strengths": [
+    "Clear communication",
+    "Concrete examples with metrics",
+    "Good STAR method usage"
+  ],
+  "weaknesses": [
+    "Could elaborate more on results",
+    "Lacked discussion of alternative approaches",
+    "No mention of lessons learned"
+  ],
+  "answer_analyses": [
+    {
+      "question": "Tell me about a time you led a team.",
+      "answer_summary": "Led a team of 5 engineers to ship a feature in 3 weeks.",
+      "score": 8.0,
+      "feedback": "Good specific example with metrics. Could include more about the result.",
+      "suggestions": [
+        "Quantify the business impact of the feature",
+        "Describe how you delegated tasks"
+      ]
+    },
+    {
+      "question": "What challenges did you face?",
+      "answer_summary": "Managed tight deadlines through scope prioritization.",
+      "score": 7.0,
+      "feedback": "Good problem-solving, but could go deeper on the process.",
+      "suggestions": [
+        "Explain the criteria used for prioritization"
+      ]
+    }
+  ]
+}

--- a/apps/web/app/api/analysis/__fixtures__/technical-gpt-response.json
+++ b/apps/web/app/api/analysis/__fixtures__/technical-gpt-response.json
@@ -1,0 +1,17 @@
+{
+  "overall_score": 7.0,
+  "summary": "Candidate demonstrated solid problem-solving skills.",
+  "strengths": ["Clear explanation", "Correct approach", "Good complexity analysis"],
+  "weaknesses": ["Edge cases not discussed", "No error handling", "Could optimize further"],
+  "code_quality_score": 6.5,
+  "explanation_quality_score": 7.5,
+  "answer_analyses": [
+    {
+      "question": "Walk me through your approach.",
+      "answer_summary": "Candidate used a sliding window.",
+      "score": 7.0,
+      "feedback": "Good approach but could discuss alternatives.",
+      "suggestions": ["Mention brute force first", "Discuss trade-offs"]
+    }
+  ]
+}

--- a/apps/web/app/api/analysis/behavioral/route.integration.test.ts
+++ b/apps/web/app/api/analysis/behavioral/route.integration.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Integration test for POST /api/analysis/behavioral.
+ *
+ * This route has no DB calls and no auth — it's a pure server-to-server
+ * GPT proxy. The integration suite still exercises the full Zod-validated
+ * request → response pipeline against a mocked OpenAI client and re-parses
+ * the response body with `feedbackResponseSchema` to prove every constraint
+ * in the wire contract is satisfied.
+ *
+ * Story 22 acceptance criteria: "Integration tests mock OpenAI and assert
+ * full Zod-validated response shapes."
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const mockChatCreate = vi.fn();
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    chat = { completions: { create: mockChatCreate } };
+  },
+}));
+
+vi.stubEnv("OPENAI_API_KEY", "sk-integration-test");
+
+import { POST } from "./route";
+import { feedbackResponseSchema } from "@/lib/analysis-schemas";
+
+const VALID_GPT_RESPONSE = readFileSync(
+  join(__dirname, "..", "__fixtures__", "behavioral-gpt-response.json"),
+  "utf-8",
+);
+
+const SAMPLE_TRANSCRIPT = [
+  { speaker: "ai", text: "Tell me about a time you led a team.", timestamp_ms: 0 },
+  {
+    speaker: "user",
+    text: "I led a team of 5 engineers to ship a feature in 3 weeks.",
+    timestamp_ms: 5000,
+  },
+  { speaker: "ai", text: "What challenges did you face?", timestamp_ms: 15000 },
+  {
+    speaker: "user",
+    text: "Tight deadlines; we cut scope.",
+    timestamp_ms: 20000,
+  },
+];
+
+const VALID_BODY = {
+  session_id: "sess-integration-1",
+  transcript: SAMPLE_TRANSCRIPT,
+  config: {
+    company_name: "Google",
+    job_description: "Senior Software Engineer",
+    difficulty: 0.8,
+    interview_style: 0.5,
+  },
+};
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3000/api/analysis/behavioral", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/analysis/behavioral (integration)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 on empty transcript", async () => {
+    const res = await POST(
+      makeRequest({ session_id: "s", transcript: [], config: {} }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/empty/i);
+    expect(mockChatCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on missing required field (session_id)", async () => {
+    const res = await POST(
+      makeRequest({ transcript: SAMPLE_TRANSCRIPT, config: {} }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockChatCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with full Zod-validated body matching the canonical fixture", async () => {
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: VALID_GPT_RESPONSE } }],
+    });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+
+    // Re-parse with the schema to prove every Zod constraint passes end-to-end.
+    const reparsed = feedbackResponseSchema.safeParse(body);
+    expect(reparsed.success).toBe(true);
+
+    expect(body.overall_score).toBe(7.5);
+    expect(body.summary).toContain("leadership");
+    expect(body.strengths).toHaveLength(3);
+    expect(body.weaknesses).toHaveLength(3);
+    expect(body.answer_analyses).toHaveLength(2);
+    expect(body.answer_analyses[0].score).toBe(8.0);
+    expect(body.answer_analyses[1].score).toBe(7.0);
+    expect(mockChatCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 500 after retry exhaustion (two malformed responses)", async () => {
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: "not valid json {{{" } }],
+    });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(500);
+    expect(mockChatCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 200 on retry-then-succeed (empty first, fixture second)", async () => {
+    mockChatCreate
+      .mockResolvedValueOnce({ choices: [{ message: { content: null } }] })
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: VALID_GPT_RESPONSE } }],
+      });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(mockChatCreate).toHaveBeenCalledTimes(2);
+
+    const body = await res.json();
+    expect(feedbackResponseSchema.safeParse(body).success).toBe(true);
+    expect(body.overall_score).toBe(7.5);
+  });
+});

--- a/apps/web/app/api/analysis/behavioral/route.test.ts
+++ b/apps/web/app/api/analysis/behavioral/route.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const mockChatCreate = vi.fn();
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    chat = { completions: { create: mockChatCreate } };
+  },
+}));
+
+import { POST } from "./route";
+
+const VALID_GPT_RESPONSE = readFileSync(
+  join(__dirname, "..", "__fixtures__", "behavioral-gpt-response.json"),
+  "utf-8",
+);
+
+const SAMPLE_TRANSCRIPT = [
+  { speaker: "ai", text: "Tell me about yourself.", timestamp_ms: 0 },
+  { speaker: "user", text: "I'm an engineer.", timestamp_ms: 5000 },
+];
+
+const VALID_BODY = {
+  session_id: "sess-1",
+  transcript: SAMPLE_TRANSCRIPT,
+  config: { difficulty: 0.8 },
+};
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3000/api/analysis/behavioral", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/analysis/behavioral (unit)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.OPENAI_API_KEY = "sk-test-key";
+  });
+
+  it("returns 400 when JSON body cannot be parsed", async () => {
+    const req = new NextRequest("http://localhost:3000/api/analysis/behavioral", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when session_id is missing", async () => {
+    const res = await POST(makeRequest({ transcript: SAMPLE_TRANSCRIPT }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on empty transcript", async () => {
+    const res = await POST(
+      makeRequest({ session_id: "s", transcript: [], config: {} }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/empty/i);
+  });
+
+  it("returns 200 with validated response on happy path", async () => {
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: VALID_GPT_RESPONSE } }],
+    });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.overall_score).toBe(7.5);
+    expect(body.answer_analyses).toHaveLength(2);
+    expect(mockChatCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries once on invalid JSON then returns the parsed result", async () => {
+    mockChatCreate
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: "not valid json {{{" } }],
+      })
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: VALID_GPT_RESPONSE } }],
+      });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(mockChatCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries once on empty content then returns the parsed result", async () => {
+    mockChatCreate
+      .mockResolvedValueOnce({ choices: [{ message: { content: null } }] })
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: VALID_GPT_RESPONSE } }],
+      });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(mockChatCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 500 after two empty responses", async () => {
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: null } }],
+    });
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(500);
+    expect(mockChatCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 500 after two schema-invalid responses", async () => {
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: '{"overall_score": 5}' } }],
+    });
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(500);
+    expect(mockChatCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 500 when OPENAI_API_KEY is unset", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/web/app/api/analysis/behavioral/route.ts
+++ b/apps/web/app/api/analysis/behavioral/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server";
+import OpenAI from "openai";
+
+import { createRequestLogger } from "@/lib/logger";
+import {
+  buildBehavioralPrompt,
+  BEHAVIORAL_SYSTEM_PROMPT,
+} from "@/lib/analysis-prompts";
+import {
+  feedbackRequestSchema,
+  feedbackResponseSchema,
+} from "@/lib/analysis-schemas";
+import {
+  OpenAIRetryError,
+  withOpenAIRetry,
+} from "@/lib/openai-retry";
+
+/**
+ * POST /api/analysis/behavioral
+ *
+ * Internal, server-to-server route ported from FastAPI
+ * `/analysis/behavioral` (apps/api/app/routers/analysis.py). No auth — matches
+ * the original which is reachable only from `apps/web/app/api/sessions/[id]/feedback/route.ts`.
+ *
+ * Story 23 will swap the existing feedback route to call this one. Until then
+ * this endpoint runs in parallel for byte-equivalent validation.
+ */
+export async function POST(request: NextRequest) {
+  const log = createRequestLogger({ route: "POST /api/analysis/behavioral" });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = feedbackRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request", details: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  if (parsed.data.transcript.length === 0) {
+    return NextResponse.json({ error: "Transcript is empty" }, { status: 400 });
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    log.error("OPENAI_API_KEY not configured");
+    return NextResponse.json(
+      { error: "OpenAI API key not configured" },
+      { status: 500 },
+    );
+  }
+
+  const openai = new OpenAI({ apiKey });
+  const prompt = buildBehavioralPrompt(parsed.data.transcript, parsed.data.config);
+
+  try {
+    const result = await withOpenAIRetry(
+      () =>
+        openai.chat.completions.create({
+          model: "gpt-5.4-mini",
+          messages: [
+            { role: "system", content: BEHAVIORAL_SYSTEM_PROMPT },
+            { role: "user", content: prompt },
+          ],
+          response_format: { type: "json_object" },
+          temperature: 0.3,
+          max_completion_tokens: 4000,
+        }),
+      (raw) => {
+        let json: unknown;
+        try {
+          json = JSON.parse(raw);
+        } catch (e) {
+          throw new OpenAIRetryError("invalid_json", e);
+        }
+        const validated = feedbackResponseSchema.safeParse(json);
+        if (!validated.success) {
+          throw new OpenAIRetryError("schema_mismatch", validated.error);
+        }
+        return validated.data;
+      },
+      { service: "behavioral-analysis", log },
+    );
+
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof OpenAIRetryError) {
+      log.error(
+        { reason: err.reason },
+        "behavioral analysis exhausted retries",
+      );
+      return NextResponse.json(
+        { error: `GPT response malformed: ${err.reason}` },
+        { status: 500 },
+      );
+    }
+    log.error({ err }, "behavioral analysis failed");
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Unknown error" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/analysis/technical/route.integration.test.ts
+++ b/apps/web/app/api/analysis/technical/route.integration.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Integration test for POST /api/analysis/technical.
+ *
+ * Like the behavioral integration test, this route has no DB and no auth.
+ * The integration suite still exercises the full Zod-validated request →
+ * response pipeline with a mocked OpenAI client and re-parses the response
+ * with `technicalFeedbackResponseSchema` to prove every constraint passes.
+ *
+ * The "timeline_injected_from_correlator_not_gpt" test mirrors
+ * `apps/api/tests/test_code_analyzer.py::test_timeline_injected_from_correlator_not_gpt`
+ * — GPT returns an empty timeline_analysis but the route MUST overwrite it
+ * with the deterministic `buildTimeline()` result before validation.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const mockChatCreate = vi.fn();
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    chat = { completions: { create: mockChatCreate } };
+  },
+}));
+
+vi.stubEnv("OPENAI_API_KEY", "sk-integration-test");
+
+import { POST } from "./route";
+import { technicalFeedbackResponseSchema } from "@/lib/analysis-schemas";
+
+const VALID_GPT_RESPONSE_RAW = readFileSync(
+  join(__dirname, "..", "__fixtures__", "technical-gpt-response.json"),
+  "utf-8",
+);
+const VALID_GPT_RESPONSE_OBJ = JSON.parse(VALID_GPT_RESPONSE_RAW);
+
+const SAMPLE_TRANSCRIPT = [
+  { speaker: "user", text: "I'll use a sliding window approach.", timestamp_ms: 1000 },
+  { speaker: "user", text: "The time complexity is O(n).", timestamp_ms: 5000 },
+];
+
+const SAMPLE_SNAPSHOTS = [
+  { code: "def solution(): pass", language: "python", timestamp_ms: 500, event_type: "edit" },
+  {
+    code: "def solution(nums):\n    return max(nums)",
+    language: "python",
+    timestamp_ms: 8000,
+    event_type: "edit",
+  },
+];
+
+const VALID_BODY = {
+  session_id: "sess-tech-int-1",
+  transcript: SAMPLE_TRANSCRIPT,
+  code_snapshots: SAMPLE_SNAPSHOTS,
+  config: {
+    interview_type: "leetcode",
+    focus_areas: ["arrays", "sliding_window"],
+    difficulty: "medium",
+    language: "python",
+  },
+};
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3000/api/analysis/technical", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/analysis/technical (integration)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 on empty transcript", async () => {
+    const res = await POST(
+      makeRequest({
+        session_id: "s",
+        transcript: [],
+        code_snapshots: [],
+        config: {},
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockChatCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on missing required field (code_snapshots)", async () => {
+    const res = await POST(
+      makeRequest({
+        session_id: "s",
+        transcript: SAMPLE_TRANSCRIPT,
+        config: {},
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockChatCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with full Zod-validated body matching the canonical fixture", async () => {
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: VALID_GPT_RESPONSE_RAW } }],
+    });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    const reparsed = technicalFeedbackResponseSchema.safeParse(body);
+    expect(reparsed.success).toBe(true);
+
+    expect(body.overall_score).toBe(7.0);
+    expect(body.code_quality_score).toBe(6.5);
+    expect(body.explanation_quality_score).toBe(7.5);
+    expect(body.strengths).toHaveLength(3);
+    expect(body.weaknesses).toHaveLength(3);
+    expect(body.answer_analyses).toHaveLength(1);
+    expect(body.answer_analyses[0].score).toBe(7.0);
+    // Timeline should always be populated (from buildTimeline, not GPT).
+    expect(body.timeline_analysis.length).toBe(
+      SAMPLE_TRANSCRIPT.length + SAMPLE_SNAPSHOTS.length,
+    );
+    expect(mockChatCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 500 after retry exhaustion (two malformed responses)", async () => {
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: "not valid json {{{" } }],
+    });
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(500);
+    expect(mockChatCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 200 on retry-then-succeed (empty first, fixture second)", async () => {
+    mockChatCreate
+      .mockResolvedValueOnce({ choices: [{ message: { content: null } }] })
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: VALID_GPT_RESPONSE_RAW } }],
+      });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(mockChatCreate).toHaveBeenCalledTimes(2);
+    const body = await res.json();
+    expect(technicalFeedbackResponseSchema.safeParse(body).success).toBe(true);
+  });
+
+  it("timeline_injected_from_correlator_not_gpt: overrides GPT's empty timeline", async () => {
+    // GPT returns the fixture but with timeline_analysis explicitly empty.
+    const gptResponse = {
+      ...VALID_GPT_RESPONSE_OBJ,
+      timeline_analysis: [],
+    };
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: JSON.stringify(gptResponse) } }],
+    });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    // The route MUST overwrite GPT's empty list with the buildTimeline result.
+    expect(body.timeline_analysis.length).toBeGreaterThan(0);
+    expect(body.timeline_analysis.length).toBe(
+      SAMPLE_TRANSCRIPT.length + SAMPLE_SNAPSHOTS.length,
+    );
+    // Timeline should be sorted by timestamp_ms.
+    const timestamps = body.timeline_analysis.map(
+      (e: { timestamp_ms: number }) => e.timestamp_ms,
+    );
+    const sorted = [...timestamps].sort((a, b) => a - b);
+    expect(timestamps).toEqual(sorted);
+    // Earliest event should be the first snapshot at 500ms.
+    expect(timestamps[0]).toBe(500);
+  });
+});

--- a/apps/web/app/api/analysis/technical/route.test.ts
+++ b/apps/web/app/api/analysis/technical/route.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const mockChatCreate = vi.fn();
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    chat = { completions: { create: mockChatCreate } };
+  },
+}));
+
+import { POST } from "./route";
+
+const VALID_GPT_RESPONSE = readFileSync(
+  join(__dirname, "..", "__fixtures__", "technical-gpt-response.json"),
+  "utf-8",
+);
+
+const SAMPLE_TRANSCRIPT = [
+  { speaker: "user", text: "Sliding window approach.", timestamp_ms: 1000 },
+  { speaker: "user", text: "Time complexity is O(n).", timestamp_ms: 5000 },
+];
+
+const SAMPLE_SNAPSHOTS = [
+  { code: "def solution(): pass", language: "python", timestamp_ms: 500, event_type: "edit" },
+  {
+    code: "def solution(nums):\n    return max(nums)",
+    language: "python",
+    timestamp_ms: 8000,
+    event_type: "edit",
+  },
+];
+
+const VALID_BODY = {
+  session_id: "sess-tech-1",
+  transcript: SAMPLE_TRANSCRIPT,
+  code_snapshots: SAMPLE_SNAPSHOTS,
+  config: {
+    interview_type: "leetcode",
+    focus_areas: ["arrays"],
+    difficulty: "medium",
+    language: "python",
+  },
+};
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3000/api/analysis/technical", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/analysis/technical (unit)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.OPENAI_API_KEY = "sk-test-key";
+  });
+
+  it("returns 400 when JSON body cannot be parsed", async () => {
+    const req = new NextRequest("http://localhost:3000/api/analysis/technical", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect((await POST(req)).status).toBe(400);
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    const res = await POST(
+      makeRequest({ session_id: "s", transcript: SAMPLE_TRANSCRIPT }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 on empty transcript", async () => {
+    const res = await POST(
+      makeRequest({
+        session_id: "s",
+        transcript: [],
+        code_snapshots: [],
+        config: {},
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 happy path", async () => {
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: VALID_GPT_RESPONSE } }],
+    });
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.code_quality_score).toBe(6.5);
+    expect(body.explanation_quality_score).toBe(7.5);
+  });
+
+  it("retries once on invalid JSON then returns the parsed result", async () => {
+    mockChatCreate
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: "not valid json {{{" } }],
+      })
+      .mockResolvedValueOnce({
+        choices: [{ message: { content: VALID_GPT_RESPONSE } }],
+      });
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(mockChatCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 500 after two empty responses", async () => {
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: null } }],
+    });
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(500);
+    expect(mockChatCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 500 when OPENAI_API_KEY is unset", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/web/app/api/analysis/technical/route.ts
+++ b/apps/web/app/api/analysis/technical/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from "next/server";
+import OpenAI from "openai";
+
+import { createRequestLogger } from "@/lib/logger";
+import {
+  buildTechnicalPrompt,
+  TECHNICAL_SYSTEM_PROMPT,
+} from "@/lib/analysis-prompts";
+import {
+  technicalFeedbackRequestSchema,
+  technicalFeedbackResponseSchema,
+} from "@/lib/analysis-schemas";
+import {
+  OpenAIRetryError,
+  withOpenAIRetry,
+} from "@/lib/openai-retry";
+import { buildTimeline } from "@/lib/timeline-correlator";
+
+/**
+ * POST /api/analysis/technical
+ *
+ * Internal, server-to-server route ported from FastAPI
+ * `/analysis/technical` (apps/api/app/routers/analysis.py). No auth.
+ *
+ * The deterministic timeline is built locally via `buildTimeline()` and
+ * **overwrites** whatever GPT returns for `timeline_analysis` before schema
+ * validation. This mirrors the Python `code_analyzer.py` behavior and means
+ * the response always contains an authoritative timeline derived from the
+ * actual transcript + code snapshots, never a hallucinated one.
+ */
+export async function POST(request: NextRequest) {
+  const log = createRequestLogger({ route: "POST /api/analysis/technical" });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = technicalFeedbackRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request", details: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  if (parsed.data.transcript.length === 0) {
+    return NextResponse.json({ error: "Transcript is empty" }, { status: 400 });
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    log.error("OPENAI_API_KEY not configured");
+    return NextResponse.json(
+      { error: "OpenAI API key not configured" },
+      { status: 500 },
+    );
+  }
+
+  const openai = new OpenAI({ apiKey });
+  const prompt = buildTechnicalPrompt(
+    parsed.data.transcript,
+    parsed.data.code_snapshots,
+    parsed.data.config,
+  );
+
+  // Build the deterministic timeline ONCE up front; the parseAndValidate
+  // closure injects it into every parse attempt, overriding whatever GPT
+  // returned for `timeline_analysis`.
+  const timeline = buildTimeline(
+    parsed.data.transcript,
+    parsed.data.code_snapshots,
+  );
+
+  try {
+    const result = await withOpenAIRetry(
+      () =>
+        openai.chat.completions.create({
+          model: "gpt-5.4-mini",
+          messages: [
+            { role: "system", content: TECHNICAL_SYSTEM_PROMPT },
+            { role: "user", content: prompt },
+          ],
+          response_format: { type: "json_object" },
+          temperature: 0.3,
+          max_completion_tokens: 4000,
+        }),
+      (raw) => {
+        let json: Record<string, unknown>;
+        try {
+          json = JSON.parse(raw) as Record<string, unknown>;
+        } catch (e) {
+          throw new OpenAIRetryError("invalid_json", e);
+        }
+        // Inject deterministic timeline BEFORE validation. This is the whole
+        // reason the technical route exists — we never trust GPT's timeline.
+        json.timeline_analysis = timeline;
+        const validated = technicalFeedbackResponseSchema.safeParse(json);
+        if (!validated.success) {
+          throw new OpenAIRetryError("schema_mismatch", validated.error);
+        }
+        return validated.data;
+      },
+      { service: "technical-analysis", log },
+    );
+
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof OpenAIRetryError) {
+      log.error(
+        { reason: err.reason },
+        "technical analysis exhausted retries",
+      );
+      return NextResponse.json(
+        { error: `GPT response malformed: ${err.reason}` },
+        { status: 500 },
+      );
+    }
+    log.error({ err }, "technical analysis failed");
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Unknown error" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/lib/__fixtures__/behavioral-prompt.expected.txt
+++ b/apps/web/lib/__fixtures__/behavioral-prompt.expected.txt
@@ -1,0 +1,15 @@
+Company: Google
+Job Description:
+Senior Software Engineer
+Interview level: Senior/Staff
+
+--- TRANSCRIPT ---
+
+Interviewer: Tell me about a time you led a team.
+Candidate: At my previous company, I led a team of 5 engineers to ship a new feature in 3 weeks.
+Interviewer: What challenges did you face?
+Candidate: We had tight deadlines and had to cut some scope. I facilitated a prioritization session.
+
+--- END TRANSCRIPT ---
+
+Analyze this interview and provide structured feedback as JSON.

--- a/apps/web/lib/__fixtures__/technical-prompt.expected.txt
+++ b/apps/web/lib/__fixtures__/technical-prompt.expected.txt
@@ -1,0 +1,27 @@
+Interview Type: leetcode
+Difficulty: Medium
+Language: python
+Focus Areas: Arrays, Sliding Window
+
+--- CODE EVOLUTION ---
+Language used: python
+Total snapshots: 2
+
+[Snapshot 1 at 00:00 — edit, python]
+```python
+def solution(): pass
+```
+
+[FINAL SUBMISSION at 00:08 — edit, python]
+```python
+def solution(nums):
+    return max(nums)
+```
+--- END CODE ---
+
+--- TRANSCRIPT ---
+Candidate: I'll use a sliding window approach.
+Candidate: The time complexity is O(n).
+--- END TRANSCRIPT ---
+
+Analyze this technical interview and provide structured feedback as JSON.

--- a/apps/web/lib/analysis-prompts.test.ts
+++ b/apps/web/lib/analysis-prompts.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  buildBehavioralPrompt,
+  buildTechnicalPrompt,
+  type BehavioralPromptConfig,
+  type TechnicalPromptConfig,
+} from "./analysis-prompts";
+import type {
+  CodeSnapshotInput,
+  TranscriptEntryInput,
+} from "./validations";
+
+// ---- Canonical fixtures (mirror Python tests one-for-one) ----
+
+const SAMPLE_TRANSCRIPT: TranscriptEntryInput[] = [
+  { speaker: "ai", text: "Tell me about a time you led a team.", timestamp_ms: 0 },
+  {
+    speaker: "user",
+    text: "At my previous company, I led a team of 5 engineers to ship a new feature in 3 weeks.",
+    timestamp_ms: 5000,
+  },
+  { speaker: "ai", text: "What challenges did you face?", timestamp_ms: 15000 },
+  {
+    speaker: "user",
+    text: "We had tight deadlines and had to cut some scope. I facilitated a prioritization session.",
+    timestamp_ms: 20000,
+  },
+];
+
+const SAMPLE_CONFIG: BehavioralPromptConfig = {
+  company_name: "Google",
+  job_description: "Senior Software Engineer",
+  difficulty: 0.8,
+};
+
+const TECH_TRANSCRIPT: TranscriptEntryInput[] = [
+  { speaker: "user", text: "I'll use a sliding window approach.", timestamp_ms: 1000 },
+  { speaker: "user", text: "The time complexity is O(n).", timestamp_ms: 5000 },
+];
+
+const TECH_SNAPSHOTS: CodeSnapshotInput[] = [
+  { code: "def solution(): pass", language: "python", timestamp_ms: 500, event_type: "edit" },
+  {
+    code: "def solution(nums):\n    return max(nums)",
+    language: "python",
+    timestamp_ms: 8000,
+    event_type: "edit",
+  },
+];
+
+const TECH_CONFIG: TechnicalPromptConfig = {
+  interview_type: "leetcode",
+  focus_areas: ["arrays", "sliding_window"],
+  difficulty: "medium",
+  language: "python",
+};
+
+// ---- buildBehavioralPrompt ----
+
+describe("buildBehavioralPrompt", () => {
+  it("includes company name", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, SAMPLE_CONFIG);
+    expect(prompt).toContain("Company: Google");
+  });
+
+  it("includes job description", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, SAMPLE_CONFIG);
+    expect(prompt).toContain("Senior Software Engineer");
+  });
+
+  it("maps difficulty 0.8 to Senior/Staff", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, SAMPLE_CONFIG);
+    expect(prompt).toContain("Interview level: Senior/Staff");
+  });
+
+  it("maps difficulty 0.2 to Entry-level", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, { difficulty: 0.2 });
+    expect(prompt).toContain("Entry-level");
+  });
+
+  it("maps difficulty 0.5 to Mid-level", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, { difficulty: 0.5 });
+    expect(prompt).toContain("Mid-level");
+  });
+
+  it("defaults missing difficulty to Mid-level", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, {});
+    expect(prompt).toContain("Mid-level");
+  });
+
+  it("treats boundary 0.3 as Entry-level (<= 0.3)", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, { difficulty: 0.3 });
+    expect(prompt).toContain("Entry-level");
+  });
+
+  it("treats boundary 0.7 as Senior/Staff (>= 0.7)", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, { difficulty: 0.7 });
+    expect(prompt).toContain("Senior/Staff");
+  });
+
+  it("maps speaker labels (ai → Interviewer, user → Candidate)", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, SAMPLE_CONFIG);
+    expect(prompt).toContain("Interviewer: Tell me about a time");
+    expect(prompt).toContain("Candidate: At my previous company");
+  });
+
+  it("omits company line when company_name is missing", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, {});
+    expect(prompt).not.toContain("Company:");
+  });
+
+  it("contains transcript markers", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, SAMPLE_CONFIG);
+    expect(prompt).toContain("--- TRANSCRIPT ---");
+    expect(prompt).toContain("--- END TRANSCRIPT ---");
+  });
+
+  it("byte-equivalent to Python _build_analysis_prompt for canonical fixture", () => {
+    const expected = readFileSync(
+      join(__dirname, "__fixtures__", "behavioral-prompt.expected.txt"),
+      "utf-8",
+    );
+    const actual = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, SAMPLE_CONFIG);
+    expect(actual).toBe(expected);
+  });
+});
+
+// ---- buildTechnicalPrompt ----
+
+describe("buildTechnicalPrompt", () => {
+  it("includes interview type", () => {
+    const prompt = buildTechnicalPrompt(TECH_TRANSCRIPT, TECH_SNAPSHOTS, TECH_CONFIG);
+    expect(prompt.toLowerCase()).toContain("leetcode");
+  });
+
+  it("includes capitalized difficulty", () => {
+    const prompt = buildTechnicalPrompt(TECH_TRANSCRIPT, TECH_SNAPSHOTS, TECH_CONFIG);
+    expect(prompt).toContain("Medium");
+  });
+
+  it("includes language", () => {
+    const prompt = buildTechnicalPrompt(TECH_TRANSCRIPT, TECH_SNAPSHOTS, TECH_CONFIG);
+    expect(prompt.toLowerCase()).toContain("python");
+  });
+
+  it("includes title-cased focus areas", () => {
+    const prompt = buildTechnicalPrompt(TECH_TRANSCRIPT, TECH_SNAPSHOTS, TECH_CONFIG);
+    expect(prompt).toContain("Arrays");
+    expect(prompt).toContain("Sliding Window");
+  });
+
+  it("includes final code", () => {
+    const prompt = buildTechnicalPrompt(TECH_TRANSCRIPT, TECH_SNAPSHOTS, TECH_CONFIG);
+    expect(prompt).toContain("max(nums)");
+  });
+
+  it("includes transcript text", () => {
+    const prompt = buildTechnicalPrompt(TECH_TRANSCRIPT, TECH_SNAPSHOTS, TECH_CONFIG);
+    expect(prompt).toContain("sliding window approach");
+  });
+
+  it("uses Candidate label for user speaker", () => {
+    const prompt = buildTechnicalPrompt(TECH_TRANSCRIPT, TECH_SNAPSHOTS, TECH_CONFIG);
+    expect(prompt).toContain("Candidate:");
+  });
+
+  it("handles empty snapshots gracefully", () => {
+    const prompt = buildTechnicalPrompt(TECH_TRANSCRIPT, [], TECH_CONFIG);
+    expect(prompt).toContain("No code was written");
+  });
+
+  it("includes all snapshots with timestamps and labels", () => {
+    const prompt = buildTechnicalPrompt(TECH_TRANSCRIPT, TECH_SNAPSHOTS, TECH_CONFIG);
+    expect(prompt).toContain("Snapshot 1");
+    expect(prompt).toContain("FINAL SUBMISSION");
+    expect(prompt).toContain("def solution(): pass");
+    expect(prompt).toContain("max(nums)");
+  });
+
+  it("formats mm:ss timestamps with zero padding", () => {
+    const prompt = buildTechnicalPrompt(
+      TECH_TRANSCRIPT,
+      [
+        { code: "x", language: "python", timestamp_ms: 65000, event_type: "edit" },
+        { code: "y", language: "python", timestamp_ms: 125000, event_type: "edit" },
+      ],
+      TECH_CONFIG,
+    );
+    expect(prompt).toContain("01:05");
+    expect(prompt).toContain("02:05");
+  });
+
+  it("supports system_design / hard config", () => {
+    const config: TechnicalPromptConfig = {
+      interview_type: "system_design",
+      focus_areas: ["scalability"],
+      difficulty: "hard",
+      language: "any",
+    };
+    const prompt = buildTechnicalPrompt(TECH_TRANSCRIPT, TECH_SNAPSHOTS, config);
+    expect(prompt.toLowerCase()).toContain("system_design");
+    expect(prompt).toContain("Hard");
+  });
+
+  it("byte-equivalent to Python build_technical_analysis_prompt for canonical fixture", () => {
+    const expected = readFileSync(
+      join(__dirname, "__fixtures__", "technical-prompt.expected.txt"),
+      "utf-8",
+    );
+    const actual = buildTechnicalPrompt(TECH_TRANSCRIPT, TECH_SNAPSHOTS, TECH_CONFIG);
+    expect(actual).toBe(expected);
+  });
+});

--- a/apps/web/lib/analysis-prompts.ts
+++ b/apps/web/lib/analysis-prompts.ts
@@ -1,0 +1,269 @@
+/**
+ * Analysis prompts: builds the GPT user-message strings for behavioral and
+ * technical interview analysis.
+ *
+ * Ported byte-for-byte from:
+ *   - apps/api/app/services/feedback_generator.py::_build_analysis_prompt
+ *   - apps/api/app/services/code_analyzer.py::build_technical_analysis_prompt
+ *
+ * Pure functions. No I/O, no async, no auth. The exact string output is
+ * load-bearing — `analysis-prompts.test.ts` snapshots the result against an
+ * expected.txt fixture generated from the Python source so any drift fails CI.
+ */
+
+import type {
+  CodeSnapshotInput,
+  TranscriptEntryInput,
+} from "./validations";
+
+// ---- System prompts (string-equal to Python module-level constants) ----
+
+export const BEHAVIORAL_SYSTEM_PROMPT = `You are an expert interview coach analyzing a behavioral interview transcript.
+
+Your task is to evaluate the candidate's performance and provide structured, actionable feedback.
+
+For each question-answer pair you identify in the transcript:
+1. Extract the interviewer's question
+2. Summarize the candidate's answer in 1-2 sentences
+3. Score the answer from 0-10 based on:
+   - Use of STAR method (Situation, Task, Action, Result)
+   - Specificity and concrete examples
+   - Relevance to the question
+   - Communication clarity
+   - Depth and thoughtfulness
+4. Provide specific feedback on what was good and what could improve
+5. Give 1-3 actionable suggestions
+
+Then provide an overall assessment:
+- Overall score (weighted average of individual answers)
+- 2-3 sentence summary
+- Top 3 strengths
+- Top 3 areas for improvement
+
+Respond ONLY with valid JSON matching this exact structure:
+{
+  "overall_score": <float 0-10>,
+  "summary": "<2-3 sentence overall assessment>",
+  "strengths": ["<strength 1>", "<strength 2>", "<strength 3>"],
+  "weaknesses": ["<weakness 1>", "<weakness 2>", "<weakness 3>"],
+  "answer_analyses": [
+    {
+      "question": "<the interviewer's question>",
+      "answer_summary": "<1-2 sentence summary of candidate's answer>",
+      "score": <float 0-10>,
+      "feedback": "<specific feedback on this answer>",
+      "suggestions": ["<suggestion 1>", "<suggestion 2>"]
+    }
+  ]
+}`;
+
+export const TECHNICAL_SYSTEM_PROMPT = `You are an expert technical interview coach analyzing a coding interview session.
+
+You will receive:
+- A full transcript of the candidate's verbal explanations
+- The candidate's code evolution (all snapshots from start to final submission)
+- Session configuration (problem type, focus areas, difficulty)
+
+Evaluate the candidate on two dimensions:
+
+1. **Code Quality (0-10)**: correctness, efficiency, readability,
+   edge case handling, time/space complexity awareness
+2. **Explanation Quality (0-10)**: clarity of thought process,
+   problem decomposition, trade-off discussion, communication
+
+Analyze distinct aspects of the candidate's performance.
+Use these categories for the answer_analyses array:
+- **Approach & Problem Decomposition**: How the candidate broke
+  down the problem and chose their strategy
+- **Implementation**: Code correctness, structure, and style —
+  reference specific lines or functions from the code snapshots
+- **Complexity Analysis**: Whether the candidate discussed
+  time/space complexity and if their analysis was correct
+- **Edge Cases & Testing**: Whether edge cases were considered in code or discussion
+- **Communication**: How well the candidate explained their thinking throughout
+
+For each analysis, reference specific code from the snapshots
+(e.g., "The loop on line 3 could use enumerate instead") and
+specific quotes from the transcript when relevant.
+
+Respond ONLY with valid JSON matching this exact structure:
+{
+  "overall_score": <float 0-10>,
+  "summary": "<2-3 sentence overall assessment referencing specific parts of the code>",
+  "strengths": ["<strength — cite code or transcript>", "<strength>", "<strength>"],
+  "weaknesses": ["<weakness — cite code or transcript>", "<weakness>", "<weakness>"],
+  "code_quality_score": <float 0-10>,
+  "explanation_quality_score": <float 0-10>,
+  "answer_analyses": [
+    {
+      "question": "<aspect being evaluated, e.g. 'Approach & Problem Decomposition'>",
+      "answer_summary": "<1-2 sentence summary of what the candidate did, referencing code>",
+      "score": <float 0-10>,
+      "feedback": "<specific feedback citing code lines and transcript quotes>",
+      "suggestions": ["<actionable suggestion>", "<actionable suggestion>"]
+    }
+  ]
+}`;
+
+// ---- Behavioral prompt config ----
+
+export interface BehavioralPromptConfig {
+  company_name?: string | null;
+  job_description?: string | null;
+  expected_questions?: string[] | null;
+  interview_style?: number;
+  difficulty?: number;
+}
+
+/**
+ * Build the user-message string for behavioral analysis. Ported line-for-line
+ * from `_build_analysis_prompt` in feedback_generator.py — every `parts.append`
+ * here corresponds to a Python `parts.append`, and the final `parts.join("\n")`
+ * mirrors Python's `"\n".join(parts)`.
+ */
+export function buildBehavioralPrompt(
+  transcript: TranscriptEntryInput[],
+  config: BehavioralPromptConfig,
+): string {
+  const parts: string[] = [];
+
+  // Context
+  if (config.company_name) {
+    parts.push(`Company: ${config.company_name}`);
+  }
+  if (config.job_description) {
+    parts.push(`Job Description:\n${config.job_description}`);
+  }
+
+  // Difficulty context — Python defaults difficulty to 0.5 on BehavioralConfig,
+  // so a missing field falls into the mid-level branch.
+  const difficulty = config.difficulty ?? 0.5;
+  if (difficulty <= 0.3) {
+    parts.push("Interview level: Entry-level");
+  } else if (difficulty >= 0.7) {
+    parts.push("Interview level: Senior/Staff");
+  } else {
+    parts.push("Interview level: Mid-level");
+  }
+
+  parts.push("\n--- TRANSCRIPT ---\n");
+
+  for (const entry of transcript) {
+    const speaker = entry.speaker === "ai" ? "Interviewer" : "Candidate";
+    parts.push(`${speaker}: ${entry.text}`);
+  }
+
+  parts.push("\n--- END TRANSCRIPT ---");
+  parts.push("\nAnalyze this interview and provide structured feedback as JSON.");
+
+  return parts.join("\n");
+}
+
+// ---- Technical prompt config ----
+
+export interface TechnicalPromptConfig {
+  interview_type?: string;
+  focus_areas?: string[];
+  difficulty?: string;
+  language?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Format `timestamp_ms` as `mm:ss` matching Python's
+ * `f"{minutes:02d}:{seconds:02d}"` where
+ *   minutes = timestamp_ms // 60000
+ *   seconds = (timestamp_ms % 60000) // 1000
+ */
+function formatMmSs(timestampMs: number): string {
+  const minutes = Math.floor(timestampMs / 60000);
+  const seconds = Math.floor((timestampMs % 60000) / 1000);
+  return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+}
+
+/**
+ * Capitalize first character only — mirrors Python's `str.capitalize()` for
+ * the difficulty label in the technical prompt. Note Python's full
+ * `capitalize()` lowercases the rest, but in the source code the only inputs
+ * used here are "easy"/"medium"/"hard" (all lowercase already).
+ */
+function pyCapitalize(s: string): string {
+  if (s.length === 0) return s;
+  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+}
+
+/**
+ * Mirror Python's `str(a).replace("_", " ").title()` for focus-area labels.
+ * Python `str.title()` uppercases the first letter of each "word" (split on
+ * any non-alphabetic boundary), lowercasing the rest. For the focus_area
+ * inputs in this codebase ("arrays", "sliding_window", "scalability", etc.)
+ * the simple word-by-word capitalization matches byte-for-byte.
+ */
+function pyTitleCase(s: string): string {
+  return s
+    .replace(/_/g, " ")
+    .split(" ")
+    .map((w) => (w.length === 0 ? w : w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()))
+    .join(" ");
+}
+
+/**
+ * Build the user-message string for technical analysis. Ported line-for-line
+ * from `build_technical_analysis_prompt` in code_analyzer.py.
+ */
+export function buildTechnicalPrompt(
+  transcript: TranscriptEntryInput[],
+  codeSnapshots: CodeSnapshotInput[],
+  config: TechnicalPromptConfig,
+): string {
+  const parts: string[] = [];
+
+  // Session config context — Python uses dict.get with defaults.
+  const interviewType = (config.interview_type as string | undefined) ?? "leetcode";
+  const focusAreas = (config.focus_areas as string[] | undefined) ?? [];
+  const difficulty = (config.difficulty as string | undefined) ?? "medium";
+  const language = (config.language as string | undefined) ?? "python";
+
+  parts.push(`Interview Type: ${interviewType}`);
+  parts.push(`Difficulty: ${pyCapitalize(difficulty)}`);
+  parts.push(`Language: ${language}`);
+  if (focusAreas.length > 0) {
+    const areasStr = focusAreas.map((a) => pyTitleCase(String(a))).join(", ");
+    parts.push(`Focus Areas: ${areasStr}`);
+  }
+
+  // Code evolution — include all snapshots so GPT can reference the progression
+  parts.push("\n--- CODE EVOLUTION ---");
+  if (codeSnapshots.length > 0) {
+    const sortedSnapshots = [...codeSnapshots].sort(
+      (a, b) => a.timestamp_ms - b.timestamp_ms,
+    );
+    parts.push(`Language used: ${sortedSnapshots[sortedSnapshots.length - 1].language}`);
+    parts.push(`Total snapshots: ${sortedSnapshots.length}`);
+
+    sortedSnapshots.forEach((snap, idx) => {
+      const isLast = idx === sortedSnapshots.length - 1;
+      const label = isLast ? "FINAL SUBMISSION" : `Snapshot ${idx + 1}`;
+      const ts = formatMmSs(snap.timestamp_ms);
+      parts.push(
+        `\n[${label} at ${ts} — ${snap.event_type}, ${snap.language}]` +
+          `\n\`\`\`${snap.language}\n${snap.code}\n\`\`\``,
+      );
+    });
+  } else {
+    parts.push("No code was written.");
+  }
+  parts.push("--- END CODE ---");
+
+  // Transcript
+  parts.push("\n--- TRANSCRIPT ---");
+  for (const entry of transcript) {
+    const speaker = entry.speaker === "user" ? "Candidate" : "Interviewer";
+    parts.push(`${speaker}: ${entry.text}`);
+  }
+  parts.push("--- END TRANSCRIPT ---");
+
+  parts.push("\nAnalyze this technical interview and provide structured feedback as JSON.");
+
+  return parts.join("\n");
+}

--- a/apps/web/lib/analysis-schemas.test.ts
+++ b/apps/web/lib/analysis-schemas.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import {
+  answerAnalysisSchema,
+  feedbackRequestSchema,
+  feedbackResponseSchema,
+  technicalFeedbackRequestSchema,
+  technicalFeedbackResponseSchema,
+} from "./analysis-schemas";
+
+const VALID_ANSWER = {
+  question: "Tell me about a time...",
+  answer_summary: "Did things",
+  score: 7,
+  feedback: "Good",
+  suggestions: ["More detail"],
+};
+
+const VALID_FEEDBACK_RESPONSE = {
+  overall_score: 7.5,
+  summary: "Solid",
+  strengths: ["a", "b"],
+  weaknesses: ["c"],
+  answer_analyses: [VALID_ANSWER],
+};
+
+describe("answerAnalysisSchema", () => {
+  it("accepts a valid answer analysis", () => {
+    expect(answerAnalysisSchema.safeParse(VALID_ANSWER).success).toBe(true);
+  });
+
+  it("rejects score below 0", () => {
+    expect(
+      answerAnalysisSchema.safeParse({ ...VALID_ANSWER, score: -0.1 }).success,
+    ).toBe(false);
+  });
+
+  it("accepts score exactly 0", () => {
+    expect(
+      answerAnalysisSchema.safeParse({ ...VALID_ANSWER, score: 0 }).success,
+    ).toBe(true);
+  });
+
+  it("accepts score exactly 10", () => {
+    expect(
+      answerAnalysisSchema.safeParse({ ...VALID_ANSWER, score: 10 }).success,
+    ).toBe(true);
+  });
+
+  it("rejects score above 10", () => {
+    expect(
+      answerAnalysisSchema.safeParse({ ...VALID_ANSWER, score: 10.1 }).success,
+    ).toBe(false);
+  });
+
+  it("rejects missing required fields", () => {
+    expect(answerAnalysisSchema.safeParse({ score: 5 }).success).toBe(false);
+  });
+});
+
+describe("feedbackResponseSchema", () => {
+  it("accepts canonical fixture", () => {
+    const result = feedbackResponseSchema.safeParse(VALID_FEEDBACK_RESPONSE);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects overall_score above 10", () => {
+    expect(
+      feedbackResponseSchema.safeParse({
+        ...VALID_FEEDBACK_RESPONSE,
+        overall_score: 11,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects missing summary", () => {
+    const { summary: _omit, ...without } = VALID_FEEDBACK_RESPONSE;
+    void _omit;
+    expect(feedbackResponseSchema.safeParse(without).success).toBe(false);
+  });
+});
+
+describe("feedbackRequestSchema", () => {
+  it("accepts a minimal valid request and defaults config", () => {
+    const result = feedbackRequestSchema.safeParse({
+      session_id: "abc",
+      transcript: [{ speaker: "ai", text: "Hi", timestamp_ms: 0 }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.config.difficulty).toBe(0.5);
+      expect(result.data.config.interview_style).toBe(0.5);
+    }
+  });
+
+  it("rejects request missing session_id", () => {
+    expect(
+      feedbackRequestSchema.safeParse({
+        transcript: [{ speaker: "ai", text: "Hi", timestamp_ms: 0 }],
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("technicalFeedbackRequestSchema", () => {
+  it("accepts a valid technical request with loose config dict", () => {
+    const result = technicalFeedbackRequestSchema.safeParse({
+      session_id: "abc",
+      transcript: [{ speaker: "user", text: "hi", timestamp_ms: 0 }],
+      code_snapshots: [
+        { code: "x", language: "py", timestamp_ms: 1, event_type: "edit" },
+      ],
+      config: { interview_type: "leetcode", anything_extra: 42 },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects technical request missing config", () => {
+    expect(
+      technicalFeedbackRequestSchema.safeParse({
+        session_id: "abc",
+        transcript: [],
+        code_snapshots: [],
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("technicalFeedbackResponseSchema", () => {
+  const VALID_TECH = {
+    overall_score: 7,
+    summary: "Solid",
+    strengths: ["a"],
+    weaknesses: ["b"],
+    code_quality_score: 6.5,
+    explanation_quality_score: 7.5,
+    answer_analyses: [VALID_ANSWER],
+    timeline_analysis: [
+      {
+        timestamp_ms: 0,
+        event_type: "speech" as const,
+        summary: "hi",
+        code: null,
+        full_text: null,
+      },
+    ],
+  };
+
+  it("accepts canonical valid response", () => {
+    expect(technicalFeedbackResponseSchema.safeParse(VALID_TECH).success).toBe(true);
+  });
+
+  it("rejects code_quality_score above 10", () => {
+    expect(
+      technicalFeedbackResponseSchema.safeParse({
+        ...VALID_TECH,
+        code_quality_score: 11,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects explanation_quality_score below 0", () => {
+    expect(
+      technicalFeedbackResponseSchema.safeParse({
+        ...VALID_TECH,
+        explanation_quality_score: -1,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects missing timeline_analysis", () => {
+    const { timeline_analysis: _omit, ...without } = VALID_TECH;
+    void _omit;
+    expect(technicalFeedbackResponseSchema.safeParse(without).success).toBe(false);
+  });
+});

--- a/apps/web/lib/analysis-schemas.ts
+++ b/apps/web/lib/analysis-schemas.ts
@@ -1,0 +1,88 @@
+/**
+ * Zod schemas for the behavioral + technical analysis routes.
+ *
+ * Mirror the Pydantic models in `apps/api/app/schemas.py` field-for-field so
+ * the cutover in Story 23 can swap the FastAPI service out without changing
+ * the wire format consumed by `apps/web/app/api/sessions/[id]/feedback/route.ts`.
+ *
+ * Naming note: `technicalAnalysisConfigSchema` here is intentionally a loose
+ * `z.record` to match Pydantic's `dict` typing on `TechnicalFeedbackRequest`.
+ * The strict `technicalConfigSchema` in `validations.ts` validates a different
+ * shape (the session-creation config UI) and must not be reused here.
+ */
+
+import { z } from "zod/v4";
+import {
+  codeSnapshotInputSchema,
+  timelineEventSchema,
+  transcriptEntryInputSchema,
+} from "./validations";
+
+// ---- Behavioral config (mirrors Pydantic BehavioralConfig) ----
+
+export const behavioralAnalysisConfigSchema = z.object({
+  company_name: z.string().nullable().optional(),
+  job_description: z.string().nullable().optional(),
+  expected_questions: z.array(z.string()).nullable().optional(),
+  interview_style: z.number().default(0.5),
+  difficulty: z.number().default(0.5),
+});
+export type BehavioralAnalysisConfig = z.infer<typeof behavioralAnalysisConfigSchema>;
+
+// ---- Behavioral request / response ----
+
+export const feedbackRequestSchema = z.object({
+  session_id: z.string(),
+  transcript: z.array(transcriptEntryInputSchema),
+  // `prefault({})` (instead of `.default({})`) ensures the inner schema runs
+  // when `config` is omitted, so its nested `interview_style` / `difficulty`
+  // defaults populate the parsed object — matching the Pydantic default of
+  // `BehavioralConfig()`.
+  config: behavioralAnalysisConfigSchema.prefault({}),
+});
+export type FeedbackRequest = z.infer<typeof feedbackRequestSchema>;
+
+export const answerAnalysisSchema = z.object({
+  question: z.string(),
+  answer_summary: z.string(),
+  score: z.number().min(0).max(10),
+  feedback: z.string(),
+  suggestions: z.array(z.string()),
+});
+export type AnswerAnalysis = z.infer<typeof answerAnalysisSchema>;
+
+export const feedbackResponseSchema = z.object({
+  overall_score: z.number().min(0).max(10),
+  summary: z.string(),
+  strengths: z.array(z.string()),
+  weaknesses: z.array(z.string()),
+  answer_analyses: z.array(answerAnalysisSchema),
+});
+export type FeedbackResponse = z.infer<typeof feedbackResponseSchema>;
+
+// ---- Technical config (loose dict, mirrors Pydantic dict typing) ----
+
+export const technicalAnalysisConfigSchema = z.record(z.string(), z.unknown());
+export type TechnicalAnalysisConfig = z.infer<typeof technicalAnalysisConfigSchema>;
+
+// ---- Technical request / response ----
+
+export const technicalFeedbackRequestSchema = z.object({
+  session_id: z.string(),
+  transcript: z.array(transcriptEntryInputSchema),
+  code_snapshots: z.array(codeSnapshotInputSchema),
+  config: technicalAnalysisConfigSchema,
+});
+export type TechnicalFeedbackRequest = z.infer<typeof technicalFeedbackRequestSchema>;
+
+export const technicalFeedbackResponseSchema = z.object({
+  overall_score: z.number().min(0).max(10),
+  summary: z.string(),
+  strengths: z.array(z.string()),
+  weaknesses: z.array(z.string()),
+  code_quality_score: z.number().min(0).max(10),
+  explanation_quality_score: z.number().min(0).max(10),
+  answer_analyses: z.array(answerAnalysisSchema),
+  timeline_analysis: z.array(timelineEventSchema),
+});
+export type TechnicalFeedbackResponse = z.infer<typeof technicalFeedbackResponseSchema>;

--- a/apps/web/lib/openai-retry.test.ts
+++ b/apps/web/lib/openai-retry.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  withOpenAIRetry,
+  OpenAIRetryError,
+  type OpenAIChatLikeResponse,
+} from "./openai-retry";
+
+function makeLogger() {
+  return {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+function ok(content: string | null): OpenAIChatLikeResponse {
+  return { choices: [{ message: { content } }] };
+}
+
+const SERVICE = "test-service";
+
+describe("withOpenAIRetry", () => {
+  // ---- empty reason ----
+
+  it("succeeds on attempt 1 (no retry, no warning)", async () => {
+    const log = makeLogger();
+    const call = vi.fn().mockResolvedValue(ok("good"));
+    const parseAndValidate = vi.fn().mockReturnValue({ ok: true });
+
+    const result = await withOpenAIRetry(call, parseAndValidate, {
+      service: SERVICE,
+      log,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(parseAndValidate).toHaveBeenCalledWith("good");
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("retries on empty content then succeeds", async () => {
+    const log = makeLogger();
+    const call = vi
+      .fn()
+      .mockResolvedValueOnce(ok(null))
+      .mockResolvedValueOnce(ok("good"));
+    const parseAndValidate = vi.fn().mockReturnValue({ ok: true });
+
+    const result = await withOpenAIRetry(call, parseAndValidate, {
+      service: SERVICE,
+      log,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      { attempt: 1, service: SERVICE, reason: "empty" },
+      "GPT response malformed, retrying",
+    );
+  });
+
+  it("throws after two empty responses", async () => {
+    const log = makeLogger();
+    const call = vi.fn().mockResolvedValue(ok(null));
+    const parseAndValidate = vi.fn();
+
+    await expect(
+      withOpenAIRetry(call, parseAndValidate, { service: SERVICE, log }),
+    ).rejects.toMatchObject({
+      name: "OpenAIRetryError",
+      reason: "empty",
+    });
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(parseAndValidate).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledTimes(1);
+  });
+
+  // ---- invalid_json reason ----
+
+  it("retries on invalid_json then succeeds", async () => {
+    const log = makeLogger();
+    const call = vi.fn().mockResolvedValue(ok("anything"));
+    const parseAndValidate = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new OpenAIRetryError("invalid_json");
+      })
+      .mockReturnValueOnce({ parsed: true });
+
+    const result = await withOpenAIRetry(call, parseAndValidate, {
+      service: SERVICE,
+      log,
+    });
+
+    expect(result).toEqual({ parsed: true });
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(parseAndValidate).toHaveBeenCalledTimes(2);
+    expect(log.warn).toHaveBeenCalledWith(
+      { attempt: 1, service: SERVICE, reason: "invalid_json" },
+      "GPT response malformed, retrying",
+    );
+  });
+
+  it("throws after two invalid_json responses", async () => {
+    const log = makeLogger();
+    const call = vi.fn().mockResolvedValue(ok("nope"));
+    const parseAndValidate = vi.fn().mockImplementation(() => {
+      throw new OpenAIRetryError("invalid_json");
+    });
+
+    await expect(
+      withOpenAIRetry(call, parseAndValidate, { service: SERVICE, log }),
+    ).rejects.toMatchObject({ reason: "invalid_json" });
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(log.warn).toHaveBeenCalledTimes(1);
+  });
+
+  // ---- schema_mismatch reason ----
+
+  it("retries on schema_mismatch then succeeds", async () => {
+    const log = makeLogger();
+    const call = vi.fn().mockResolvedValue(ok("anything"));
+    const parseAndValidate = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new OpenAIRetryError("schema_mismatch");
+      })
+      .mockReturnValueOnce({ valid: true });
+
+    const result = await withOpenAIRetry(call, parseAndValidate, {
+      service: SERVICE,
+      log,
+    });
+
+    expect(result).toEqual({ valid: true });
+    expect(log.warn).toHaveBeenCalledWith(
+      { attempt: 1, service: SERVICE, reason: "schema_mismatch" },
+      "GPT response malformed, retrying",
+    );
+  });
+
+  it("throws after two schema_mismatch responses", async () => {
+    const log = makeLogger();
+    const call = vi.fn().mockResolvedValue(ok("anything"));
+    const parseAndValidate = vi.fn().mockImplementation(() => {
+      throw new OpenAIRetryError("schema_mismatch");
+    });
+
+    await expect(
+      withOpenAIRetry(call, parseAndValidate, { service: SERVICE, log }),
+    ).rejects.toMatchObject({ reason: "schema_mismatch" });
+    expect(call).toHaveBeenCalledTimes(2);
+  });
+
+  // ---- mixed reasons + non-retry errors ----
+
+  it("retries empty then schema_mismatch then throws schema_mismatch", async () => {
+    const log = makeLogger();
+    const call = vi
+      .fn()
+      .mockResolvedValueOnce(ok(null))
+      .mockResolvedValueOnce(ok("bad"));
+    const parseAndValidate = vi.fn().mockImplementation(() => {
+      throw new OpenAIRetryError("schema_mismatch");
+    });
+
+    await expect(
+      withOpenAIRetry(call, parseAndValidate, { service: SERVICE, log }),
+    ).rejects.toMatchObject({ reason: "schema_mismatch" });
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      { attempt: 1, service: SERVICE, reason: "empty" },
+      "GPT response malformed, retrying",
+    );
+  });
+
+  it("does not retry non-OpenAIRetryError errors (e.g. network failure)", async () => {
+    const log = makeLogger();
+    const networkErr = new Error("ECONNRESET");
+    const call = vi.fn().mockRejectedValue(networkErr);
+    const parseAndValidate = vi.fn();
+
+    await expect(
+      withOpenAIRetry(call, parseAndValidate, { service: SERVICE, log }),
+    ).rejects.toBe(networkErr);
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/openai-retry.ts
+++ b/apps/web/lib/openai-retry.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared retry helper for OpenAI calls that parse + validate JSON responses.
+ *
+ * Retries **once** on a malformed response (empty content, JSON parse error,
+ * or schema validation error) using the same prompt — mirroring the pattern
+ * in apps/api/app/services/{feedback_generator,code_analyzer}.py.
+ *
+ * On the first failed attempt this emits a structured Pino warning:
+ *   log.warn({ attempt: 1, service, reason }, "GPT response malformed, retrying")
+ * where reason ∈ "empty" | "invalid_json" | "schema_mismatch".
+ *
+ * On the second failed attempt the underlying `OpenAIRetryError` is re-thrown.
+ */
+
+import type pino from "pino";
+
+export type OpenAIRetryReason = "empty" | "invalid_json" | "schema_mismatch";
+
+export class OpenAIRetryError extends Error {
+  reason: OpenAIRetryReason;
+  cause?: unknown;
+
+  constructor(reason: OpenAIRetryReason, cause?: unknown) {
+    super(`OpenAI response malformed: ${reason}`);
+    this.name = "OpenAIRetryError";
+    this.reason = reason;
+    this.cause = cause;
+  }
+}
+
+/**
+ * Minimal shape of an OpenAI chat completion response that this helper needs.
+ * Declared structurally so callers don't have to import the OpenAI SDK types.
+ */
+export interface OpenAIChatLikeResponse {
+  choices: Array<{ message: { content: string | null } }>;
+}
+
+export interface WithOpenAIRetryOptions {
+  service: string;
+  log: pino.Logger;
+}
+
+/**
+ * Run an OpenAI call + parse + validate pipeline with one retry on malformed
+ * responses.
+ *
+ * @param call               Thunk that performs the OpenAI chat completion.
+ * @param parseAndValidate   Pure function that parses the raw string content
+ *                           and returns the validated `T`. MUST throw an
+ *                           `OpenAIRetryError("invalid_json")` on JSON parse
+ *                           failure and `OpenAIRetryError("schema_mismatch")`
+ *                           on schema validation failure. Any other thrown
+ *                           error propagates immediately without a retry.
+ * @param opts               `{ service, log }` for the structured warning.
+ */
+export async function withOpenAIRetry<T>(
+  call: () => Promise<OpenAIChatLikeResponse>,
+  parseAndValidate: (raw: string) => T,
+  opts: WithOpenAIRetryOptions,
+): Promise<T> {
+  const { service, log } = opts;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const response = await call();
+      const content = response.choices[0]?.message?.content;
+      if (!content) {
+        throw new OpenAIRetryError("empty");
+      }
+      return parseAndValidate(content);
+    } catch (err) {
+      if (!(err instanceof OpenAIRetryError)) {
+        // Non-retry-error: propagate immediately, do not retry.
+        throw err;
+      }
+      if (attempt === 0) {
+        log.warn(
+          { attempt: 1, service, reason: err.reason },
+          "GPT response malformed, retrying",
+        );
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  // Defensive: the loop always returns or throws above.
+  throw new OpenAIRetryError("empty");
+}


### PR DESCRIPTION
## Summary
- Add `POST /api/analysis/behavioral` and `POST /api/analysis/technical` as pure Next.js ports of the FastAPI `/analysis/*` endpoints — byte-equivalent prompts, identical retry semantics, matching snake_case wire contract.
- Add three shared `lib/` modules: `analysis-prompts.ts` (line-for-line ports of `_build_analysis_prompt` and `build_technical_analysis_prompt`), `analysis-schemas.ts` (Zod mirrors of the Pydantic `FeedbackRequest`/`FeedbackResponse` and `TechnicalFeedbackRequest`/`TechnicalFeedbackResponse`), and `openai-retry.ts` (shared 2-attempt helper with closed `"empty" | "invalid_json" | "schema_mismatch"` reason enum).
- Technical route injects the deterministic `buildTimeline()` result from Story 21 into the GPT response **before** Zod validation, mirroring `code_analyzer.py` so the timeline is never hallucinated.
- 77 new tests: 24 prompt (including 2 byte-equivalent snapshots against Python-generated `*.expected.txt` fixtures), 9 retry-helper, 17 schema, 11 integration (5 behavioral + 6 technical, including `timeline_injected_from_correlator_not_gpt` mirrored from `test_code_analyzer.py`).
- **No cutover.** `app/api/sessions/[id]/feedback/route.ts` still points at `PYTHON_API_URL`; `apps/api/` is untouched. Both services run in parallel until Story 23.

## Context
- Part of #9 ([REFACTOR] Consolidate apps/api FastAPI → Next.js), Story 2 of 4.
- Story 21 landed `buildTimeline` plus the `*Input` Zod schemas in `lib/validations.ts`; Story 22 builds on them here.
- The new routes are intentionally **unauthenticated** — they are internal server-to-server, matching current FastAPI behavior (the caller at `app/api/sessions/[id]/feedback/route.ts` enforces auth). This is an explicit, documented divergence from the `apps/web/CLAUDE.md` "always check auth() first" default and is called out in both route file docblocks.
- `analysis-schemas.ts` is a new file (not appended to `lib/validations.ts`) because its `technicalAnalysisConfigSchema` is intentionally a loose `z.record(z.string(), z.unknown())` to match Pydantic `dict` typing and must not be confused with the strict `technicalConfigSchema` already in `validations.ts`.

## Test plan
- [x] \`npx turbo lint typecheck test\` — 368 unit tests pass, 0 new warnings
- [x] \`cd apps/web && npm run test:integration\` — 190 pass (176 baseline + 11 new + 3 from adjacent work)
- [x] Byte-equivalent prompt snapshots verified against Python subprocess output during QA
- [x] \`timeline_injected_from_correlator_not_gpt\` integration test mirrors Python \`test_code_analyzer.py\` exactly (GPT returns empty timeline, route must overwrite)
- [x] Retry helper: 9 tests across 3 reasons × {success-on-1, success-on-2, fail-twice}
- [x] \`apps/api/\` untouched; \`app/api/sessions/[id]/feedback/route.ts\` untouched

## Out of scope
- Story 23: cut \`sessions/[id]/feedback\` over to the new local routes, port the pytest integration suite to Vitest.
- Story 24: delete \`apps/api/\`, remove the Python CI job, update root README and CLAUDE.md.

Closes: part of #9 (Story 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)