### PR TITLE
chore: install graphify + fix qa-tester Bash execution rule

### DIFF
--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -20,6 +20,12 @@ test was poorly written, and even then only with explicit reasoning.
 
 Run these in order. Stop and report a failure as soon as **any** step fails.
 
+**Execution rule:** Every shell command below must be issued as its **own
+Bash tool call**. Do not chain commands with `&&` or `;` in a single call —
+compound commands confuse the permission system's prefix matching and get
+auto-denied in background runs. If a step shows two commands in a fenced
+block, that's two Bash calls, not one.
+
 ### 1. Static analysis
 
 ```bash

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,6 +24,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Glob|Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -f graphify-out/graph.json ] && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.\"}}' || true"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,8 @@ coverage/
 
 # Misc
 *.tsbuildinfo
-next-env.d.ts.claude/worktrees/
+next-env.d.ts
+.claude/worktrees/
+
+# Graphify knowledge graph (local tool state)
+graphify-out/

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,49 @@
+# Exclusions for `graphify update .` — same syntax as .gitignore.
+# Keep in sync with .gitignore for anything that is noise for the graph.
+
+# Dependencies
+node_modules/
+.pnp/
+
+# Build outputs
+.next/
+out/
+dist/
+build/
+.turbo/
+**/dist/
+
+# Generated / lockfiles
+package-lock.json
+*.tsbuildinfo
+next-env.d.ts
+
+# Drizzle migration metadata (snapshots are noisy, SQL files are fine)
+apps/web/drizzle/meta/
+
+# Python caches / venvs
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+
+# Tests coverage
+coverage/
+.pytest_cache/
+
+# Test-only fixtures + Playwright artefacts
+apps/web/e2e/.auth/
+apps/web/playwright-report/
+apps/web/test-results/
+
+# IDE / OS
+.vscode/
+.idea/
+.DS_Store
+
+# Graphify itself
+graphify-out/
+.claude/worktrees/
+
+# Archived design docs (parked work, don't want them skewing god nodes)
+dev_logs/Backlog-archive.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,3 +115,12 @@ npm run db:migrate    # Apply locally
 - Never use `console.log` in server-side code (Next.js API routes). See the
   per-app CLAUDE.md for the structured logger pattern.
 - Never commit secrets or files containing them (`.env`, `credentials.json`).
+
+## graphify
+
+This project has a graphify knowledge graph at graphify-out/.
+
+Rules:
+- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
+- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
+- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)


### PR DESCRIPTION
## Summary

Two small housekeeping changes for the autonomous-loop tooling.

### 1. `graphify claude install` — knowledge graph integration

Installed the [graphify](https://pypi.org/project/graphifyy/) Claude Code integration (`graphifyy 0.4.14` via pipx):

- Adds a `## graphify` section to the root `CLAUDE.md` telling Claude to consult `graphify-out/GRAPH_REPORT.md` and `graphify-out/wiki/index.md` before answering architecture questions, and to run `graphify update .` after code edits (AST-only, no API cost).
- Registers a `PreToolUse` hook in `.claude/settings.json` on `Glob|Grep` that, when `graphify-out/graph.json` exists, injects a reminder to start from the graph report rather than raw files.

Initial graph build (`graphify update .`) has **not** been run yet — it's a separate opt-in step once we confirm whether it costs API credits. Until the graph exists, the hook is a no-op.

### 2. qa-tester: require one Bash call per step

During Wave 1's parallel rollout, the `qa-tester` subagent bounced on a compound command:

```
rm -rf apps/web/.next && npx turbo lint typecheck
```

Compound commands chained with `&&` confuse Claude Code's permission prefix matching and get auto-denied in background subagent runs. Added an explicit execution rule at the top of the gauntlet requiring each step to be its own Bash tool call.

## Test plan

- [x] `graphify --help` lists the `claude` subcommand
- [x] `.claude/settings.json` parses as valid JSON after the install
- [x] `CLAUDE.md` still renders cleanly
- [ ] On next Wave, verify `qa-tester` can run `npx turbo lint typecheck test` without tripping permission prompts
- [ ] Decide whether to run an initial `graphify update .` build (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)