### PR TITLE
feat(billing): Stripe Checkout endpoint and webhook handler (#36)

### DIFF
--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -1,0 +1,20 @@
+# Database
+SUPABASE_DB_URL=postgresql://postgres:password@db.your-project.supabase.co:5432/postgres
+
+# Auth (NextAuth v5)
+AUTH_SECRET=generate-with-openssl-rand-base64-32
+AUTH_URL=http://localhost:3000
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+
+# OpenAI
+OPENAI_API_KEY=sk-your-openai-key
+
+# Stripe (billing)
+STRIPE_SECRET_KEY=sk_test_your-stripe-secret-key
+STRIPE_WEBHOOK_SECRET=whsec_your-stripe-webhook-secret
+STRIPE_PRO_PRICE_ID=price_your-stripe-pro-price-id
+
+# Sentry (optional — leave blank to disable)
+SENTRY_DSN=
+NEXT_PUBLIC_SENTRY_DSN=

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -77,6 +77,63 @@ Smoke test locally:
 curl -i http://localhost:3000/api/health
 ```
 
+## Billing
+
+Preploy uses [Stripe](https://stripe.com) for Pro-plan subscriptions. The billing
+surface consists of two API routes:
+
+| Route | Description |
+|---|---|
+| `POST /api/billing/checkout` | Creates a Stripe Checkout Session and returns `{ url }` for client redirect. |
+| `POST /api/billing/webhook` | Receives Stripe lifecycle events and updates the user's plan in the DB. |
+
+### Local setup
+
+1. Install the [Stripe CLI](https://stripe.com/docs/stripe-cli) and log in:
+
+   ```bash
+   stripe login
+   ```
+
+2. Copy `.env.local.example` to `.env.local` and fill in your Stripe keys:
+
+   ```bash
+   cp apps/web/.env.local.example apps/web/.env.local
+   ```
+
+   | Variable | How to get it |
+   |---|---|
+   | `STRIPE_SECRET_KEY` | Stripe Dashboard → Developers → API keys → Secret key (`sk_test_...`). |
+   | `STRIPE_WEBHOOK_SECRET` | Copied from `stripe listen` output (see below). |
+   | `STRIPE_PRO_PRICE_ID` | Stripe Dashboard → Products → Pro plan → Price ID (`price_...`). |
+
+3. Forward Stripe events to your local dev server:
+
+   ```bash
+   stripe listen --forward-to localhost:3000/api/billing/webhook
+   ```
+
+   The CLI will print `webhook signing secret: whsec_...` — copy that value into
+   `STRIPE_WEBHOOK_SECRET` in your `.env.local`.
+
+4. Trigger a test checkout flow via the app UI (`/profile → Upgrade`), or
+   manually with the CLI:
+
+   ```bash
+   stripe trigger checkout.session.completed
+   ```
+
+### Handled events
+
+| Stripe event | Effect |
+|---|---|
+| `checkout.session.completed` | Upgrades user to `pro`, records `stripe_subscription_id`, period dates. |
+| `customer.subscription.updated` | Refreshes plan and `plan_period_end`; maps `past_due`/`unpaid` → pro-flagged. |
+| `customer.subscription.deleted` | Reverts to `free`, clears subscription ID, resets `interview_usage`. |
+| `invoice.payment_failed` | Sets `past_due_at` timestamp on the user row. |
+
+Webhook handlers are idempotent — re-delivering the same event is safe.
+
 ## Environment variables
 
 ### Runtime vs build-time
@@ -109,6 +166,10 @@ task definition / secrets manager.
 | `CI`                       | RUNTIME_ONLY       | Set by CI runners (GitHub Actions, etc.). Used to toggle Playwright retry counts and parallel workers. |
 | `PLAYWRIGHT_BASE_URL`      | RUNTIME_ONLY       | Base URL used by the Playwright E2E suite (default: `http://localhost:3000`). |
 | `PLAYWRIGHT_SKIP_WEBSERVER`| RUNTIME_ONLY       | Set to `1` in CI to skip Playwright's built-in webServer block (server is pre-started). |
+| `NEXTAUTH_URL`             | RUNTIME_ONLY       | Public URL of the app — used to build Stripe redirect URLs. Alias of `AUTH_URL`. |
+| `STRIPE_SECRET_KEY`        | RUNTIME_ONLY       | Stripe secret API key (`sk_test_...` for dev, `sk_live_...` for prod). Never expose to client. |
+| `STRIPE_WEBHOOK_SECRET`    | RUNTIME_ONLY       | Webhook signing secret from `stripe listen` or Stripe Dashboard. Used to verify inbound events. |
+| `STRIPE_PRO_PRICE_ID`      | RUNTIME_ONLY       | Stripe Price ID for the Pro subscription plan (`price_...`). |
 
 Server-only secrets (`SUPABASE_DB_URL`, `OPENAI_API_KEY`, `GOOGLE_CLIENT_SECRET`,
 `SENTRY_DSN`) must never be referenced from a file marked `"use client"` and

--- a/apps/web/app/api/billing/checkout/route.integration.test.ts
+++ b/apps/web/app/api/billing/checkout/route.integration.test.ts
@@ -19,6 +19,20 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
+// Mock the rate-limit helper so we can exercise the 429 branch on demand.
+// checkRateLimit is SYNCHRONOUS and returns NextResponse | null.
+// Default to null (passthrough) so existing happy-path tests behave normally.
+const { mockCheckRateLimit } = vi.hoisted(() => ({
+  mockCheckRateLimit: vi.fn<(userId: string) => unknown>(() => null),
+}));
+vi.mock("@/lib/api-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-utils")>();
+  return {
+    ...actual,
+    checkRateLimit: (userId: string) => mockCheckRateLimit(userId),
+  };
+});
+
 // Mock Stripe SDK — tests should not hit the real Stripe API
 const mockCustomersCreate = vi.fn();
 const mockCustomersList = vi.fn();
@@ -64,6 +78,9 @@ describe("POST /api/billing/checkout (integration)", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+
+    // Default: rate limit allows the request through (sync return).
+    mockCheckRateLimit.mockReturnValue(null);
 
     // Reset user's stripe customer id between tests
     const db = getTestDb();
@@ -183,5 +200,22 @@ describe("POST /api/billing/checkout (integration)", () => {
     });
     const res = await POST(makePostRequest());
     expect(res.status).toBe(404);
+  });
+
+  it("returns 429 when the rate limiter rejects the request", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    mockCheckRateLimit.mockReturnValueOnce(
+      new Response(JSON.stringify({ error: "rate limited" }), {
+        status: 429,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const res = await POST(makePostRequest());
+
+    expect(res.status).toBe(429);
+    // Stripe should never have been called when rate-limited.
+    expect(mockCustomersCreate).not.toHaveBeenCalled();
+    expect(mockCheckoutSessionsCreate).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/billing/checkout/route.integration.test.ts
+++ b/apps/web/app/api/billing/checkout/route.integration.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
+import { NextRequest } from "next/server";
+import {
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../../tests/setup-db";
+import { users } from "@/lib/schema";
+import { eq } from "drizzle-orm";
+
+// Mock auth — only auth is mocked
+const mockAuth = vi.fn();
+vi.mock("@/lib/auth", () => ({ auth: () => mockAuth() }));
+
+// Point db import to the test database
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return getTestDb();
+  },
+}));
+
+// Mock Stripe SDK — tests should not hit the real Stripe API
+const mockCustomersCreate = vi.fn();
+const mockCustomersList = vi.fn();
+const mockCheckoutSessionsCreate = vi.fn();
+const mockSubscriptionsRetrieve = vi.fn();
+
+vi.mock("@/lib/stripe", () => ({
+  stripe: {
+    customers: {
+      create: (...args: unknown[]) => mockCustomersCreate(...args),
+      list: (...args: unknown[]) => mockCustomersList(...args),
+    },
+    checkout: {
+      sessions: {
+        create: (...args: unknown[]) => mockCheckoutSessionsCreate(...args),
+      },
+    },
+    subscriptions: {
+      retrieve: (...args: unknown[]) => mockSubscriptionsRetrieve(...args),
+    },
+  },
+}));
+
+import { POST } from "./route";
+
+const TEST_USER = {
+  id: "00000000-0000-0000-0000-000000000001",
+  email: "checkout-test@example.com",
+  name: "Checkout Test User",
+};
+
+function makePostRequest(): NextRequest {
+  return new NextRequest("http://localhost:3000/api/billing/checkout", {
+    method: "POST",
+  });
+}
+
+describe("POST /api/billing/checkout (integration)", () => {
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values(TEST_USER).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // Reset user's stripe customer id between tests
+    const db = getTestDb();
+    await db
+      .update(users)
+      .set({ stripeCustomerId: null })
+      .where(eq(users.id, TEST_USER.id));
+
+    // Default env
+    process.env.STRIPE_PRO_PRICE_ID = "price_test_pro";
+    process.env.NEXTAUTH_URL = "http://localhost:3000";
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await POST(makePostRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when STRIPE_PRO_PRICE_ID is not set", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    delete process.env.STRIPE_PRO_PRICE_ID;
+    const res = await POST(makePostRequest());
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toMatch(/not configured/i);
+    process.env.STRIPE_PRO_PRICE_ID = "price_test_pro";
+  });
+
+  it("creates a new Stripe customer on first call and persists stripe_customer_id", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    mockCustomersCreate.mockResolvedValue({ id: "cus_new123" });
+    mockCheckoutSessionsCreate.mockResolvedValue({
+      id: "cs_test_abc",
+      url: "https://checkout.stripe.com/pay/cs_test_abc",
+    });
+
+    const res = await POST(makePostRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.url).toMatch(/checkout\.stripe\.com/);
+
+    // Verify customer was persisted
+    const db = getTestDb();
+    const [row] = await db
+      .select({ stripeCustomerId: users.stripeCustomerId })
+      .from(users)
+      .where(eq(users.id, TEST_USER.id));
+    expect(row.stripeCustomerId).toBe("cus_new123");
+
+    // customer.create was called once with user data
+    expect(mockCustomersCreate).toHaveBeenCalledTimes(1);
+    expect(mockCustomersCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: TEST_USER.email,
+        metadata: { userId: TEST_USER.id },
+      })
+    );
+  });
+
+  it("reuses existing Stripe customer on second call (does not call create again)", async () => {
+    // Pre-set a stripe customer id
+    const db = getTestDb();
+    await db
+      .update(users)
+      .set({ stripeCustomerId: "cus_existing456" })
+      .where(eq(users.id, TEST_USER.id));
+
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    mockCheckoutSessionsCreate.mockResolvedValue({
+      id: "cs_test_def",
+      url: "https://checkout.stripe.com/pay/cs_test_def",
+    });
+
+    const res = await POST(makePostRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.url).toMatch(/checkout\.stripe\.com/);
+
+    // customer.create should NOT have been called
+    expect(mockCustomersCreate).not.toHaveBeenCalled();
+
+    // Checkout session should have been created with the existing customer
+    expect(mockCheckoutSessionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ customer: "cus_existing456" })
+    );
+  });
+
+  it("creates checkout session in subscription mode with correct URLs", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    mockCustomersCreate.mockResolvedValue({ id: "cus_mode_test" });
+    mockCheckoutSessionsCreate.mockResolvedValue({
+      id: "cs_mode",
+      url: "https://checkout.stripe.com/pay/cs_mode",
+    });
+
+    await POST(makePostRequest());
+
+    expect(mockCheckoutSessionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "subscription",
+        line_items: [{ price: "price_test_pro", quantity: 1 }],
+        success_url: "http://localhost:3000/profile?billing=success",
+        cancel_url: "http://localhost:3000/profile?billing=cancelled",
+      })
+    );
+  });
+
+  it("returns 404 when user is not found in db", async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: "00000000-0000-0000-0000-000000000099" },
+    });
+    const res = await POST(makePostRequest());
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/web/app/api/billing/checkout/route.ts
+++ b/apps/web/app/api/billing/checkout/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { users } from "@/lib/schema";
+import { eq } from "drizzle-orm";
+import { stripe } from "@/lib/stripe";
+import { checkRateLimit } from "@/lib/api-utils";
+import { createRequestLogger } from "@/lib/logger";
+
+/**
+ * POST /api/billing/checkout
+ * Creates a Stripe Checkout Session for the Pro plan.
+ * Looks up or creates a Stripe customer for the current user, persisting
+ * stripe_customer_id on the users row for re-use on subsequent calls.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function POST(_request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const log = createRequestLogger({
+    route: "POST /api/billing/checkout",
+    userId: session.user.id,
+  });
+
+  const rateLimited = checkRateLimit(session.user.id);
+  if (rateLimited) return rateLimited;
+
+  const proPriceId = process.env.STRIPE_PRO_PRICE_ID;
+  if (!proPriceId) {
+    log.error("STRIPE_PRO_PRICE_ID is not configured");
+    return NextResponse.json(
+      { error: "Billing is not configured" },
+      { status: 500 }
+    );
+  }
+
+  // Load user row to get or create stripe customer
+  const [user] = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      name: users.name,
+      stripeCustomerId: users.stripeCustomerId,
+    })
+    .from(users)
+    .where(eq(users.id, session.user.id));
+
+  if (!user) {
+    log.warn("user not found in db");
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  let customerId = user.stripeCustomerId;
+
+  // Create Stripe customer if one doesn't exist yet
+  if (!customerId) {
+    log.info("creating new stripe customer");
+    const customer = await stripe.customers.create({
+      email: user.email,
+      name: user.name ?? undefined,
+      metadata: { userId: user.id },
+    });
+    customerId = customer.id;
+
+    // Persist so subsequent calls reuse the same customer
+    await db
+      .update(users)
+      .set({ stripeCustomerId: customerId })
+      .where(eq(users.id, user.id));
+
+    log.info({ stripeCustomerId: customerId }, "stripe customer created and saved");
+  } else {
+    log.info({ stripeCustomerId: customerId }, "reusing existing stripe customer");
+  }
+
+  const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
+  const checkoutSession = await stripe.checkout.sessions.create({
+    customer: customerId,
+    mode: "subscription",
+    line_items: [{ price: proPriceId, quantity: 1 }],
+    success_url: `${baseUrl}/profile?billing=success`,
+    cancel_url: `${baseUrl}/profile?billing=cancelled`,
+    metadata: { userId: user.id },
+  });
+
+  log.info({ checkoutSessionId: checkoutSession.id }, "checkout session created");
+
+  return NextResponse.json({ url: checkoutSession.url });
+}

--- a/apps/web/app/api/billing/webhook/route.integration.test.ts
+++ b/apps/web/app/api/billing/webhook/route.integration.test.ts
@@ -125,8 +125,9 @@ describe("POST /api/billing/webhook (integration)", () => {
 
   // ---- checkout.session.completed ----
 
-  it("flips plan to pro on checkout.session.completed", async () => {
+  it("flips plan to pro on checkout.session.completed and stores the period end from items.data[0]", async () => {
     const now = Math.floor(Date.now() / 1000);
+    const expectedPeriodEnd = now + 30 * 24 * 3600;
     const event = makeStripeEvent("checkout.session.completed", {
       id: "cs_test_001",
       subscription: "sub_test_001",
@@ -134,10 +135,17 @@ describe("POST /api/billing/webhook (integration)", () => {
     });
 
     mockConstructEvent.mockReturnValueOnce(event);
+    // Stripe v22 nests period timestamps under subscription.items.data[0].
     mockSubscriptionsRetrieve.mockResolvedValueOnce({
       id: "sub_test_001",
-      current_period_start: now,
-      current_period_end: now + 30 * 24 * 3600,
+      items: {
+        data: [
+          {
+            current_period_start: now,
+            current_period_end: expectedPeriodEnd,
+          },
+        ],
+      },
     });
 
     const res = await POST(makeWebhookRequest(JSON.stringify({})));
@@ -151,12 +159,18 @@ describe("POST /api/billing/webhook (integration)", () => {
       .select({
         plan: users.plan,
         stripeSubscriptionId: users.stripeSubscriptionId,
+        planPeriodEnd: users.planPeriodEnd,
       })
       .from(users)
       .where(eq(users.id, TEST_USER.id));
 
     expect(row.plan).toBe("pro");
     expect(row.stripeSubscriptionId).toBe("sub_test_001");
+    // Tight assertion: the period end must come from items.data[0], not fall
+    // back to `new Date()`. Allow a few seconds of clock drift.
+    expect(row.planPeriodEnd).not.toBeNull();
+    const actualSec = Math.floor(row.planPeriodEnd!.getTime() / 1000);
+    expect(Math.abs(actualSec - expectedPeriodEnd)).toBeLessThan(5);
   });
 
   it("is idempotent — same checkout.session.completed event twice makes exactly one state change", async () => {
@@ -170,8 +184,14 @@ describe("POST /api/billing/webhook (integration)", () => {
     mockConstructEvent.mockReturnValue(event);
     mockSubscriptionsRetrieve.mockResolvedValue({
       id: "sub_test_idem",
-      current_period_start: now,
-      current_period_end: now + 30 * 24 * 3600,
+      items: {
+        data: [
+          {
+            current_period_start: now,
+            current_period_end: now + 30 * 24 * 3600,
+          },
+        ],
+      },
     });
 
     // Process event twice
@@ -263,12 +283,19 @@ describe("POST /api/billing/webhook (integration)", () => {
     const now = Math.floor(Date.now() / 1000);
     const newPeriodEnd = now + 60 * 24 * 3600;
 
+    // Stripe v22 nests period timestamps under items.data[0].
     const event = makeStripeEvent("customer.subscription.updated", {
       id: "sub_updated",
       customer: TEST_USER.stripeCustomerId,
       status: "active",
-      current_period_start: now,
-      current_period_end: newPeriodEnd,
+      items: {
+        data: [
+          {
+            current_period_start: now,
+            current_period_end: newPeriodEnd,
+          },
+        ],
+      },
     });
 
     mockConstructEvent.mockReturnValueOnce(event);
@@ -282,7 +309,11 @@ describe("POST /api/billing/webhook (integration)", () => {
       .where(eq(users.id, TEST_USER.id));
 
     expect(row.plan).toBe("pro");
+    // Tight assertion: must match items.data[0].current_period_end, not
+    // fall back to `new Date()`. Allow a few seconds of clock drift.
     expect(row.planPeriodEnd).not.toBeNull();
+    const actualSec = Math.floor(row.planPeriodEnd!.getTime() / 1000);
+    expect(Math.abs(actualSec - newPeriodEnd)).toBeLessThan(5);
   });
 
   it("sets plan to free on customer.subscription.updated with canceled status", async () => {
@@ -292,8 +323,14 @@ describe("POST /api/billing/webhook (integration)", () => {
       id: "sub_canceled_update",
       customer: TEST_USER.stripeCustomerId,
       status: "canceled",
-      current_period_start: now,
-      current_period_end: now + 86400,
+      items: {
+        data: [
+          {
+            current_period_start: now,
+            current_period_end: now + 86400,
+          },
+        ],
+      },
     });
 
     mockConstructEvent.mockReturnValueOnce(event);

--- a/apps/web/app/api/billing/webhook/route.integration.test.ts
+++ b/apps/web/app/api/billing/webhook/route.integration.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
+import { NextRequest } from "next/server";
+import {
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../../tests/setup-db";
+import { users, interviewUsage } from "@/lib/schema";
+import { eq } from "drizzle-orm";
+import type Stripe from "stripe";
+
+// Point db import to the test database
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return getTestDb();
+  },
+}));
+
+// Mock the Stripe SDK — we control constructEvent so we can test signed vs unsigned
+const mockConstructEvent = vi.fn();
+const mockSubscriptionsRetrieve = vi.fn();
+
+vi.mock("@/lib/stripe", () => ({
+  stripe: {
+    webhooks: {
+      constructEvent: (...args: unknown[]) => mockConstructEvent(...args),
+    },
+    subscriptions: {
+      retrieve: (...args: unknown[]) => mockSubscriptionsRetrieve(...args),
+    },
+  },
+}));
+
+import { POST } from "./route";
+
+const TEST_USER = {
+  id: "00000000-0000-0000-0000-000000000002",
+  email: "webhook-test@example.com",
+  name: "Webhook Test User",
+  stripeCustomerId: "cus_webhook_test",
+};
+
+function makeWebhookRequest(body: string, sig = "valid-sig"): NextRequest {
+  return new NextRequest("http://localhost:3000/api/billing/webhook", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "stripe-signature": sig,
+    },
+    body,
+  });
+}
+
+function makeStripeEvent(
+  type: string,
+  data: Record<string, unknown>
+): Stripe.Event {
+  return {
+    id: `evt_test_${Date.now()}`,
+    type,
+    object: "event",
+    api_version: "2026-03-25.dahlia",
+    created: Math.floor(Date.now() / 1000),
+    data: { object: data },
+    livemode: false,
+    pending_webhooks: 0,
+    request: null,
+  } as unknown as Stripe.Event;
+}
+
+describe("POST /api/billing/webhook (integration)", () => {
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values(TEST_USER).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test_secret";
+
+    // Reset user state between tests
+    const db = getTestDb();
+    await db
+      .update(users)
+      .set({
+        plan: "free",
+        stripeSubscriptionId: null,
+        planPeriodStart: null,
+        planPeriodEnd: null,
+        pastDueAt: null,
+      })
+      .where(eq(users.id, TEST_USER.id));
+
+    // Clear usage records
+    await db.delete(interviewUsage).where(eq(interviewUsage.userId, TEST_USER.id));
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  // ---- Signature verification ----
+
+  it("returns 400 when stripe-signature header is missing", async () => {
+    const req = new NextRequest("http://localhost:3000/api/billing/webhook", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(mockConstructEvent).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when signature verification fails (invalid payload)", async () => {
+    mockConstructEvent.mockImplementationOnce(() => {
+      throw new Error("No signatures found matching the expected signature");
+    });
+    const res = await POST(makeWebhookRequest("{}", "bad-sig"));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/signature/i);
+  });
+
+  // ---- checkout.session.completed ----
+
+  it("flips plan to pro on checkout.session.completed", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const event = makeStripeEvent("checkout.session.completed", {
+      id: "cs_test_001",
+      subscription: "sub_test_001",
+      metadata: { userId: TEST_USER.id },
+    });
+
+    mockConstructEvent.mockReturnValueOnce(event);
+    mockSubscriptionsRetrieve.mockResolvedValueOnce({
+      id: "sub_test_001",
+      current_period_start: now,
+      current_period_end: now + 30 * 24 * 3600,
+    });
+
+    const res = await POST(makeWebhookRequest(JSON.stringify({})));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.received).toBe(true);
+
+    // Verify DB state
+    const db = getTestDb();
+    const [row] = await db
+      .select({
+        plan: users.plan,
+        stripeSubscriptionId: users.stripeSubscriptionId,
+      })
+      .from(users)
+      .where(eq(users.id, TEST_USER.id));
+
+    expect(row.plan).toBe("pro");
+    expect(row.stripeSubscriptionId).toBe("sub_test_001");
+  });
+
+  it("is idempotent — same checkout.session.completed event twice makes exactly one state change", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const event = makeStripeEvent("checkout.session.completed", {
+      id: "cs_test_idem",
+      subscription: "sub_test_idem",
+      metadata: { userId: TEST_USER.id },
+    });
+
+    mockConstructEvent.mockReturnValue(event);
+    mockSubscriptionsRetrieve.mockResolvedValue({
+      id: "sub_test_idem",
+      current_period_start: now,
+      current_period_end: now + 30 * 24 * 3600,
+    });
+
+    // Process event twice
+    await POST(makeWebhookRequest(JSON.stringify({})));
+    await POST(makeWebhookRequest(JSON.stringify({})));
+
+    // Only one call to subscriptions.retrieve (second call is idempotent short-circuit)
+    expect(mockSubscriptionsRetrieve).toHaveBeenCalledTimes(1);
+
+    // DB should reflect pro plan still
+    const db = getTestDb();
+    const [row] = await db
+      .select({ plan: users.plan })
+      .from(users)
+      .where(eq(users.id, TEST_USER.id));
+    expect(row.plan).toBe("pro");
+  });
+
+  // ---- customer.subscription.deleted ----
+
+  it("resets plan to free and clears subscription on customer.subscription.deleted", async () => {
+    // First upgrade the user
+    const db = getTestDb();
+    await db
+      .update(users)
+      .set({ plan: "pro", stripeSubscriptionId: "sub_to_delete" })
+      .where(eq(users.id, TEST_USER.id));
+
+    const event = makeStripeEvent("customer.subscription.deleted", {
+      id: "sub_to_delete",
+      customer: TEST_USER.stripeCustomerId,
+      current_period_start: Math.floor(Date.now() / 1000),
+      current_period_end: Math.floor(Date.now() / 1000) + 86400,
+      status: "canceled",
+    });
+
+    mockConstructEvent.mockReturnValueOnce(event);
+
+    const res = await POST(makeWebhookRequest(JSON.stringify({})));
+    expect(res.status).toBe(200);
+
+    const [row] = await db
+      .select({
+        plan: users.plan,
+        stripeSubscriptionId: users.stripeSubscriptionId,
+      })
+      .from(users)
+      .where(eq(users.id, TEST_USER.id));
+
+    expect(row.plan).toBe("free");
+    expect(row.stripeSubscriptionId).toBeNull();
+  });
+
+  it("clears interview_usage on customer.subscription.deleted", async () => {
+    const db = getTestDb();
+    // Insert a usage record
+    const periodStart = new Date();
+    periodStart.setDate(1);
+    periodStart.setHours(0, 0, 0, 0);
+    await db.insert(interviewUsage).values({
+      userId: TEST_USER.id,
+      periodStart,
+      count: 5,
+    });
+
+    const event = makeStripeEvent("customer.subscription.deleted", {
+      id: "sub_usage_clear",
+      customer: TEST_USER.stripeCustomerId,
+      current_period_start: Math.floor(Date.now() / 1000),
+      current_period_end: Math.floor(Date.now() / 1000) + 86400,
+      status: "canceled",
+    });
+
+    mockConstructEvent.mockReturnValueOnce(event);
+    const res = await POST(makeWebhookRequest(JSON.stringify({})));
+    expect(res.status).toBe(200);
+
+    // Usage should be cleared
+    const usageRows = await db
+      .select()
+      .from(interviewUsage)
+      .where(eq(interviewUsage.userId, TEST_USER.id));
+    expect(usageRows).toHaveLength(0);
+  });
+
+  // ---- customer.subscription.updated ----
+
+  it("refreshes plan and period_end on customer.subscription.updated (active → pro)", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const newPeriodEnd = now + 60 * 24 * 3600;
+
+    const event = makeStripeEvent("customer.subscription.updated", {
+      id: "sub_updated",
+      customer: TEST_USER.stripeCustomerId,
+      status: "active",
+      current_period_start: now,
+      current_period_end: newPeriodEnd,
+    });
+
+    mockConstructEvent.mockReturnValueOnce(event);
+    const res = await POST(makeWebhookRequest(JSON.stringify({})));
+    expect(res.status).toBe(200);
+
+    const db = getTestDb();
+    const [row] = await db
+      .select({ plan: users.plan, planPeriodEnd: users.planPeriodEnd })
+      .from(users)
+      .where(eq(users.id, TEST_USER.id));
+
+    expect(row.plan).toBe("pro");
+    expect(row.planPeriodEnd).not.toBeNull();
+  });
+
+  it("sets plan to free on customer.subscription.updated with canceled status", async () => {
+    const now = Math.floor(Date.now() / 1000);
+
+    const event = makeStripeEvent("customer.subscription.updated", {
+      id: "sub_canceled_update",
+      customer: TEST_USER.stripeCustomerId,
+      status: "canceled",
+      current_period_start: now,
+      current_period_end: now + 86400,
+    });
+
+    mockConstructEvent.mockReturnValueOnce(event);
+    const res = await POST(makeWebhookRequest(JSON.stringify({})));
+    expect(res.status).toBe(200);
+
+    const db = getTestDb();
+    const [row] = await db
+      .select({ plan: users.plan })
+      .from(users)
+      .where(eq(users.id, TEST_USER.id));
+    expect(row.plan).toBe("free");
+  });
+
+  // ---- invoice.payment_failed ----
+
+  it("sets past_due_at on invoice.payment_failed", async () => {
+    const event = makeStripeEvent("invoice.payment_failed", {
+      id: "in_failed",
+      customer: TEST_USER.stripeCustomerId,
+      status: "open",
+    });
+
+    mockConstructEvent.mockReturnValueOnce(event);
+    const res = await POST(makeWebhookRequest(JSON.stringify({})));
+    expect(res.status).toBe(200);
+
+    const db = getTestDb();
+    const [row] = await db
+      .select({ pastDueAt: users.pastDueAt })
+      .from(users)
+      .where(eq(users.id, TEST_USER.id));
+    expect(row.pastDueAt).not.toBeNull();
+  });
+
+  // ---- Stale webhook noise ----
+
+  it("returns 200 (not error) when user is not found — stale webhook noise", async () => {
+    const event = makeStripeEvent("checkout.session.completed", {
+      id: "cs_stale",
+      subscription: "sub_stale",
+      metadata: { userId: "00000000-0000-0000-0000-000000000099" },
+    });
+
+    mockConstructEvent.mockReturnValueOnce(event);
+    mockSubscriptionsRetrieve.mockResolvedValueOnce({
+      id: "sub_stale",
+      current_period_start: Math.floor(Date.now() / 1000),
+      current_period_end: Math.floor(Date.now() / 1000) + 86400,
+    });
+
+    const res = await POST(makeWebhookRequest(JSON.stringify({})));
+    // Should return 200 — stale noise, not a bug
+    expect(res.status).toBe(200);
+  });
+
+  // ---- Unhandled event types ----
+
+  it("returns 200 for unhandled event types", async () => {
+    const event = makeStripeEvent("payment_intent.created", { id: "pi_test" });
+    mockConstructEvent.mockReturnValueOnce(event);
+    const res = await POST(makeWebhookRequest(JSON.stringify({})));
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/web/app/api/billing/webhook/route.ts
+++ b/apps/web/app/api/billing/webhook/route.ts
@@ -1,0 +1,288 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { users, interviewUsage } from "@/lib/schema";
+import { eq } from "drizzle-orm";
+import { stripe } from "@/lib/stripe";
+import { createRequestLogger } from "@/lib/logger";
+import type Stripe from "stripe";
+
+/**
+ * POST /api/billing/webhook
+ * Handles Stripe webhook events for subscription lifecycle management.
+ * No auth — verified via Stripe signature instead.
+ */
+export async function POST(request: NextRequest) {
+  const log = createRequestLogger({ route: "POST /api/billing/webhook" });
+
+  const body = await request.text();
+  const sig = request.headers.get("stripe-signature");
+
+  if (!sig) {
+    log.warn("missing stripe-signature header");
+    return NextResponse.json({ error: "Missing signature" }, { status: 400 });
+  }
+
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    log.error("STRIPE_WEBHOOK_SECRET is not configured");
+    return NextResponse.json(
+      { error: "Webhook not configured" },
+      { status: 500 }
+    );
+  }
+
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(body, sig, webhookSecret);
+  } catch (err) {
+    log.warn({ err }, "stripe signature verification failed");
+    return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
+  }
+
+  log.info({ eventType: event.type, eventId: event.id }, "processing stripe webhook");
+
+  try {
+    switch (event.type) {
+      case "checkout.session.completed":
+        await handleCheckoutSessionCompleted(
+          event.data.object as Stripe.Checkout.Session,
+          log
+        );
+        break;
+      case "customer.subscription.updated":
+        await handleSubscriptionUpdated(
+          event.data.object as Stripe.Subscription,
+          log
+        );
+        break;
+      case "customer.subscription.deleted":
+        await handleSubscriptionDeleted(
+          event.data.object as Stripe.Subscription,
+          log
+        );
+        break;
+      case "invoice.payment_failed":
+        await handleInvoicePaymentFailed(
+          event.data.object as Stripe.Invoice,
+          log
+        );
+        break;
+      default:
+        log.info({ eventType: event.type }, "unhandled event type — skipping");
+    }
+  } catch (err) {
+    // Log and return 200 so Stripe doesn't retry indefinitely.
+    // If a user row is missing, that's stale webhook noise, not a bug.
+    log.error({ err, eventType: event.type, eventId: event.id }, "webhook handler error");
+  }
+
+  return NextResponse.json({ received: true });
+}
+
+// ---------------------------------------------------------------------------
+// Individual event handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * checkout.session.completed
+ * Sets plan to "pro", records subscription ID and period dates.
+ */
+async function handleCheckoutSessionCompleted(
+  session: Stripe.Checkout.Session,
+  log: ReturnType<typeof createRequestLogger>
+) {
+  const userId = session.metadata?.userId;
+  if (!userId) {
+    log.warn({ sessionId: session.id }, "checkout.session.completed: no userId in metadata");
+    return;
+  }
+
+  if (!session.subscription) {
+    log.warn({ sessionId: session.id }, "checkout.session.completed: no subscription on session");
+    return;
+  }
+
+  const subscriptionId =
+    typeof session.subscription === "string"
+      ? session.subscription
+      : session.subscription.id;
+
+  // Check user exists and guard idempotency BEFORE hitting Stripe API
+  const [existing] = await db
+    .select({ stripeSubscriptionId: users.stripeSubscriptionId })
+    .from(users)
+    .where(eq(users.id, userId));
+
+  if (!existing) {
+    log.warn({ userId }, "checkout.session.completed: user not found — skipping");
+    return;
+  }
+
+  // Idempotent: if already set to this subscription, skip
+  if (existing.stripeSubscriptionId === subscriptionId) {
+    log.info({ userId, subscriptionId }, "checkout.session.completed: already processed — skipping");
+    return;
+  }
+
+  // Fetch full subscription to get period dates
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+  // current_period_start/end moved to subscription.items in Stripe v22+
+  const firstItem = subscription.items?.data?.[0];
+  const periodStart = firstItem
+    ? new Date(firstItem.current_period_start * 1000)
+    : new Date();
+  const periodEnd = firstItem
+    ? new Date(firstItem.current_period_end * 1000)
+    : new Date();
+
+  await db
+    .update(users)
+    .set({
+      plan: "pro",
+      stripeSubscriptionId: subscriptionId,
+      planPeriodStart: periodStart,
+      planPeriodEnd: periodEnd,
+      pastDueAt: null,
+    })
+    .where(eq(users.id, userId));
+
+  log.info({ userId, subscriptionId }, "checkout.session.completed: user upgraded to pro");
+}
+
+/**
+ * customer.subscription.updated
+ * Refreshes plan_period_end and plan from subscription status.
+ */
+async function handleSubscriptionUpdated(
+  subscription: Stripe.Subscription,
+  log: ReturnType<typeof createRequestLogger>
+) {
+  const customerId =
+    typeof subscription.customer === "string"
+      ? subscription.customer
+      : subscription.customer.id;
+
+  const [user] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.stripeCustomerId, customerId));
+
+  if (!user) {
+    log.warn({ customerId }, "customer.subscription.updated: no user found — skipping");
+    return;
+  }
+
+  // current_period_start/end moved to subscription.items in Stripe v22+
+  const firstItem = subscription.items?.data?.[0];
+  const periodEnd = firstItem
+    ? new Date(firstItem.current_period_end * 1000)
+    : new Date();
+  const periodStart = firstItem
+    ? new Date(firstItem.current_period_start * 1000)
+    : new Date();
+
+  const status = subscription.status;
+  let plan: "free" | "pro" = "free";
+
+  if (status === "active" || status === "trialing") {
+    plan = "pro";
+  } else if (status === "past_due" || status === "unpaid") {
+    // Pro but flagged — we keep plan as pro but the past_due_at will be set
+    plan = "pro";
+  }
+  // "canceled" | "incomplete_expired" | others → "free"
+
+  await db
+    .update(users)
+    .set({
+      plan,
+      planPeriodStart: periodStart,
+      planPeriodEnd: periodEnd,
+      stripeSubscriptionId: subscription.id,
+    })
+    .where(eq(users.id, user.id));
+
+  log.info({ userId: user.id, status, plan }, "customer.subscription.updated: plan refreshed");
+}
+
+/**
+ * customer.subscription.deleted
+ * Reverts user to free plan, clears subscription ID, resets usage counter.
+ */
+async function handleSubscriptionDeleted(
+  subscription: Stripe.Subscription,
+  log: ReturnType<typeof createRequestLogger>
+) {
+  const customerId =
+    typeof subscription.customer === "string"
+      ? subscription.customer
+      : subscription.customer.id;
+
+  const [user] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.stripeCustomerId, customerId));
+
+  if (!user) {
+    log.warn({ customerId }, "customer.subscription.deleted: no user found — skipping");
+    return;
+  }
+
+  await db
+    .update(users)
+    .set({
+      plan: "free",
+      stripeSubscriptionId: null,
+      planPeriodStart: null,
+      planPeriodEnd: null,
+      pastDueAt: null,
+    })
+    .where(eq(users.id, user.id));
+
+  // Reset interview_usage for the current period
+  const periodStart = new Date();
+  periodStart.setDate(1);
+  periodStart.setHours(0, 0, 0, 0);
+
+  await db
+    .delete(interviewUsage)
+    .where(eq(interviewUsage.userId, user.id));
+
+  log.info({ userId: user.id }, "customer.subscription.deleted: plan reset to free, usage cleared");
+}
+
+/**
+ * invoice.payment_failed
+ * Sets past_due_at timestamp on the user row.
+ */
+async function handleInvoicePaymentFailed(
+  invoice: Stripe.Invoice,
+  log: ReturnType<typeof createRequestLogger>
+) {
+  const customerId =
+    typeof invoice.customer === "string"
+      ? invoice.customer
+      : (invoice.customer as Stripe.Customer | null)?.id;
+
+  if (!customerId) {
+    log.warn("invoice.payment_failed: no customer id on invoice — skipping");
+    return;
+  }
+
+  const [user] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.stripeCustomerId, customerId));
+
+  if (!user) {
+    log.warn({ customerId }, "invoice.payment_failed: no user found — skipping");
+    return;
+  }
+
+  await db
+    .update(users)
+    .set({ pastDueAt: new Date() })
+    .where(eq(users.id, user.id));
+
+  log.info({ userId: user.id }, "invoice.payment_failed: past_due_at set");
+}

--- a/apps/web/drizzle/0007_slow_smasher.sql
+++ b/apps/web/drizzle/0007_slow_smasher.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "past_due_at" timestamp with time zone;

--- a/apps/web/drizzle/meta/0007_snapshot.json
+++ b/apps/web/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,984 @@
+{
+  "id": "192306d7-cc0b-4bc4-bb78-414f203a5dfe",
+  "prevId": "4e89bb6e-0fc2-46c2-8493-f5f8bbe5e521",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.code_snapshots": {
+      "name": "code_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "code_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_result": {
+          "name": "execution_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "code_snapshots_session_id_interview_sessions_id_fk": {
+          "name": "code_snapshots_session_id_interview_sessions_id_fk",
+          "tableFrom": "code_snapshots",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_questions": {
+      "name": "company_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_questions_user_id_users_id_fk": {
+          "name": "company_questions_user_id_users_id_fk",
+          "tableFrom": "company_questions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_plans": {
+      "name": "interview_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interview_date": {
+          "name": "interview_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_data": {
+          "name": "plan_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_plans_user_id_users_id_fk": {
+          "name": "interview_plans_user_id_users_id_fk",
+          "tableFrom": "interview_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_sessions": {
+      "name": "interview_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'configuring'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_sessions_user_id_users_id_fk": {
+          "name": "interview_sessions_user_id_users_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_usage": {
+      "name": "interview_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "interview_usage_user_period_unique": {
+          "name": "interview_usage_user_period_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interview_usage_user_id_users_id_fk": {
+          "name": "interview_usage_user_id_users_id_fk",
+          "tableFrom": "interview_usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_feedback": {
+      "name": "session_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_score": {
+          "name": "overall_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strengths": {
+          "name": "strengths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "weaknesses": {
+          "name": "weaknesses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "answer_analyses": {
+          "name": "answer_analyses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "code_quality_score": {
+          "name": "code_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation_quality_score": {
+          "name": "explanation_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeline_analysis": {
+          "name": "timeline_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_feedback_session_id_interview_sessions_id_fk": {
+          "name": "session_feedback_session_id_interview_sessions_id_fk",
+          "tableFrom": "session_feedback",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_templates": {
+      "name": "session_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_templates_user_id_users_id_fk": {
+          "name": "session_templates_user_id_users_id_fk",
+          "tableFrom": "session_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcripts": {
+      "name": "transcripts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcripts_session_id_interview_sessions_id_fk": {
+          "name": "transcripts_session_id_interview_sessions_id_fk",
+          "tableFrom": "transcripts",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_badge_unique": {
+          "name": "user_badge_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "badge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_resumes": {
+      "name": "user_resumes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_resumes_user_id_users_id_fk": {
+          "name": "user_resumes_user_id_users_id_fk",
+          "tableFrom": "user_resumes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "user_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_start": {
+          "name": "plan_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_end": {
+          "name": "plan_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "past_due_at": {
+          "name": "past_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.code_event_type": {
+      "name": "code_event_type",
+      "schema": "public",
+      "values": [
+        "edit",
+        "run",
+        "submit"
+      ]
+    },
+    "public.interview_type": {
+      "name": "interview_type",
+      "schema": "public",
+      "values": [
+        "behavioral",
+        "technical"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "configuring",
+        "in_progress",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.user_plan": {
+      "name": "user_plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "max"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1776254159957,
       "tag": "0006_silly_banshee",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1776257828145,
+      "tag": "0007_slow_smasher",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/schema.ts
+++ b/apps/web/lib/schema.ts
@@ -51,6 +51,7 @@ export const users = pgTable("users", {
   stripeSubscriptionId: text("stripe_subscription_id"),
   planPeriodStart: timestamp("plan_period_start", { withTimezone: true }),
   planPeriodEnd: timestamp("plan_period_end", { withTimezone: true }),
+  pastDueAt: timestamp("past_due_at", { withTimezone: true }),
   disabledAt: timestamp("disabled_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -1,0 +1,13 @@
+/**
+ * Stripe singleton client.
+ * Import `stripe` anywhere server-side; never expose it to client bundles.
+ */
+import Stripe from "stripe";
+
+if (!process.env.STRIPE_SECRET_KEY && process.env.NODE_ENV === "production") {
+  throw new Error("STRIPE_SECRET_KEY is not set");
+}
+
+export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? "sk_test_placeholder", {
+  apiVersion: "2026-03-25.dahlia",
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,6 +42,7 @@
     "react-dom": "19.2.4",
     "recharts": "^3.8.1",
     "shadcn": "^4.2.0",
+    "stripe": "^22.0.1",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "react-dom": "19.2.4",
         "recharts": "^3.8.1",
         "shadcn": "^4.2.0",
+        "stripe": "^22.0.1",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
         "zod": "^4.3.6",
@@ -15076,6 +15077,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.0.1.tgz",
+      "integrity": "sha512-Yw764pZ6s8Xu4CtUZdD5uWOkw6gc9xzO9OKylCuj1gMhMDLbyGbDtaPNNSFE4mB6njYSHESYIVbF1iIzUfAl2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/styled-jsx": {


### PR DESCRIPTION
## Summary

- Adds `POST /api/billing/checkout` — creates or reuses a Stripe customer, starts a Checkout Session in subscription mode, returns `{ url }` for client redirect. Protected by `auth()` and `checkRateLimit()`.
- Adds `POST /api/billing/webhook` — verifies Stripe signatures, handles `checkout.session.completed` (idempotent), `customer.subscription.updated`, `customer.subscription.deleted`, `invoice.payment_failed`. Returns 200 on stale-user noise so Stripe does not retry indefinitely.
- Adds `past_due_at TIMESTAMPTZ NULL` column to `users` via migration `0007_slow_smasher.sql`. Reads `subscription.items.data[0]` for period timestamps (correct Stripe v22 pattern).

Closes #36
Part of #34

## Manual setup required before this works in prod

1. **Stripe Dashboard** — create a "Pro" product with a recurring monthly price. Copy the `price_...` ID.
2. **Vercel env vars** — set `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRO_PRICE_ID`.
3. **Webhook endpoint** — in Stripe Dashboard → Developers → Webhooks, add `https://<domain>/api/billing/webhook` with events `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`, `invoice.payment_failed`. Copy the signing secret into `STRIPE_WEBHOOK_SECRET`.
4. **Local dev** — copy `apps/web/.env.local.example` to `.env.local`, then `stripe listen --forward-to localhost:3000/api/billing/webhook`.

## Pre-merge notes

**Migration collision with #39 (STAR helper):** the parallel Wave 2 branch `feature/39-star-story-helper` also generates migration `0007`. Whichever lands second must rebase onto main and regenerate its migration:
```bash
cd apps/web
git rebase origin/main
npm run db:generate   # produces 0008_*
git add drizzle/
git rebase --continue
```
Coordinate before merging either; do not merge both without this step.

## Test plan

- [x] `npx turbo lint typecheck test` — 410 unit/component tests green
- [x] `npm run test:integration` — 213 integration tests green (18 new for billing, including rate-limit 429 branch and Stripe v22 `items.data[0]` extraction)
- [ ] Manual smoke: start `stripe listen`, hit `/api/billing/checkout`, complete a test checkout, verify `users.plan` flips to `"pro"` and `plan_period_end` matches the Stripe subscription period
- [ ] `past_due_at` migration applied cleanly on staging DB
- [ ] Reviewer approves

🤖 Generated with [Claude Code](https://claude.com/claude-code)