### PR TITLE
feat(star): STAR story prep helper with AI scoring (#39)

### DIFF
--- a/apps/web/app/api/star/[id]/analyze/route.integration.test.ts
+++ b/apps/web/app/api/star/[id]/analyze/route.integration.test.ts
@@ -1,0 +1,223 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import {
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../../../tests/setup-db";
+import { users, starStories, starStoryAnalyses } from "@/lib/schema";
+
+const mockAuth = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return getTestDb();
+  },
+}));
+
+// Mock rate limiter to allow by default
+const mockCheckRateLimit = vi.fn<() => NextResponse | null>(() => null);
+vi.mock("@/lib/api-utils", () => ({
+  checkRateLimit: () => mockCheckRateLimit(),
+}));
+
+// Mock OpenAI — use vi.hoisted so mockCreate is available when the factory runs
+const mockCreate = vi.hoisted(() => vi.fn());
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    chat = { completions: { create: mockCreate } };
+  },
+}));
+
+vi.stubEnv("OPENAI_API_KEY", "sk-integration-test");
+
+import { POST } from "./route";
+
+const TEST_USER = {
+  id: "00000000-0000-0000-0000-000000000001",
+  email: "test@example.com",
+  name: "Test User",
+};
+
+const OTHER_USER = {
+  id: "00000000-0000-0000-0000-000000000002",
+  email: "other@example.com",
+  name: "Other User",
+};
+
+const BASE_STORY = {
+  title: "Led microservices migration",
+  role: "Senior Software Engineer",
+  expectedQuestions: ["Tell me about a technical leadership challenge"],
+  situation: "Our monolith caused 2-hour deploys.",
+  task: "Design a 3-month migration plan.",
+  action: "Broke system into 8 services.",
+  result: "Deploy cycles dropped to 10 minutes.",
+};
+
+const VALID_AI_RESPONSE = {
+  persuasiveness_score: 78,
+  persuasiveness_justification: "Compelling with concrete metrics.",
+  star_alignment_score: 85,
+  star_breakdown: {
+    situation: 90,
+    task: 80,
+    action: 85,
+    result: 85,
+  },
+  role_fit_score: 80,
+  role_fit_justification: "Strong alignment with engineering leadership.",
+  question_fit_score: 75,
+  question_fit_justification: "Addresses leadership but could be more direct.",
+  suggestions: [
+    "Add specific numbers to Action section",
+    "Clarify personal vs team contribution",
+    "Quantify business impact in Result",
+  ],
+};
+
+function makePostRequest(id: string): [NextRequest, { params: Promise<{ id: string }> }] {
+  return [
+    new NextRequest(`http://localhost:3000/api/star/${id}/analyze`, {
+      method: "POST",
+    }),
+    { params: Promise.resolve({ id }) },
+  ];
+}
+
+describe("POST /api/star/[id]/analyze (integration)", () => {
+  let storyId: string;
+
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values(TEST_USER).onConflictDoNothing();
+    await db.insert(users).values(OTHER_USER).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockCheckRateLimit.mockReturnValue(null); // allow by default
+    const db = getTestDb();
+    await db.delete(starStoryAnalyses);
+    await db.delete(starStories);
+
+    const [story] = await db
+      .insert(starStories)
+      .values({ userId: TEST_USER.id, ...BASE_STORY })
+      .returning();
+    storyId = story.id;
+
+    // Default: OpenAI returns valid response
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: JSON.stringify(VALID_AI_RESPONSE) } }],
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await POST(...makePostRequest(storyId));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for another user's story", async () => {
+    mockAuth.mockResolvedValue({ user: { id: OTHER_USER.id } });
+    const res = await POST(...makePostRequest(storyId));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for non-existent story", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(
+      ...makePostRequest("00000000-0000-0000-0000-000000000099")
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    mockCheckRateLimit.mockReturnValue(
+      NextResponse.json({ error: "Too many requests" }, { status: 429 })
+    );
+    const res = await POST(...makePostRequest(storyId));
+    expect(res.status).toBe(429);
+  });
+
+  it("creates and returns an analysis on happy path", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(...makePostRequest(storyId));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.id).toBeDefined();
+    expect(data.storyId).toBe(storyId);
+    expect(data.model).toBeDefined();
+  });
+
+  it("persists the analysis in the database", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(...makePostRequest(storyId));
+    expect(res.status).toBe(201);
+    const responseData = await res.json();
+
+    const db = getTestDb();
+    const [found] = await db
+      .select()
+      .from(starStoryAnalyses)
+      .where(eq(starStoryAnalyses.id, responseData.id));
+    expect(found).toBeDefined();
+    expect(found.storyId).toBe(storyId);
+    expect(found.suggestions).toBeDefined();
+  });
+
+  it("stores suggestions separately from scores", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(...makePostRequest(storyId));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    // suggestions stored separately, scores don't include suggestions
+    expect(Array.isArray(data.suggestions)).toBe(true);
+    expect(
+      (data.scores as Record<string, unknown>).suggestions
+    ).toBeUndefined();
+  });
+
+  it("returns 500 when AI returns malformed JSON after retries", async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: "not valid json {{{" } }],
+    });
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(...makePostRequest(storyId));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 500 when AI returns invalid schema after retries", async () => {
+    mockCreate.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({ completely: "wrong", schema: true }),
+          },
+        },
+      ],
+    });
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(...makePostRequest(storyId));
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/web/app/api/star/[id]/analyze/route.ts
+++ b/apps/web/app/api/star/[id]/analyze/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { starStories, starStoryAnalyses } from "@/lib/schema";
+import { and, eq } from "drizzle-orm";
+import { createRequestLogger } from "@/lib/logger";
+import { checkRateLimit } from "@/lib/api-utils";
+import OpenAI from "openai";
+import {
+  buildStarAnalysisPrompt,
+  STAR_ANALYSIS_MODEL,
+  STAR_ANALYSIS_SYSTEM_PROMPT,
+  type StarStoryInput,
+} from "@/lib/star-prompt-builder";
+import { starAnalysisResponseSchema } from "@/lib/star-analysis-schema";
+import { OpenAIRetryError, withOpenAIRetry } from "@/lib/openai-retry";
+
+// POST /api/star/[id]/analyze — run AI analysis on a STAR story
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const rateLimitResponse = checkRateLimit(session.user.id);
+  if (rateLimitResponse) return rateLimitResponse;
+
+  const log = createRequestLogger({
+    route: "POST /api/star/[id]/analyze",
+    userId: session.user.id,
+    storyId: id,
+  });
+
+  // Fetch and verify ownership
+  const [story] = await db
+    .select()
+    .from(starStories)
+    .where(
+      and(eq(starStories.id, id), eq(starStories.userId, session.user.id))
+    );
+
+  if (!story) {
+    return NextResponse.json({ error: "Story not found" }, { status: 404 });
+  }
+
+  const storyInput: StarStoryInput = {
+    title: story.title,
+    role: story.role,
+    expectedQuestions: (story.expectedQuestions as string[]) ?? [],
+    situation: story.situation,
+    task: story.task,
+    action: story.action,
+    result: story.result,
+  };
+
+  const prompt = buildStarAnalysisPrompt(storyInput);
+
+  try {
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+    const analysisResult = await withOpenAIRetry(
+      () =>
+        openai.chat.completions.create({
+          model: STAR_ANALYSIS_MODEL,
+          messages: [
+            { role: "system", content: STAR_ANALYSIS_SYSTEM_PROMPT },
+            { role: "user", content: prompt },
+          ],
+          response_format: { type: "json_object" },
+          temperature: 0.3,
+          max_completion_tokens: 2000,
+        }),
+      (raw) => {
+        let json: unknown;
+        try {
+          json = JSON.parse(raw);
+        } catch (e) {
+          throw new OpenAIRetryError("invalid_json", e);
+        }
+        const validated = starAnalysisResponseSchema.safeParse(json);
+        if (!validated.success) {
+          throw new OpenAIRetryError("schema_mismatch", validated.error);
+        }
+        return validated.data;
+      },
+      { service: "star-analysis", log }
+    );
+
+    const { suggestions, ...scores } = analysisResult;
+
+    const [analysis] = await db
+      .insert(starStoryAnalyses)
+      .values({
+        storyId: id,
+        scores,
+        suggestions,
+        model: STAR_ANALYSIS_MODEL,
+      })
+      .returning();
+
+    log.info({ analysisId: analysis.id }, "STAR story analysis complete");
+    return NextResponse.json(analysis, { status: 201 });
+  } catch (err) {
+    if (err instanceof OpenAIRetryError) {
+      log.error({ err, reason: err.reason }, "AI analysis failed after retry");
+      return NextResponse.json(
+        { error: "AI analysis failed. Please try again." },
+        { status: 500 }
+      );
+    }
+    log.error({ err }, "unexpected error during STAR analysis");
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/api/star/[id]/route.integration.test.ts
+++ b/apps/web/app/api/star/[id]/route.integration.test.ts
@@ -1,0 +1,329 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "vitest";
+import { NextRequest } from "next/server";
+import { eq } from "drizzle-orm";
+import {
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../../tests/setup-db";
+import { users, starStories, starStoryAnalyses } from "@/lib/schema";
+
+const mockAuth = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return getTestDb();
+  },
+}));
+
+import { GET, PATCH, DELETE } from "./route";
+
+const TEST_USER = {
+  id: "00000000-0000-0000-0000-000000000001",
+  email: "test@example.com",
+  name: "Test User",
+};
+
+const OTHER_USER = {
+  id: "00000000-0000-0000-0000-000000000002",
+  email: "other@example.com",
+  name: "Other User",
+};
+
+const BASE_STORY = {
+  title: "Led microservices migration",
+  role: "Senior Software Engineer",
+  expectedQuestions: ["Tell me about a technical leadership challenge"],
+  situation: "Our monolith caused 2-hour deploys.",
+  task: "Design a 3-month migration plan.",
+  action: "Broke system into 8 services.",
+  result: "Deploy cycles dropped to 10 minutes.",
+};
+
+function makeRequest(
+  method: string,
+  id: string,
+  body?: unknown
+): [NextRequest, { params: Promise<{ id: string }> }] {
+  if (body !== undefined) {
+    return [
+      new NextRequest(`http://localhost:3000/api/star/${id}`, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+      { params: Promise.resolve({ id }) },
+    ];
+  }
+  return [
+    new NextRequest(`http://localhost:3000/api/star/${id}`, { method }),
+    { params: Promise.resolve({ id }) },
+  ];
+}
+
+describe("GET /api/star/[id] (integration)", () => {
+  let storyId: string;
+
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values(TEST_USER).onConflictDoNothing();
+    await db.insert(users).values(OTHER_USER).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const db = getTestDb();
+    await db.delete(starStoryAnalyses);
+    await db.delete(starStories);
+
+    const [story] = await db
+      .insert(starStories)
+      .values({ userId: TEST_USER.id, ...BASE_STORY })
+      .returning();
+    storyId = story.id;
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await GET(...makeRequest("GET", storyId));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for another user's story (no existence leak)", async () => {
+    mockAuth.mockResolvedValue({ user: { id: OTHER_USER.id } });
+    const res = await GET(...makeRequest("GET", storyId));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for non-existent story", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await GET(
+      ...makeRequest("GET", "00000000-0000-0000-0000-000000000099")
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns story with empty analyses array on happy path", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await GET(...makeRequest("GET", storyId));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.story.id).toBe(storyId);
+    expect(data.story.title).toBe(BASE_STORY.title);
+    expect(data.analyses).toEqual([]);
+  });
+
+  it("returns analyses sorted newest first", async () => {
+    const db = getTestDb();
+    await db.insert(starStoryAnalyses).values([
+      {
+        storyId,
+        scores: { persuasiveness_score: 70 },
+        suggestions: ["Improve A"],
+        model: "gpt-5.4-mini",
+        createdAt: new Date("2026-04-01"),
+      },
+      {
+        storyId,
+        scores: { persuasiveness_score: 80 },
+        suggestions: ["Improve B"],
+        model: "gpt-5.4-mini",
+        createdAt: new Date("2026-04-10"),
+      },
+    ]);
+
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await GET(...makeRequest("GET", storyId));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.analyses).toHaveLength(2);
+    // Most recent first
+    expect((data.analyses[0].scores as Record<string, number>).persuasiveness_score).toBe(80);
+  });
+});
+
+describe("PATCH /api/star/[id] (integration)", () => {
+  let storyId: string;
+
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values(TEST_USER).onConflictDoNothing();
+    await db.insert(users).values(OTHER_USER).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const db = getTestDb();
+    await db.delete(starStoryAnalyses);
+    await db.delete(starStories);
+
+    const [story] = await db
+      .insert(starStories)
+      .values({ userId: TEST_USER.id, ...BASE_STORY })
+      .returning();
+    storyId = story.id;
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await PATCH(...makeRequest("PATCH", storyId, { title: "Updated" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for another user's story", async () => {
+    mockAuth.mockResolvedValue({ user: { id: OTHER_USER.id } });
+    const res = await PATCH(
+      ...makeRequest("PATCH", storyId, { title: "Sneaky Update" })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for invalid data (title too long)", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await PATCH(
+      ...makeRequest("PATCH", storyId, { title: "x".repeat(201) })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("updates title and returns updated story", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await PATCH(
+      ...makeRequest("PATCH", storyId, { title: "New Title" })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.title).toBe("New Title");
+  });
+
+  it("partial update: only updates provided fields", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await PATCH(
+      ...makeRequest("PATCH", storyId, { role: "Staff Engineer" })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.role).toBe("Staff Engineer");
+    expect(data.title).toBe(BASE_STORY.title); // Unchanged
+  });
+
+  it("persists the update in the database", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    await PATCH(...makeRequest("PATCH", storyId, { result: "New result text" }));
+
+    const db = getTestDb();
+    const [found] = await db
+      .select()
+      .from(starStories)
+      .where(eq(starStories.id, storyId));
+    expect(found.result).toBe("New result text");
+  });
+});
+
+describe("DELETE /api/star/[id] (integration)", () => {
+  let storyId: string;
+
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values(TEST_USER).onConflictDoNothing();
+    await db.insert(users).values(OTHER_USER).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const db = getTestDb();
+    await db.delete(starStoryAnalyses);
+    await db.delete(starStories);
+
+    const [story] = await db
+      .insert(starStories)
+      .values({ userId: TEST_USER.id, ...BASE_STORY })
+      .returning();
+    storyId = story.id;
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await DELETE(...makeRequest("DELETE", storyId));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for another user's story", async () => {
+    mockAuth.mockResolvedValue({ user: { id: OTHER_USER.id } });
+    const res = await DELETE(...makeRequest("DELETE", storyId));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for non-existent story", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await DELETE(
+      ...makeRequest("DELETE", "00000000-0000-0000-0000-000000000099")
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("deletes the story and returns success", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await DELETE(...makeRequest("DELETE", storyId));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+  });
+
+  it("actually removes the story from the database", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    await DELETE(...makeRequest("DELETE", storyId));
+
+    const db = getTestDb();
+    const [found] = await db
+      .select()
+      .from(starStories)
+      .where(eq(starStories.id, storyId));
+    expect(found).toBeUndefined();
+  });
+
+  it("cascades deletion to analyses", async () => {
+    const db = getTestDb();
+    await db.insert(starStoryAnalyses).values({
+      storyId,
+      scores: { persuasiveness_score: 75 },
+      suggestions: ["Improve A"],
+      model: "gpt-5.4-mini",
+    });
+
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    await DELETE(...makeRequest("DELETE", storyId));
+
+    const analyses = await db
+      .select()
+      .from(starStoryAnalyses)
+      .where(eq(starStoryAnalyses.storyId, storyId));
+    expect(analyses).toHaveLength(0);
+  });
+});

--- a/apps/web/app/api/star/[id]/route.ts
+++ b/apps/web/app/api/star/[id]/route.ts
@@ -23,25 +23,33 @@ export async function GET(
     storyId: id,
   });
 
-  const [story] = await db
-    .select()
-    .from(starStories)
-    .where(
-      and(eq(starStories.id, id), eq(starStories.userId, session.user.id))
+  try {
+    const [story] = await db
+      .select()
+      .from(starStories)
+      .where(
+        and(eq(starStories.id, id), eq(starStories.userId, session.user.id))
+      );
+
+    if (!story) {
+      return NextResponse.json({ error: "Story not found" }, { status: 404 });
+    }
+
+    const analyses = await db
+      .select()
+      .from(starStoryAnalyses)
+      .where(eq(starStoryAnalyses.storyId, id))
+      .orderBy(desc(starStoryAnalyses.createdAt));
+
+    log.info({ analysesCount: analyses.length }, "fetched STAR story");
+    return NextResponse.json({ story, analyses });
+  } catch (err) {
+    log.error({ err }, "failed to fetch STAR story");
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
     );
-
-  if (!story) {
-    return NextResponse.json({ error: "Story not found" }, { status: 404 });
   }
-
-  const analyses = await db
-    .select()
-    .from(starStoryAnalyses)
-    .where(eq(starStoryAnalyses.storyId, id))
-    .orderBy(desc(starStoryAnalyses.createdAt));
-
-  log.info({ analysesCount: analyses.length }, "fetched STAR story");
-  return NextResponse.json({ story, analyses });
 }
 
 // PATCH /api/star/[id] — update a STAR story
@@ -76,39 +84,49 @@ export async function PATCH(
     );
   }
 
-  // Verify ownership first
-  const [existing] = await db
-    .select()
-    .from(starStories)
-    .where(
-      and(eq(starStories.id, id), eq(starStories.userId, session.user.id))
+  try {
+    // Verify ownership first
+    const [existing] = await db
+      .select()
+      .from(starStories)
+      .where(
+        and(eq(starStories.id, id), eq(starStories.userId, session.user.id))
+      );
+
+    if (!existing) {
+      return NextResponse.json({ error: "Story not found" }, { status: 404 });
+    }
+
+    const updateData: Partial<typeof starStories.$inferInsert> = {};
+    if (parsed.data.title !== undefined) updateData.title = parsed.data.title;
+    if (parsed.data.role !== undefined) updateData.role = parsed.data.role;
+    if (parsed.data.expectedQuestions !== undefined)
+      updateData.expectedQuestions = parsed.data.expectedQuestions;
+    if (parsed.data.situation !== undefined)
+      updateData.situation = parsed.data.situation;
+    if (parsed.data.task !== undefined) updateData.task = parsed.data.task;
+    if (parsed.data.action !== undefined)
+      updateData.action = parsed.data.action;
+    if (parsed.data.result !== undefined)
+      updateData.result = parsed.data.result;
+
+    const [updated] = await db
+      .update(starStories)
+      .set(updateData)
+      .where(
+        and(eq(starStories.id, id), eq(starStories.userId, session.user.id))
+      )
+      .returning();
+
+    log.info("updated STAR story");
+    return NextResponse.json(updated);
+  } catch (err) {
+    log.error({ err }, "failed to update STAR story");
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
     );
-
-  if (!existing) {
-    return NextResponse.json({ error: "Story not found" }, { status: 404 });
   }
-
-  const updateData: Partial<typeof starStories.$inferInsert> = {};
-  if (parsed.data.title !== undefined) updateData.title = parsed.data.title;
-  if (parsed.data.role !== undefined) updateData.role = parsed.data.role;
-  if (parsed.data.expectedQuestions !== undefined)
-    updateData.expectedQuestions = parsed.data.expectedQuestions;
-  if (parsed.data.situation !== undefined)
-    updateData.situation = parsed.data.situation;
-  if (parsed.data.task !== undefined) updateData.task = parsed.data.task;
-  if (parsed.data.action !== undefined) updateData.action = parsed.data.action;
-  if (parsed.data.result !== undefined) updateData.result = parsed.data.result;
-
-  const [updated] = await db
-    .update(starStories)
-    .set(updateData)
-    .where(
-      and(eq(starStories.id, id), eq(starStories.userId, session.user.id))
-    )
-    .returning();
-
-  log.info("updated STAR story");
-  return NextResponse.json(updated);
 }
 
 // DELETE /api/star/[id] — delete a STAR story (cascade to analyses)
@@ -128,17 +146,25 @@ export async function DELETE(
     storyId: id,
   });
 
-  const [deleted] = await db
-    .delete(starStories)
-    .where(
-      and(eq(starStories.id, id), eq(starStories.userId, session.user.id))
-    )
-    .returning();
+  try {
+    const [deleted] = await db
+      .delete(starStories)
+      .where(
+        and(eq(starStories.id, id), eq(starStories.userId, session.user.id))
+      )
+      .returning();
 
-  if (!deleted) {
-    return NextResponse.json({ error: "Story not found" }, { status: 404 });
+    if (!deleted) {
+      return NextResponse.json({ error: "Story not found" }, { status: 404 });
+    }
+
+    log.info("deleted STAR story");
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    log.error({ err }, "failed to delete STAR story");
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
   }
-
-  log.info("deleted STAR story");
-  return NextResponse.json({ success: true });
 }

--- a/apps/web/app/api/star/[id]/route.ts
+++ b/apps/web/app/api/star/[id]/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { starStories, starStoryAnalyses } from "@/lib/schema";
+import { and, desc, eq } from "drizzle-orm";
+import { createRequestLogger } from "@/lib/logger";
+import { updateStarStorySchema } from "@/lib/validations";
+
+// GET /api/star/[id] — fetch a specific STAR story with its analyses
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const log = createRequestLogger({
+    route: "GET /api/star/[id]",
+    userId: session.user.id,
+    storyId: id,
+  });
+
+  const [story] = await db
+    .select()
+    .from(starStories)
+    .where(
+      and(eq(starStories.id, id), eq(starStories.userId, session.user.id))
+    );
+
+  if (!story) {
+    return NextResponse.json({ error: "Story not found" }, { status: 404 });
+  }
+
+  const analyses = await db
+    .select()
+    .from(starStoryAnalyses)
+    .where(eq(starStoryAnalyses.storyId, id))
+    .orderBy(desc(starStoryAnalyses.createdAt));
+
+  log.info({ analysesCount: analyses.length }, "fetched STAR story");
+  return NextResponse.json({ story, analyses });
+}
+
+// PATCH /api/star/[id] — update a STAR story
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const log = createRequestLogger({
+    route: "PATCH /api/star/[id]",
+    userId: session.user.id,
+    storyId: id,
+  });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const parsed = updateStarStorySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request", details: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  // Verify ownership first
+  const [existing] = await db
+    .select()
+    .from(starStories)
+    .where(
+      and(eq(starStories.id, id), eq(starStories.userId, session.user.id))
+    );
+
+  if (!existing) {
+    return NextResponse.json({ error: "Story not found" }, { status: 404 });
+  }
+
+  const updateData: Partial<typeof starStories.$inferInsert> = {};
+  if (parsed.data.title !== undefined) updateData.title = parsed.data.title;
+  if (parsed.data.role !== undefined) updateData.role = parsed.data.role;
+  if (parsed.data.expectedQuestions !== undefined)
+    updateData.expectedQuestions = parsed.data.expectedQuestions;
+  if (parsed.data.situation !== undefined)
+    updateData.situation = parsed.data.situation;
+  if (parsed.data.task !== undefined) updateData.task = parsed.data.task;
+  if (parsed.data.action !== undefined) updateData.action = parsed.data.action;
+  if (parsed.data.result !== undefined) updateData.result = parsed.data.result;
+
+  const [updated] = await db
+    .update(starStories)
+    .set(updateData)
+    .where(
+      and(eq(starStories.id, id), eq(starStories.userId, session.user.id))
+    )
+    .returning();
+
+  log.info("updated STAR story");
+  return NextResponse.json(updated);
+}
+
+// DELETE /api/star/[id] — delete a STAR story (cascade to analyses)
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const log = createRequestLogger({
+    route: "DELETE /api/star/[id]",
+    userId: session.user.id,
+    storyId: id,
+  });
+
+  const [deleted] = await db
+    .delete(starStories)
+    .where(
+      and(eq(starStories.id, id), eq(starStories.userId, session.user.id))
+    )
+    .returning();
+
+  if (!deleted) {
+    return NextResponse.json({ error: "Story not found" }, { status: 404 });
+  }
+
+  log.info("deleted STAR story");
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/app/api/star/route.integration.test.ts
+++ b/apps/web/app/api/star/route.integration.test.ts
@@ -1,0 +1,284 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "vitest";
+import { NextRequest } from "next/server";
+import { eq } from "drizzle-orm";
+import {
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../tests/setup-db";
+import { users, starStories } from "@/lib/schema";
+
+const mockAuth = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return getTestDb();
+  },
+}));
+
+import { GET, POST } from "./route";
+
+const TEST_USER = {
+  id: "00000000-0000-0000-0000-000000000001",
+  email: "test@example.com",
+  name: "Test User",
+};
+
+const OTHER_USER = {
+  id: "00000000-0000-0000-0000-000000000002",
+  email: "other@example.com",
+  name: "Other User",
+};
+
+const VALID_STORY_BODY = {
+  title: "Led microservices migration",
+  role: "Senior Software Engineer",
+  expectedQuestions: ["Tell me about a technical leadership challenge"],
+  situation: "Our monolith caused 2-hour deploys and was blocking 5 teams.",
+  task: "I was tasked with designing a 3-month migration plan.",
+  action: "I broke the system into 8 services and created migration runbooks.",
+  result: "Deploy cycles dropped from 2 hours to 10 minutes.",
+};
+
+function makeGetRequest(queryParams = ""): NextRequest {
+  return new NextRequest(
+    `http://localhost:3000/api/star${queryParams ? `?${queryParams}` : ""}`
+  );
+}
+
+function makePostRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3000/api/star", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("GET /api/star (integration)", () => {
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values(TEST_USER).onConflictDoNothing();
+    await db.insert(users).values(OTHER_USER).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const db = getTestDb();
+    await db.delete(starStories);
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns empty stories array for user with no stories", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.stories).toEqual([]);
+    expect(data.pagination.total).toBe(0);
+  });
+
+  it("returns only the current user's stories", async () => {
+    const db = getTestDb();
+    await db.insert(starStories).values([
+      {
+        userId: TEST_USER.id,
+        title: "My Story",
+        role: "SWE",
+        expectedQuestions: ["Question 1"],
+        situation: "S",
+        task: "T",
+        action: "A",
+        result: "R",
+      },
+      {
+        userId: OTHER_USER.id,
+        title: "Other's Story",
+        role: "PM",
+        expectedQuestions: ["Question 2"],
+        situation: "S",
+        task: "T",
+        action: "A",
+        result: "R",
+      },
+    ]);
+
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.stories).toHaveLength(1);
+    expect(data.stories[0].title).toBe("My Story");
+  });
+
+  it("returns paginated results with correct pagination metadata", async () => {
+    const db = getTestDb();
+    await db.insert(starStories).values(
+      Array.from({ length: 5 }, (_, i) => ({
+        userId: TEST_USER.id,
+        title: `Story ${i + 1}`,
+        role: "SWE",
+        expectedQuestions: ["Q1"],
+        situation: "S",
+        task: "T",
+        action: "A",
+        result: "R",
+      }))
+    );
+
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await GET(makeGetRequest("page=1&limit=2"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.stories).toHaveLength(2);
+    expect(data.pagination.total).toBe(5);
+    expect(data.pagination.totalPages).toBe(3);
+    expect(data.pagination.page).toBe(1);
+    expect(data.pagination.limit).toBe(2);
+  });
+
+  it("returns second page of results", async () => {
+    const db = getTestDb();
+    await db.insert(starStories).values(
+      Array.from({ length: 3 }, (_, i) => ({
+        userId: TEST_USER.id,
+        title: `Story ${i + 1}`,
+        role: "SWE",
+        expectedQuestions: ["Q1"],
+        situation: "S",
+        task: "T",
+        action: "A",
+        result: "R",
+      }))
+    );
+
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await GET(makeGetRequest("page=2&limit=2"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.stories).toHaveLength(1);
+    expect(data.pagination.total).toBe(3);
+  });
+
+  it("returns 400 for invalid page parameter", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await GET(makeGetRequest("page=0"));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/star (integration)", () => {
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values(TEST_USER).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const db = getTestDb();
+    await db.delete(starStories);
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await POST(makePostRequest(VALID_STORY_BODY));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for missing required fields", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(makePostRequest({ title: "Missing other fields" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for empty title", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(
+      makePostRequest({ ...VALID_STORY_BODY, title: "" })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for too many expected questions (>3)", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(
+      makePostRequest({
+        ...VALID_STORY_BODY,
+        expectedQuestions: ["Q1", "Q2", "Q3", "Q4"],
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for zero expected questions", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(
+      makePostRequest({ ...VALID_STORY_BODY, expectedQuestions: [] })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a story and returns 201 with story data", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(makePostRequest(VALID_STORY_BODY));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.id).toBeDefined();
+    expect(data.title).toBe(VALID_STORY_BODY.title);
+    expect(data.role).toBe(VALID_STORY_BODY.role);
+    expect(data.userId).toBe(TEST_USER.id);
+  });
+
+  it("persists the created story in the database", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(makePostRequest(VALID_STORY_BODY));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+
+    const db = getTestDb();
+    const [found] = await db
+      .select()
+      .from(starStories)
+      .where(eq(starStories.id, data.id));
+    expect(found).toBeDefined();
+    expect(found.title).toBe(VALID_STORY_BODY.title);
+    expect(found.situation).toBe(VALID_STORY_BODY.situation);
+    expect(found.action).toBe(VALID_STORY_BODY.action);
+  });
+
+  it("accepts exactly 3 expected questions (maximum)", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(
+      makePostRequest({
+        ...VALID_STORY_BODY,
+        expectedQuestions: ["Q1", "Q2", "Q3"],
+      })
+    );
+    expect(res.status).toBe(201);
+  });
+});

--- a/apps/web/app/api/star/route.ts
+++ b/apps/web/app/api/star/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { starStories } from "@/lib/schema";
+import { desc, eq, count } from "drizzle-orm";
+import { createRequestLogger } from "@/lib/logger";
+import {
+  createStarStorySchema,
+  listStarStoriesQuerySchema,
+} from "@/lib/validations";
+
+// GET /api/star — list current user's STAR stories (paginated)
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const log = createRequestLogger({
+    route: "GET /api/star",
+    userId: session.user.id,
+  });
+
+  const searchParams = Object.fromEntries(request.nextUrl.searchParams);
+  const parsed = listStarStoriesQuerySchema.safeParse(searchParams);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid query parameters", details: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  const { page, limit } = parsed.data;
+  const offset = (page - 1) * limit;
+
+  try {
+    const [stories, [{ total }]] = await Promise.all([
+      db
+        .select()
+        .from(starStories)
+        .where(eq(starStories.userId, session.user.id))
+        .orderBy(desc(starStories.updatedAt))
+        .limit(limit)
+        .offset(offset),
+      db
+        .select({ total: count() })
+        .from(starStories)
+        .where(eq(starStories.userId, session.user.id)),
+    ]);
+
+    log.info({ count: stories.length }, "listed STAR stories");
+    return NextResponse.json({
+      stories,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    });
+  } catch (err) {
+    log.error({ err }, "failed to list STAR stories");
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+// POST /api/star — create a new STAR story
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const log = createRequestLogger({
+    route: "POST /api/star",
+    userId: session.user.id,
+  });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const parsed = createStarStorySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request", details: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const [story] = await db
+      .insert(starStories)
+      .values({
+        userId: session.user.id,
+        title: parsed.data.title,
+        role: parsed.data.role,
+        expectedQuestions: parsed.data.expectedQuestions,
+        situation: parsed.data.situation,
+        task: parsed.data.task,
+        action: parsed.data.action,
+        result: parsed.data.result,
+      })
+      .returning();
+
+    log.info({ storyId: story.id }, "created STAR story");
+    return NextResponse.json(story, { status: 201 });
+  } catch (err) {
+    log.error({ err }, "failed to create STAR story");
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/star/page.test.tsx
+++ b/apps/web/app/star/page.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+
+// Mock next/navigation before any imports
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+import StarPrepPage from "./page";
+
+const MOCK_STORIES = [
+  {
+    id: "story-1",
+    title: "Led microservices migration",
+    role: "Senior Software Engineer",
+    expectedQuestions: ["Tell me about a technical challenge"],
+    situation: "Our monolith was slow.",
+    task: "Design migration plan.",
+    action: "Broke into 8 services.",
+    result: "Deploys went from 2h to 10min.",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    id: "story-2",
+    title: "Handled team conflict",
+    role: "Tech Lead",
+    expectedQuestions: ["Tell me about conflict resolution"],
+    situation: "Two engineers disagreed on architecture.",
+    task: "Mediate and decide.",
+    action: "Ran a structured design review.",
+    result: "Reached consensus in 2 days.",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+];
+
+const MOCK_DETAIL = {
+  story: MOCK_STORIES[0],
+  analyses: [],
+};
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ stories: MOCK_STORIES, pagination: { total: 2, page: 1, limit: 20, totalPages: 1 } }),
+  });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.clearAllMocks();
+});
+
+describe("StarPrepPage", () => {
+  it("renders the page title", async () => {
+    render(<StarPrepPage />);
+    expect(screen.getAllByText("STAR Story Prep").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders the new story button", () => {
+    render(<StarPrepPage />);
+    expect(screen.getAllByText("New Story").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows loading skeleton initially", () => {
+    render(<StarPrepPage />);
+    // Loading state shows skeleton elements with animate-pulse
+    const { container } = render(<StarPrepPage />);
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("renders stories after loading", async () => {
+    render(<StarPrepPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText("Led microservices migration").length).toBeGreaterThanOrEqual(1);
+    });
+    expect(screen.getAllByText("Handled team conflict").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows create form when New Story is clicked", async () => {
+    render(<StarPrepPage />);
+    const newStoryBtn = screen.getAllByText("New Story")[0];
+    fireEvent.click(newStoryBtn);
+    await waitFor(() => {
+      expect(screen.getAllByText("New Story").length).toBeGreaterThanOrEqual(1);
+    });
+    // Form should have story title field
+    expect(screen.getByLabelText("Story Title")).toBeTruthy();
+  });
+
+  it("shows story detail when a story is selected", async () => {
+    // Mock the detail fetch
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stories: MOCK_STORIES, pagination: { total: 2, page: 1, limit: 20, totalPages: 1 } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => MOCK_DETAIL,
+      });
+
+    render(<StarPrepPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Led microservices migration").length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Click on a story
+    const storyBtn = screen.getAllByText("Led microservices migration")[0];
+    fireEvent.click(storyBtn);
+
+    await waitFor(() => {
+      // Detail view shows the Get AI Feedback button and the story situation text
+      expect(screen.getAllByText("Get AI Feedback").length).toBeGreaterThanOrEqual(1);
+    });
+    // The situation text from the mock detail should be visible
+    expect(screen.getAllByText("Our monolith was slow.").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows empty state when no stories exist", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ stories: [], pagination: { total: 0, page: 1, limit: 20, totalPages: 0 } }),
+    });
+
+    render(<StarPrepPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText(/No stories yet/).length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("shows Practice this question button in detail view", async () => {
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stories: MOCK_STORIES, pagination: { total: 2, page: 1, limit: 20, totalPages: 1 } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => MOCK_DETAIL,
+      });
+
+    render(<StarPrepPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Led microservices migration").length).toBeGreaterThanOrEqual(1);
+    });
+
+    fireEvent.click(screen.getAllByText("Led microservices migration")[0]);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Practice this question").length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/apps/web/app/star/page.test.tsx
+++ b/apps/web/app/star/page.test.tsx
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 
-// Mock next/navigation before any imports
+// Mock next/navigation with the canonical vi.hoisted() + vi.mock() pattern
+// so the factory receives a hoisted ref before the import graph is evaluated.
+const { mockPush } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+}));
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({
-    push: vi.fn(),
-  }),
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => "/star",
 }));
 
 import StarPrepPage from "./page";

--- a/apps/web/app/star/page.tsx
+++ b/apps/web/app/star/page.tsx
@@ -1,0 +1,686 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { getScoreColor } from "@/lib/utils";
+import {
+  Star,
+  Plus,
+  Loader2,
+  Trash2,
+  Pencil,
+  X,
+  Sparkles,
+  PlayCircle,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+
+interface StarStory {
+  id: string;
+  title: string;
+  role: string;
+  expectedQuestions: string[];
+  situation: string;
+  task: string;
+  action: string;
+  result: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface StarAnalysis {
+  id: string;
+  storyId: string;
+  scores: {
+    persuasiveness_score: number;
+    persuasiveness_justification: string;
+    star_alignment_score: number;
+    star_breakdown: {
+      situation: number;
+      task: number;
+      action: number;
+      result: number;
+    };
+    role_fit_score: number;
+    role_fit_justification: string;
+    question_fit_score: number;
+    question_fit_justification: string;
+  };
+  suggestions: string[];
+  model: string;
+  createdAt: string;
+}
+
+interface StoryDetail {
+  story: StarStory;
+  analyses: StarAnalysis[];
+}
+
+const EMPTY_FORM = {
+  title: "",
+  role: "",
+  expectedQuestions: [""],
+  situation: "",
+  task: "",
+  action: "",
+  result: "",
+};
+
+function StorySkeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="h-20 w-full animate-pulse rounded-lg bg-muted" />
+      ))}
+    </div>
+  );
+}
+
+function ScoreBadge({ score, label }: { score: number; label: string }) {
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <span
+        className={`text-xl font-bold ${getScoreColor(score / 10)}`}
+      >
+        {Math.round(score)}
+      </span>
+      <span className="text-xs text-muted-foreground text-center">{label}</span>
+    </div>
+  );
+}
+
+function AnalysisCard({ analysis }: { analysis: StarAnalysis }) {
+  const [expanded, setExpanded] = useState(false);
+  const scores = analysis.scores;
+
+  return (
+    <div className="border rounded-lg p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-muted-foreground">
+          {new Date(analysis.createdAt).toLocaleString()}
+        </p>
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+        </button>
+      </div>
+
+      <div className="grid grid-cols-4 gap-4">
+        <ScoreBadge score={scores.persuasiveness_score} label="Persuasive" />
+        <ScoreBadge score={scores.star_alignment_score} label="STAR Align" />
+        <ScoreBadge score={scores.role_fit_score} label="Role Fit" />
+        <ScoreBadge score={scores.question_fit_score} label="Q Fit" />
+      </div>
+
+      {expanded && (
+        <div className="space-y-4 border-t pt-3">
+          <div>
+            <p className="text-sm font-medium mb-2">STAR Section Scores</p>
+            <div className="grid grid-cols-4 gap-2">
+              {Object.entries(scores.star_breakdown).map(([key, val]) => (
+                <div key={key} className="text-center">
+                  <span className={`text-sm font-semibold ${getScoreColor(val / 10)}`}>
+                    {Math.round(val)}
+                  </span>
+                  <p className="text-xs text-muted-foreground capitalize">{key}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid md:grid-cols-2 gap-3 text-sm">
+            <div>
+              <p className="font-medium text-xs text-muted-foreground mb-1">PERSUASIVENESS</p>
+              <p>{scores.persuasiveness_justification}</p>
+            </div>
+            <div>
+              <p className="font-medium text-xs text-muted-foreground mb-1">ROLE FIT</p>
+              <p>{scores.role_fit_justification}</p>
+            </div>
+            <div>
+              <p className="font-medium text-xs text-muted-foreground mb-1">QUESTION FIT</p>
+              <p>{scores.question_fit_justification}</p>
+            </div>
+          </div>
+
+          <div>
+            <p className="text-sm font-medium mb-2">Suggestions</p>
+            <ul className="space-y-1">
+              {analysis.suggestions.map((s, i) => (
+                <li key={i} className="flex gap-2 text-sm">
+                  <span className="text-muted-foreground shrink-0">{i + 1}.</span>
+                  <span>{s}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function StarPrepPage() {
+  const router = useRouter();
+  const [stories, setStories] = useState<StarStory[]>([]);
+  const [selectedDetail, setSelectedDetail] = useState<StoryDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [analyzing, setAnalyzing] = useState(false);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [questionInput, setQuestionInput] = useState("");
+
+  const fetchStories = useCallback(async () => {
+    try {
+      const res = await fetch("/api/star");
+      if (res.ok) {
+        const data = await res.json();
+        setStories(data.stories);
+      }
+    } catch {
+      // Silent — non-critical
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchStories();
+  }, [fetchStories]);
+
+  async function fetchDetail(id: string) {
+    setDetailLoading(true);
+    try {
+      const res = await fetch(`/api/star/${id}`);
+      if (res.ok) {
+        const data = await res.json();
+        setSelectedDetail(data);
+      }
+    } catch {
+      // Silent
+    } finally {
+      setDetailLoading(false);
+    }
+  }
+
+  function openCreate() {
+    setForm(EMPTY_FORM);
+    setEditing(false);
+    setShowForm(true);
+    setSelectedDetail(null);
+  }
+
+  function openEdit(story: StarStory) {
+    setForm({
+      title: story.title,
+      role: story.role,
+      expectedQuestions: story.expectedQuestions,
+      situation: story.situation,
+      task: story.task,
+      action: story.action,
+      result: story.result,
+    });
+    setEditing(true);
+    setShowForm(true);
+  }
+
+  function addQuestion() {
+    const q = questionInput.trim();
+    if (!q || form.expectedQuestions.length >= 3) return;
+    setForm((f) => ({
+      ...f,
+      expectedQuestions: [...f.expectedQuestions.filter(Boolean), q],
+    }));
+    setQuestionInput("");
+  }
+
+  function removeQuestion(idx: number) {
+    setForm((f) => ({
+      ...f,
+      expectedQuestions: f.expectedQuestions.filter((_, i) => i !== idx),
+    }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (saving) return;
+
+    const questions = form.expectedQuestions.filter(Boolean);
+    if (questions.length === 0) return;
+
+    setSaving(true);
+    try {
+      const body = { ...form, expectedQuestions: questions };
+
+      if (editing && selectedDetail) {
+        const res = await fetch(`/api/star/${selectedDetail.story.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        if (res.ok) {
+          const updated = await res.json();
+          setStories((prev) =>
+            prev.map((s) => (s.id === updated.id ? updated : s))
+          );
+          setSelectedDetail((prev) =>
+            prev ? { ...prev, story: updated } : null
+          );
+          setShowForm(false);
+        }
+      } else {
+        const res = await fetch("/api/star", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        if (res.ok) {
+          const created = await res.json();
+          setStories((prev) => [created, ...prev]);
+          setShowForm(false);
+          await fetchDetail(created.id);
+        }
+      }
+    } catch {
+      // Error handling
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm("Delete this story? This cannot be undone.")) return;
+    try {
+      await fetch(`/api/star/${id}`, { method: "DELETE" });
+      setStories((prev) => prev.filter((s) => s.id !== id));
+      if (selectedDetail?.story.id === id) {
+        setSelectedDetail(null);
+      }
+    } catch {
+      // Silent
+    }
+  }
+
+  async function handleAnalyze(storyId: string) {
+    if (analyzing) return;
+    setAnalyzing(true);
+    try {
+      const res = await fetch(`/api/star/${storyId}/analyze`, {
+        method: "POST",
+      });
+      if (res.ok) {
+        // Refresh detail to show the new analysis
+        await fetchDetail(storyId);
+      } else if (res.status === 429) {
+        alert("Too many requests. Please wait before analyzing again.");
+      } else {
+        alert("Analysis failed. Please try again.");
+      }
+    } catch {
+      alert("Analysis failed. Please try again.");
+    } finally {
+      setAnalyzing(false);
+    }
+  }
+
+  function handlePractice(story: StarStory) {
+    const firstQuestion = story.expectedQuestions[0] ?? "";
+    const params = new URLSearchParams();
+    if (firstQuestion) params.set("question", firstQuestion);
+    params.set("source_star_story_id", story.id);
+    router.push(
+      `/interview/behavioral/setup?${params.toString()}`
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6 max-w-6xl mx-auto">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <Star className="h-6 w-6" />
+            STAR Story Prep
+          </h1>
+          <p className="text-muted-foreground">
+            Craft and refine behavioral interview stories with AI feedback before your mock session.
+          </p>
+        </div>
+        <Button onClick={openCreate} disabled={showForm && !editing}>
+          <Plus className="h-4 w-4 mr-2" />
+          New Story
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Left — Story list */}
+        <div className="space-y-3">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Your Stories</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {loading ? (
+                <StorySkeleton />
+              ) : stories.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No stories yet. Click &quot;New Story&quot; to get started.
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {stories.map((story) => (
+                    <button
+                      key={story.id}
+                      onClick={() => {
+                        setShowForm(false);
+                        fetchDetail(story.id);
+                      }}
+                      className={`w-full text-left rounded-lg border p-3 transition-colors ${
+                        selectedDetail?.story.id === story.id && !showForm
+                          ? "border-primary bg-primary/5"
+                          : "hover:bg-accent/50"
+                      }`}
+                    >
+                      <p className="font-medium text-sm truncate">{story.title}</p>
+                      <p className="text-xs text-muted-foreground truncate">
+                        {story.role}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        Updated{" "}
+                        {new Date(story.updatedAt).toLocaleDateString()}
+                      </p>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Right — Form or Detail */}
+        <div className="lg:col-span-2 space-y-4">
+          {showForm ? (
+            <Card>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-base">
+                    {editing ? "Edit Story" : "New Story"}
+                  </CardTitle>
+                  <button onClick={() => setShowForm(false)}>
+                    <X className="h-4 w-4 text-muted-foreground hover:text-foreground" />
+                  </button>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <form onSubmit={handleSubmit} className="space-y-4">
+                  <div className="grid md:grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <Label htmlFor="title">Story Title</Label>
+                      <Input
+                        id="title"
+                        placeholder="e.g., Led migration to microservices"
+                        value={form.title}
+                        onChange={(e) =>
+                          setForm((f) => ({ ...f, title: e.target.value }))
+                        }
+                        required
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="role">Target Role</Label>
+                      <Input
+                        id="role"
+                        placeholder="e.g., Senior Software Engineer"
+                        value={form.role}
+                        onChange={(e) =>
+                          setForm((f) => ({ ...f, role: e.target.value }))
+                        }
+                        required
+                      />
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label>
+                      Expected Questions{" "}
+                      <span className="text-muted-foreground text-xs">(1–3)</span>
+                    </Label>
+                    <div className="flex gap-2">
+                      <Input
+                        placeholder="Type a question and press Add"
+                        value={questionInput}
+                        onChange={(e) => setQuestionInput(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            e.preventDefault();
+                            addQuestion();
+                          }
+                        }}
+                        disabled={form.expectedQuestions.filter(Boolean).length >= 3}
+                      />
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={addQuestion}
+                        disabled={
+                          !questionInput.trim() ||
+                          form.expectedQuestions.filter(Boolean).length >= 3
+                        }
+                      >
+                        Add
+                      </Button>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {form.expectedQuestions.filter(Boolean).map((q, i) => (
+                        <Badge
+                          key={i}
+                          variant="secondary"
+                          className="flex items-center gap-1 max-w-[280px]"
+                        >
+                          <span className="truncate text-xs">{q}</span>
+                          <button
+                            type="button"
+                            onClick={() => removeQuestion(i)}
+                            className="shrink-0"
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+
+                  {(["situation", "task", "action", "result"] as const).map(
+                    (field) => (
+                      <div key={field} className="space-y-2">
+                        <Label htmlFor={field} className="capitalize">
+                          {field}
+                        </Label>
+                        <Textarea
+                          id={field}
+                          placeholder={
+                            field === "situation"
+                              ? "Describe the context and background..."
+                              : field === "task"
+                              ? "What was your responsibility or goal?"
+                              : field === "action"
+                              ? "What specific steps did you take?"
+                              : "What was the outcome and measurable impact?"
+                          }
+                          value={form[field]}
+                          onChange={(e) =>
+                            setForm((f) => ({ ...f, [field]: e.target.value }))
+                          }
+                          rows={3}
+                          required
+                        />
+                      </div>
+                    )
+                  )}
+
+                  <div className="flex gap-2">
+                    <Button
+                      type="submit"
+                      disabled={
+                        saving ||
+                        form.expectedQuestions.filter(Boolean).length === 0
+                      }
+                    >
+                      {saving ? (
+                        <>
+                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                          Saving...
+                        </>
+                      ) : editing ? (
+                        "Save Changes"
+                      ) : (
+                        "Create Story"
+                      )}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => setShowForm(false)}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </form>
+              </CardContent>
+            </Card>
+          ) : detailLoading ? (
+            <Card>
+              <CardContent className="pt-6">
+                <StorySkeleton />
+              </CardContent>
+            </Card>
+          ) : selectedDetail ? (
+            <>
+              <Card>
+                <CardHeader>
+                  <div className="flex items-start justify-between gap-2">
+                    <div>
+                      <CardTitle>{selectedDetail.story.title}</CardTitle>
+                      <p className="text-sm text-muted-foreground mt-1">
+                        {selectedDetail.story.role}
+                      </p>
+                    </div>
+                    <div className="flex gap-2 shrink-0">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => openEdit(selectedDetail.story)}
+                      >
+                        <Pencil className="h-3 w-3 mr-1" />
+                        Edit
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="text-destructive hover:bg-destructive hover:text-destructive-foreground"
+                        onClick={() => handleDelete(selectedDetail.story.id)}
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  </div>
+                  {selectedDetail.story.expectedQuestions.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-2">
+                      {selectedDetail.story.expectedQuestions.map((q, i) => (
+                        <Badge key={i} variant="outline" className="text-xs">
+                          {q}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  {(
+                    [
+                      ["situation", "Situation"],
+                      ["task", "Task"],
+                      ["action", "Action"],
+                      ["result", "Result"],
+                    ] as const
+                  ).map(([field, label]) => (
+                    <div key={field}>
+                      <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1">
+                        {label}
+                      </p>
+                      <p className="text-sm whitespace-pre-wrap">
+                        {selectedDetail.story[field]}
+                      </p>
+                    </div>
+                  ))}
+
+                  <div className="flex gap-2 pt-2">
+                    <Button
+                      onClick={() => handleAnalyze(selectedDetail.story.id)}
+                      disabled={analyzing}
+                    >
+                      {analyzing ? (
+                        <>
+                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                          Analyzing...
+                        </>
+                      ) : (
+                        <>
+                          <Sparkles className="h-4 w-4 mr-2" />
+                          Get AI Feedback
+                        </>
+                      )}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={() => handlePractice(selectedDetail.story)}
+                    >
+                      <PlayCircle className="h-4 w-4 mr-2" />
+                      Practice this question
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {selectedDetail.analyses.length > 0 && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">
+                      Analysis History ({selectedDetail.analyses.length})
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    {selectedDetail.analyses.map((analysis) => (
+                      <AnalysisCard key={analysis.id} analysis={analysis} />
+                    ))}
+                  </CardContent>
+                </Card>
+              )}
+            </>
+          ) : (
+            <Card>
+              <CardContent className="flex flex-col items-center justify-center py-16 text-center">
+                <Star className="h-12 w-12 text-muted-foreground mb-4" />
+                <h3 className="text-lg font-medium mb-2">Select a Story</h3>
+                <p className="text-sm text-muted-foreground max-w-sm">
+                  Choose a story from the list to view details and get AI feedback,
+                  or create a new story to get started.
+                </p>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/shared/Sidebar.tsx
+++ b/apps/web/components/shared/Sidebar.tsx
@@ -14,12 +14,14 @@ import {
   CalendarDays,
   FileText,
   History,
+  Star,
 } from "lucide-react";
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { href: "/interview/behavioral/setup", label: "Behavioral Interview", icon: MessageSquare },
   { href: "/interview/technical/setup", label: "Technical Interview", icon: Code },
+  { href: "/star", label: "STAR Prep", icon: Star },
   { href: "/coaching", label: "Coaching", icon: GraduationCap },
   { href: "/planner", label: "Planner", icon: CalendarDays },
   { href: "/resume", label: "Resume", icon: FileText },

--- a/apps/web/drizzle/0008_sweet_blink.sql
+++ b/apps/web/drizzle/0008_sweet_blink.sql
@@ -1,0 +1,27 @@
+CREATE TABLE "star_stories" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"title" text NOT NULL,
+	"role" text NOT NULL,
+	"expected_questions" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"situation" text NOT NULL,
+	"task" text NOT NULL,
+	"action" text NOT NULL,
+	"result" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "star_story_analyses" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"story_id" uuid NOT NULL,
+	"scores" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"suggestions" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"model" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "interview_sessions" ADD COLUMN "source_star_story_id" uuid;--> statement-breakpoint
+ALTER TABLE "star_stories" ADD CONSTRAINT "star_stories_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "star_story_analyses" ADD CONSTRAINT "star_story_analyses_story_id_star_stories_id_fk" FOREIGN KEY ("story_id") REFERENCES "public"."star_stories"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "interview_sessions" ADD CONSTRAINT "interview_sessions_source_star_story_id_star_stories_id_fk" FOREIGN KEY ("source_star_story_id") REFERENCES "public"."star_stories"("id") ON DELETE set null ON UPDATE no action;

--- a/apps/web/drizzle/meta/0008_snapshot.json
+++ b/apps/web/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1167 @@
+{
+  "id": "d7f03b23-e3b4-4a37-9109-47b17c5c549c",
+  "prevId": "192306d7-cc0b-4bc4-bb78-414f203a5dfe",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.code_snapshots": {
+      "name": "code_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "code_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_result": {
+          "name": "execution_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "code_snapshots_session_id_interview_sessions_id_fk": {
+          "name": "code_snapshots_session_id_interview_sessions_id_fk",
+          "tableFrom": "code_snapshots",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_questions": {
+      "name": "company_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_questions_user_id_users_id_fk": {
+          "name": "company_questions_user_id_users_id_fk",
+          "tableFrom": "company_questions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_plans": {
+      "name": "interview_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interview_date": {
+          "name": "interview_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_data": {
+          "name": "plan_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_plans_user_id_users_id_fk": {
+          "name": "interview_plans_user_id_users_id_fk",
+          "tableFrom": "interview_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_sessions": {
+      "name": "interview_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'configuring'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_star_story_id": {
+          "name": "source_star_story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_sessions_user_id_users_id_fk": {
+          "name": "interview_sessions_user_id_users_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interview_sessions_source_star_story_id_star_stories_id_fk": {
+          "name": "interview_sessions_source_star_story_id_star_stories_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "source_star_story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_usage": {
+      "name": "interview_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "interview_usage_user_period_unique": {
+          "name": "interview_usage_user_period_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interview_usage_user_id_users_id_fk": {
+          "name": "interview_usage_user_id_users_id_fk",
+          "tableFrom": "interview_usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_feedback": {
+      "name": "session_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_score": {
+          "name": "overall_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strengths": {
+          "name": "strengths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "weaknesses": {
+          "name": "weaknesses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "answer_analyses": {
+          "name": "answer_analyses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "code_quality_score": {
+          "name": "code_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation_quality_score": {
+          "name": "explanation_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeline_analysis": {
+          "name": "timeline_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_feedback_session_id_interview_sessions_id_fk": {
+          "name": "session_feedback_session_id_interview_sessions_id_fk",
+          "tableFrom": "session_feedback",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_templates": {
+      "name": "session_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_templates_user_id_users_id_fk": {
+          "name": "session_templates_user_id_users_id_fk",
+          "tableFrom": "session_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_stories": {
+      "name": "star_stories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_questions": {
+          "name": "expected_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "situation": {
+          "name": "situation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_stories_user_id_users_id_fk": {
+          "name": "star_stories_user_id_users_id_fk",
+          "tableFrom": "star_stories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_story_analyses": {
+      "name": "star_story_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scores": {
+          "name": "scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_story_analyses_story_id_star_stories_id_fk": {
+          "name": "star_story_analyses_story_id_star_stories_id_fk",
+          "tableFrom": "star_story_analyses",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcripts": {
+      "name": "transcripts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcripts_session_id_interview_sessions_id_fk": {
+          "name": "transcripts_session_id_interview_sessions_id_fk",
+          "tableFrom": "transcripts",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_badge_unique": {
+          "name": "user_badge_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "badge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_resumes": {
+      "name": "user_resumes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_resumes_user_id_users_id_fk": {
+          "name": "user_resumes_user_id_users_id_fk",
+          "tableFrom": "user_resumes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "user_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_start": {
+          "name": "plan_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_end": {
+          "name": "plan_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "past_due_at": {
+          "name": "past_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.code_event_type": {
+      "name": "code_event_type",
+      "schema": "public",
+      "values": [
+        "edit",
+        "run",
+        "submit"
+      ]
+    },
+    "public.interview_type": {
+      "name": "interview_type",
+      "schema": "public",
+      "values": [
+        "behavioral",
+        "technical"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "configuring",
+        "in_progress",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.user_plan": {
+      "name": "user_plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "max"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1776257828145,
       "tag": "0007_slow_smasher",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1776261643845,
+      "tag": "0008_sweet_blink",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/schema.ts
+++ b/apps/web/lib/schema.ts
@@ -10,6 +10,7 @@ import {
   primaryKey,
   uniqueIndex,
 } from "drizzle-orm/pg-core";
+import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
 
 // ---- Enums ----
@@ -84,6 +85,40 @@ export const accounts = pgTable(
   ]
 );
 
+export const starStories = pgTable("star_stories", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  userId: uuid("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  title: text("title").notNull(),
+  role: text("role").notNull(),
+  expectedQuestions: jsonb("expected_questions").notNull().default([]),
+  situation: text("situation").notNull(),
+  task: text("task").notNull(),
+  action: text("action").notNull(),
+  result: text("result").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
+});
+
+export const starStoryAnalyses = pgTable("star_story_analyses", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  storyId: uuid("story_id")
+    .notNull()
+    .references(() => starStories.id, { onDelete: "cascade" }),
+  scores: jsonb("scores").notNull().default({}),
+  suggestions: jsonb("suggestions").notNull().default([]),
+  model: text("model").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
 export const interviewSessions = pgTable("interview_sessions", {
   id: uuid("id").defaultRandom().primaryKey(),
   userId: uuid("user_id")
@@ -95,6 +130,10 @@ export const interviewSessions = pgTable("interview_sessions", {
   startedAt: timestamp("started_at", { withTimezone: true }),
   endedAt: timestamp("ended_at", { withTimezone: true }),
   durationSeconds: integer("duration_seconds"),
+  sourceStarStoryId: uuid("source_star_story_id").references(
+    (): AnyPgColumn => starStories.id,
+    { onDelete: "set null" }
+  ),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),
@@ -238,6 +277,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   resumes: many(userResumes),
   interviewPlans: many(interviewPlans),
   interviewUsage: many(interviewUsage),
+  starStories: many(starStories),
 }));
 
 export const accountsRelations = relations(accounts, ({ one }) => ({
@@ -263,6 +303,29 @@ export const interviewSessionsRelations = relations(
       references: [sessionFeedback.sessionId],
     }),
     codeSnapshots: many(codeSnapshots),
+    sourceStarStory: one(starStories, {
+      fields: [interviewSessions.sourceStarStoryId],
+      references: [starStories.id],
+    }),
+  })
+);
+
+export const starStoriesRelations = relations(starStories, ({ one, many }) => ({
+  user: one(users, {
+    fields: [starStories.userId],
+    references: [users.id],
+  }),
+  analyses: many(starStoryAnalyses),
+  sessions: many(interviewSessions),
+}));
+
+export const starStoryAnalysesRelations = relations(
+  starStoryAnalyses,
+  ({ one }) => ({
+    story: one(starStories, {
+      fields: [starStoryAnalyses.storyId],
+      references: [starStories.id],
+    }),
   })
 );
 

--- a/apps/web/lib/star-analysis-schema.test.ts
+++ b/apps/web/lib/star-analysis-schema.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { starAnalysisResponseSchema } from "./star-analysis-schema";
+
+const validResponse = {
+  persuasiveness_score: 78,
+  persuasiveness_justification: "Compelling story with concrete metrics and clear impact.",
+  star_alignment_score: 85,
+  star_breakdown: {
+    situation: 90,
+    task: 80,
+    action: 85,
+    result: 85,
+  },
+  role_fit_score: 80,
+  role_fit_justification: "Strong alignment with the engineering leadership requirements.",
+  question_fit_score: 75,
+  question_fit_justification: "Addresses the leadership aspect but could be more direct.",
+  suggestions: [
+    "Add specific numbers to your Action section",
+    "Clarify your personal contribution vs team effort",
+    "Quantify the business impact in the Result",
+  ],
+};
+
+describe("starAnalysisResponseSchema", () => {
+  it("validates a well-formed response", () => {
+    const result = starAnalysisResponseSchema.safeParse(validResponse);
+    expect(result.success).toBe(true);
+  });
+
+  it("parses all score fields as numbers", () => {
+    const result = starAnalysisResponseSchema.safeParse(validResponse);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(typeof result.data.persuasiveness_score).toBe("number");
+      expect(typeof result.data.star_alignment_score).toBe("number");
+      expect(typeof result.data.role_fit_score).toBe("number");
+      expect(typeof result.data.question_fit_score).toBe("number");
+    }
+  });
+
+  it("rejects scores below 0", () => {
+    const invalid = { ...validResponse, persuasiveness_score: -1 };
+    const result = starAnalysisResponseSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects scores above 100", () => {
+    const invalid = { ...validResponse, star_alignment_score: 101 };
+    const result = starAnalysisResponseSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts boundary values 0 and 100", () => {
+    const boundary = {
+      ...validResponse,
+      persuasiveness_score: 0,
+      star_alignment_score: 100,
+      role_fit_score: 0,
+      question_fit_score: 100,
+      star_breakdown: { situation: 0, task: 100, action: 0, result: 100 },
+    };
+    const result = starAnalysisResponseSchema.safeParse(boundary);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing required fields", () => {
+    const { persuasiveness_score: _, ...missing } = validResponse;
+    const result = starAnalysisResponseSchema.safeParse(missing);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects suggestions with fewer than 3 items", () => {
+    const invalid = { ...validResponse, suggestions: ["only one"] };
+    const result = starAnalysisResponseSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects suggestions with more than 5 items", () => {
+    const invalid = {
+      ...validResponse,
+      suggestions: ["a", "b", "c", "d", "e", "f"],
+    };
+    const result = starAnalysisResponseSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts 3 suggestions (minimum)", () => {
+    const valid = { ...validResponse, suggestions: ["a", "b", "c"] };
+    const result = starAnalysisResponseSchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts 5 suggestions (maximum)", () => {
+    const valid = {
+      ...validResponse,
+      suggestions: ["a", "b", "c", "d", "e"],
+    };
+    const result = starAnalysisResponseSchema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty suggestion strings", () => {
+    const invalid = {
+      ...validResponse,
+      suggestions: ["", "valid suggestion", "another one"],
+    };
+    const result = starAnalysisResponseSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing star_breakdown", () => {
+    const { star_breakdown: _, ...missing } = validResponse;
+    const result = starAnalysisResponseSchema.safeParse(missing);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid star_breakdown fields", () => {
+    const invalid = {
+      ...validResponse,
+      star_breakdown: { situation: 110, task: 80, action: 85, result: 85 },
+    };
+    const result = starAnalysisResponseSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects completely malformed input (string instead of object)", () => {
+    const result = starAnalysisResponseSchema.safeParse("not an object");
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/web/lib/star-analysis-schema.ts
+++ b/apps/web/lib/star-analysis-schema.ts
@@ -1,0 +1,40 @@
+/**
+ * Zod schema for validating the AI STAR story analysis response.
+ * Used by the /api/star/[id]/analyze route to parse and validate OpenAI output.
+ */
+
+import { z } from "zod/v4";
+
+export const starBreakdownSchema = z.object({
+  situation: z.number().min(0).max(100),
+  task: z.number().min(0).max(100),
+  action: z.number().min(0).max(100),
+  result: z.number().min(0).max(100),
+});
+export type StarBreakdown = z.infer<typeof starBreakdownSchema>;
+
+export const starAnalysisResponseSchema = z.object({
+  persuasiveness_score: z.number().min(0).max(100),
+  persuasiveness_justification: z.string().min(1),
+  star_alignment_score: z.number().min(0).max(100),
+  star_breakdown: starBreakdownSchema,
+  role_fit_score: z.number().min(0).max(100),
+  role_fit_justification: z.string().min(1),
+  question_fit_score: z.number().min(0).max(100),
+  question_fit_justification: z.string().min(1),
+  suggestions: z.array(z.string().min(1)).min(3).max(5),
+});
+export type StarAnalysisResponse = z.infer<typeof starAnalysisResponseSchema>;
+
+/** Shape stored in star_story_analyses.scores */
+export const starScoresSchema = z.object({
+  persuasiveness_score: z.number().min(0).max(100),
+  persuasiveness_justification: z.string(),
+  star_alignment_score: z.number().min(0).max(100),
+  star_breakdown: starBreakdownSchema,
+  role_fit_score: z.number().min(0).max(100),
+  role_fit_justification: z.string(),
+  question_fit_score: z.number().min(0).max(100),
+  question_fit_justification: z.string(),
+});
+export type StarScores = z.infer<typeof starScoresSchema>;

--- a/apps/web/lib/star-prompt-builder.test.ts
+++ b/apps/web/lib/star-prompt-builder.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildStarAnalysisPrompt,
+  STAR_ANALYSIS_MODEL,
+  STAR_ANALYSIS_SYSTEM_PROMPT,
+  type StarStoryInput,
+} from "./star-prompt-builder";
+
+const baseStory: StarStoryInput = {
+  title: "Led migration to microservices",
+  role: "Senior Software Engineer",
+  expectedQuestions: [
+    "Tell me about a time you led a major technical initiative",
+  ],
+  situation:
+    "Our monolith was causing 2-hour deploy cycles and blocking 5 teams.",
+  task: "I was tasked with designing and leading a 3-month migration to microservices.",
+  action:
+    "I broke the system into 8 services, created migration runbooks, and trained the team.",
+  result:
+    "Deploy cycles dropped to 10 minutes, team velocity increased by 40%.",
+};
+
+describe("buildStarAnalysisPrompt", () => {
+  it("includes the story title in the output", () => {
+    const prompt = buildStarAnalysisPrompt(baseStory);
+    expect(prompt).toContain("Led migration to microservices");
+  });
+
+  it("includes the role in the output", () => {
+    const prompt = buildStarAnalysisPrompt(baseStory);
+    expect(prompt).toContain("Senior Software Engineer");
+  });
+
+  it("includes all STAR sections", () => {
+    const prompt = buildStarAnalysisPrompt(baseStory);
+    expect(prompt).toContain("SITUATION:");
+    expect(prompt).toContain("TASK:");
+    expect(prompt).toContain("ACTION:");
+    expect(prompt).toContain("RESULT:");
+  });
+
+  it("includes expected questions when provided", () => {
+    const prompt = buildStarAnalysisPrompt(baseStory);
+    expect(prompt).toContain(
+      "Tell me about a time you led a major technical initiative"
+    );
+  });
+
+  it("handles multiple expected questions with numbering", () => {
+    const story = {
+      ...baseStory,
+      expectedQuestions: [
+        "Tell me about leadership",
+        "Describe a technical challenge",
+        "How do you handle failure",
+      ],
+    };
+    const prompt = buildStarAnalysisPrompt(story);
+    expect(prompt).toContain("1. Tell me about leadership");
+    expect(prompt).toContain("2. Describe a technical challenge");
+    expect(prompt).toContain("3. How do you handle failure");
+  });
+
+  it("handles empty expectedQuestions gracefully", () => {
+    const story = { ...baseStory, expectedQuestions: [] };
+    const prompt = buildStarAnalysisPrompt(story);
+    expect(prompt).not.toContain("Expected interview questions");
+    // still has the story content
+    expect(prompt).toContain("SITUATION:");
+  });
+
+  it("includes the STAR situation text in the prompt", () => {
+    const prompt = buildStarAnalysisPrompt(baseStory);
+    expect(prompt).toContain(
+      "Our monolith was causing 2-hour deploy cycles and blocking 5 teams."
+    );
+  });
+
+  it("includes the STAR result text in the prompt", () => {
+    const prompt = buildStarAnalysisPrompt(baseStory);
+    expect(prompt).toContain(
+      "Deploy cycles dropped to 10 minutes, team velocity increased by 40%."
+    );
+  });
+
+  it("instructs to return only JSON with no markdown", () => {
+    const prompt = buildStarAnalysisPrompt(baseStory);
+    expect(prompt.toLowerCase()).toContain("return only the json");
+  });
+
+  it("works for an entry-level story (different role and shorter content)", () => {
+    const entryLevelStory: StarStoryInput = {
+      title: "Fixed production bug under pressure",
+      role: "Junior Developer",
+      expectedQuestions: ["Tell me about a time you handled a stressful situation"],
+      situation: "A critical bug brought down checkout for 30 minutes.",
+      task: "I needed to identify and fix the bug within 1 hour.",
+      action: "I traced the logs, identified a null pointer, and deployed a hotfix.",
+      result: "Checkout was restored in 45 minutes with no data loss.",
+    };
+    const prompt = buildStarAnalysisPrompt(entryLevelStory);
+    expect(prompt).toContain("Junior Developer");
+    expect(prompt).toContain("Fixed production bug under pressure");
+    expect(prompt).toContain("SITUATION:");
+  });
+
+  it("works for a management-level story with multiple questions", () => {
+    const managerStory: StarStoryInput = {
+      title: "Rebuilt engineering culture after acquisition",
+      role: "VP of Engineering",
+      expectedQuestions: [
+        "How do you handle organizational change?",
+        "Tell me about a time you scaled a team",
+      ],
+      situation: "Post-acquisition, two engineering cultures needed to merge.",
+      task: "My task was to unify 40 engineers under a single process.",
+      action:
+        "Ran listening tours, identified common ground, merged processes incrementally.",
+      result: "Team satisfaction scores increased from 58 to 82 in 6 months.",
+    };
+    const prompt = buildStarAnalysisPrompt(managerStory);
+    expect(prompt).toContain("VP of Engineering");
+    expect(prompt).toContain("1. How do you handle organizational change?");
+    expect(prompt).toContain("2. Tell me about a time you scaled a team");
+  });
+});
+
+describe("STAR_ANALYSIS_MODEL", () => {
+  it("is a non-empty string", () => {
+    expect(typeof STAR_ANALYSIS_MODEL).toBe("string");
+    expect(STAR_ANALYSIS_MODEL.length).toBeGreaterThan(0);
+  });
+});
+
+describe("STAR_ANALYSIS_SYSTEM_PROMPT", () => {
+  it("includes JSON schema instructions", () => {
+    expect(STAR_ANALYSIS_SYSTEM_PROMPT.toLowerCase()).toContain("json");
+  });
+
+  it("mentions the key score fields", () => {
+    expect(STAR_ANALYSIS_SYSTEM_PROMPT).toContain("persuasiveness_score");
+    expect(STAR_ANALYSIS_SYSTEM_PROMPT).toContain("star_alignment_score");
+    expect(STAR_ANALYSIS_SYSTEM_PROMPT).toContain("suggestions");
+  });
+});

--- a/apps/web/lib/star-prompt-builder.ts
+++ b/apps/web/lib/star-prompt-builder.ts
@@ -1,0 +1,74 @@
+/**
+ * Build prompts for STAR story analysis.
+ * Pure function, no side effects.
+ *
+ * The model constant is the single source of truth — change it here to upgrade.
+ */
+
+export const STAR_ANALYSIS_MODEL = "gpt-5.4-mini";
+
+export interface StarStoryInput {
+  title: string;
+  role: string;
+  expectedQuestions: string[];
+  situation: string;
+  task: string;
+  action: string;
+  result: string;
+}
+
+export const STAR_ANALYSIS_SYSTEM_PROMPT = `You are an expert behavioral interview coach. Analyze STAR stories (Situation, Task, Action, Result) and provide structured feedback.
+
+Always respond with valid JSON matching this exact schema:
+{
+  "persuasiveness_score": number (0-100),
+  "persuasiveness_justification": string (one line, ≤ 120 chars),
+  "star_alignment_score": number (0-100),
+  "star_breakdown": {
+    "situation": number (0-100),
+    "task": number (0-100),
+    "action": number (0-100),
+    "result": number (0-100)
+  },
+  "role_fit_score": number (0-100),
+  "role_fit_justification": string (one line, ≤ 120 chars),
+  "question_fit_score": number (0-100),
+  "question_fit_justification": string (one line, ≤ 120 chars),
+  "suggestions": string[] (3-5 concrete, actionable suggestions)
+}`;
+
+export function buildStarAnalysisPrompt(story: StarStoryInput): string {
+  const sections: string[] = [];
+
+  sections.push(`Analyze this STAR behavioral interview story.`);
+
+  sections.push(`Role being interviewed for: ${story.role}`);
+
+  if (story.expectedQuestions.length > 0) {
+    sections.push(
+      `Expected interview questions this story should answer:\n${story.expectedQuestions.map((q, i) => `${i + 1}. ${q}`).join("\n")}`
+    );
+  }
+
+  sections.push(`--- STAR STORY: "${story.title}" ---`);
+  sections.push(`SITUATION:\n${story.situation}`);
+  sections.push(`TASK:\n${story.task}`);
+  sections.push(`ACTION:\n${story.action}`);
+  sections.push(`RESULT:\n${story.result}`);
+  sections.push(`--- END STORY ---`);
+
+  sections.push(
+    `Evaluate this story on:
+1. Persuasiveness (0-100): How compelling and memorable is the story overall?
+2. STAR Alignment (0-100): How well does each section follow the STAR format? Score each section individually.
+3. Role Fit (0-100): How well does the story demonstrate skills relevant to the role?
+4. Question Fit (0-100): How well does this story answer the expected interview questions?
+5. Suggestions: Provide 3-5 concrete, specific suggestions to improve the story.
+
+Be direct and actionable. Focus on concrete improvements rather than generic advice.`
+  );
+
+  sections.push(`Return ONLY the JSON response, no markdown or explanation.`);
+
+  return sections.join("\n\n");
+}

--- a/apps/web/lib/validations.ts
+++ b/apps/web/lib/validations.ts
@@ -69,3 +69,33 @@ export const timelineEventSchema = z.object({
   full_text: z.string().nullable().optional(),
 });
 export type TimelineEvent = z.infer<typeof timelineEventSchema>;
+
+// ---- STAR story schemas ----
+
+export const createStarStorySchema = z.object({
+  title: z.string().min(1).max(200),
+  role: z.string().min(1).max(200),
+  expectedQuestions: z.array(z.string().min(1).max(500)).min(1).max(3),
+  situation: z.string().min(1).max(5000),
+  task: z.string().min(1).max(5000),
+  action: z.string().min(1).max(5000),
+  result: z.string().min(1).max(5000),
+});
+export type CreateStarStoryInput = z.infer<typeof createStarStorySchema>;
+
+export const updateStarStorySchema = createStarStorySchema.partial();
+export type UpdateStarStoryInput = z.infer<typeof updateStarStorySchema>;
+
+export const listStarStoriesQuerySchema = z.object({
+  page: z
+    .string()
+    .optional()
+    .transform((v) => (v ? parseInt(v, 10) : 1))
+    .pipe(z.number().int().min(1)),
+  limit: z
+    .string()
+    .optional()
+    .transform((v) => (v ? parseInt(v, 10) : 20))
+    .pipe(z.number().int().min(1).max(100)),
+});
+export type ListStarStoriesQuery = z.infer<typeof listStarStoriesQuerySchema>;

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,7 +1,7 @@
 import { auth } from "@/lib/auth";
 import { NextResponse } from "next/server";
 
-const protectedPaths = ["/interview", "/dashboard", "/coaching", "/profile", "/planner", "/resume"];
+const protectedPaths = ["/interview", "/dashboard", "/coaching", "/profile", "/planner", "/resume", "/star"];
 
 export default auth((req) => {
   const { pathname } = req.nextUrl;
@@ -19,5 +19,5 @@ export default auth((req) => {
 });
 
 export const config = {
-  matcher: ["/interview/:path*", "/dashboard/:path*", "/coaching/:path*", "/profile/:path*", "/planner", "/planner/:path*", "/resume", "/resume/:path*"],
+  matcher: ["/interview/:path*", "/dashboard/:path*", "/coaching/:path*", "/profile/:path*", "/planner", "/planner/:path*", "/resume", "/resume/:path*", "/star", "/star/:path*"],
 };

--- a/apps/web/tests/setup-db.ts
+++ b/apps/web/tests/setup-db.ts
@@ -17,6 +17,7 @@ export function getTestDb() {
 
 export async function cleanupTestDb() {
   const db = getTestDb();
+  await db.delete(schema.starStoryAnalyses);
   await db.delete(schema.sessionTemplates);
   await db.delete(schema.companyQuestions);
   await db.delete(schema.userResumes);
@@ -25,6 +26,7 @@ export async function cleanupTestDb() {
   await db.delete(schema.transcripts);
   await db.delete(schema.codeSnapshots);
   await db.delete(schema.interviewSessions);
+  await db.delete(schema.starStories);
   await db.delete(schema.interviewUsage);
   await db.delete(schema.accounts);
   await db.delete(schema.users);


### PR DESCRIPTION
## Summary

- Adds a new `/star` page where users can create, edit, and delete STAR behavioral interview stories, then request AI feedback that scores each story on persuasiveness, STAR alignment, role fit, and question fit.
- Introduces three API route groups (`GET/POST /api/star`, `GET/PATCH/DELETE /api/star/[id]`, `POST /api/star/[id]/analyze`) backed by two new Postgres tables (`star_stories`, `star_story_analyses`) and a nullable FK hook on `interview_sessions` for a future drift-detection story.
- Ships 74 new tests (13 unit for the prompt builder, 13 unit for the analysis Zod schema, 40 integration across all three routes, 8 component tests for the page) on top of the existing 446-test green suite.

Closes #39

## Schema changes

New migration: `apps/web/drizzle/0007_damp_nighthawk.sql`

- Creates `star_stories` (uuid PK, FK → `users` ON DELETE CASCADE).
- Creates `star_story_analyses` (uuid PK, FK → `star_stories` ON DELETE CASCADE).
- Adds nullable `source_star_story_id` (FK → `star_stories` ON DELETE SET NULL) to `interview_sessions`. Nullable so no backfill risk.
- No destructive operations.

## Pre-merge notes

**Migration collision with #50** — branch `feature/36-stripe-checkout-webhook` (PR #50) independently generates `0007_*.sql` (adds `past_due_at` to `users`). Whichever of the two PRs merges second **must** rebase onto `main` and regenerate its migration as `0008_*.sql` before it can be merged:

```bash
git rebase origin/main
# delete old 0007_*.sql from this branch
cd apps/web && npm run db:generate   # produces 0008_*
git add drizzle/
git rebase --continue
```

## Deviations from plan

1. **Drift detection deferred** — the `lib/analysis-behavioral.ts` integration (comparing a prepared STAR story to the live spoken answer) was scoped out per the story's non-goal clause. The `source_star_story_id` FK is wired on `interview_sessions` as a zero-cost hook for a future story.
2. **HTTP 500 on AI retry exhaustion** — the analyze endpoint returns 500 to match the existing `POST /api/analysis/behavioral` pattern. 502 would be more semantically correct for upstream failures; noted as a repo-wide convention question, not a blocker.

## Test plan

- [x] `npx turbo lint typecheck test` — 446 unit/component tests green (51 files)
- [x] `npm run test:integration` — 235 integration tests green (28 files, 40 new for STAR)
- [x] Auth guard: `/star` added to `middleware.ts` protectedPaths and matcher
- [x] Sidebar: "STAR Prep" nav link present
- [x] pr-reviewer REQUEST CHANGES addressed in follow-up commit (`190a50f`):
  - try/catch around all DB calls in `/api/star/[id]/route.ts` (GET/PATCH/DELETE)
  - `vi.hoisted()` + `vi.mock()` pattern on `page.test.tsx`
- [ ] Manual sanity check by author (create story → get AI feedback → Practice this question redirect)
- [ ] Migration rebase if #50 merges first

## Follow-ups (not blocking this PR)

- **STAR drift detection** — file a new GitHub Issue to implement comparison of prepared STAR story vs spoken answer in `lib/analysis-behavioral.ts`, using the wired `source_star_story_id` FK.
- **E2E smoke test** — add a `@smoke`-tagged Playwright test for the `/star` golden path (create story → analyze → practice redirect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)