### PR TITLE
chore(agents): tech-lead-planner must survey integration surfaces

### DIFF
--- a/.claude/agents/tech-lead-planner.md
+++ b/.claude/agents/tech-lead-planner.md
@@ -39,6 +39,51 @@ Before drafting the plan, answer these for yourself:
 - What integration tests already exist for the routes you'll touch? (Read
   them — your plan must extend them, not duplicate them.)
 
+## Integration survey (mandatory)
+
+Every feature lives in a web of other features. A feature that ships in
+isolation forces the user to copy-and-paste between tabs; a feature that is
+wired into its neighbors compounds value across the whole product. Your
+plan must explicitly survey the existing codebase for **integration
+opportunities** — places where this new feature can **produce data for**,
+**consume data from**, or **launch into** something that already exists.
+
+Before drafting the plan, walk through the following and write down
+anything relevant:
+
+1. **Inbound surfaces** — what existing pages, components, or routes could
+   launch into the new feature? (e.g. a new "practice this question" button
+   in a list that already exists; a new action in a sidebar card; a deep
+   link from an email.)
+2. **Outbound surfaces** — what existing features could consume the
+   artifact this story produces? (e.g. a new "analysis" output could feed
+   the dashboard streak counter, the post-session review, the badge
+   checker, or a notification.)
+3. **Shared data** — is there a DB column, prompt helper, Zod schema, or
+   rubric this story could reuse instead of inventing a parallel one? Grep
+   `lib/` and `components/shared/` before deciding anything is new.
+4. **Cross-feature triggers** — does finishing an action in this feature
+   mean another feature should update (e.g. completing a prep story should
+   increment a "prepared stories" counter that a dashboard widget already
+   reads)? Call it out, even if the other side is a follow-up.
+5. **Navigation and discoverability** — where does the user find this
+   feature from inside the existing app? A feature reachable only via a
+   direct URL is a feature the user will forget exists. Name the specific
+   `Sidebar.tsx` entry, dashboard card, or inline button that links to it.
+
+Not every feature has meaningful integrations, and that's OK — but the
+plan must **say so explicitly** ("Integration survey: no existing feature
+consumes or produces STAR stories today; the only inbound surface is a
+new sidebar link") rather than silently skip the section. Silence means
+you didn't look.
+
+When you do find integrations, prefer **wiring them up inside this story**
+when the cost is small (< ~2 extra files / < 30 extra lines). When the
+cost is larger, list them under **Follow-ups** with a one-line rationale,
+so the user can decide whether to grow the scope or file a child story.
+The goal is to avoid the pattern where a feature ships as an island and
+the user has to manually copy data between it and the rest of the app.
+
 ## What you produce
 
 A plan in this exact format:
@@ -55,6 +100,13 @@ A plan in this exact format:
 
 ### Files to modify
 - path/to/file.ts — <what changes and why>
+
+### Integration survey
+- **Inbound:** <existing pages/components that will launch into this feature, or "none — only reachable via the new sidebar link">
+- **Outbound:** <existing features that will consume this feature's output, or "none — this feature's output stays within the new pages">
+- **Shared data reused:** <list the helpers, prompts, schemas, rubrics, or columns you are reusing instead of duplicating>
+- **Wired up in this story:** <integrations small enough to include here>
+- **Follow-ups:** <integrations too large for this story, each with a one-line rationale>
 
 ### Database changes
 None  /  Add column X to table Y / etc.


### PR DESCRIPTION
## Summary

Push the \`tech-lead-planner\` subagent to actively hunt for integration opportunities between a new story and the rest of the codebase. Today the planner matches patterns of similar features but doesn't explicitly look for ways the new feature can **produce data for** or **consume data from** existing ones — which means stories routinely ship as islands and users end up copy-pasting between tabs.

## Changes

- New **Integration survey (mandatory)** section in the research checklist. Five questions the planner must answer before drafting: inbound surfaces, outbound surfaces, shared data reuse, cross-feature triggers, navigation/discoverability.
- New **Integration survey** block in the plan output format. The planner must either list the integrations or explicitly declare \"none\" — silence counts as skipping the survey.
- Guidance: wire up small integrations inside the current story (< ~2 extra files / < 30 extra lines); list larger ones under Follow-ups so the user can grow scope or spawn a child story.

## Why now

Filed alongside stories #39 (STAR story helper) and #40 (automated marketer), both of which have natural integration surfaces with existing features (behavioral practice sessions, admin tooling). The planner should push those surfaces into every implementation plan from now on.

## Test plan

- [x] Agent file still parses as valid YAML + Markdown
- [ ] First invocation of \`/standup\` post-merge produces a plan whose \"Integration survey\" section is non-empty and specific — not boilerplate

🤖 Generated with [Claude Code](https://claude.com/claude-code)