### PR TITLE
fix(api): lazy-init OpenAI client so Vercel build passes

### DIFF
--- a/apps/web/app/api/questions/smart-generate/route.ts
+++ b/apps/web/app/api/questions/smart-generate/route.ts
@@ -8,14 +8,17 @@ import { checkRateLimit } from "@/lib/api-utils";
 import { buildSmartQuestionsPrompt } from "@/lib/smart-questions-prompt";
 import OpenAI from "openai";
 
-const openai = new OpenAI();
-
 // POST /api/questions/smart-generate — generate questions combining company + resume context
 export async function POST(request: NextRequest) {
   const session = await auth();
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  // Lazy-instantiate so `next build` can import this module without
+  // OPENAI_API_KEY being present. The SDK throws synchronously if the key
+  // is missing at construction time.
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
   const rateLimited = checkRateLimit(session.user.id);
   if (rateLimited) return rateLimited;

--- a/apps/web/app/api/resume/questions/route.ts
+++ b/apps/web/app/api/resume/questions/route.ts
@@ -15,14 +15,16 @@ const requestSchema = z.object({
   question_type: z.enum(["behavioral", "technical"]),
 });
 
-const openai = new OpenAI();
-
 // POST /api/resume/questions — generate resume-tailored interview questions
 export async function POST(request: NextRequest) {
   const session = await auth();
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  // Lazy-instantiate so `next build` can import this module without
+  // OPENAI_API_KEY being present.
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
   const log = createRequestLogger({ route: "POST /api/resume/questions", userId: session.user.id });
 


### PR DESCRIPTION
## Summary

- Fixes Vercel deploy failure `Missing credentials. Please pass an apiKey, workloadIdentity, or set the OPENAI_API_KEY environment variable.` at `smart-generate/route.js:8:3` during "Collecting page data".
- Root cause: `apps/web/app/api/questions/smart-generate/route.ts` and `apps/web/app/api/resume/questions/route.ts` instantiated `new OpenAI()` at **module scope**. Next.js imports every route module during build to gather metadata, and the OpenAI SDK throws synchronously if no `apiKey` is present at construction time — so any build without `OPENAI_API_KEY` reaching the module-evaluation phase crashes.
- Fix: move `new OpenAI({ apiKey: process.env.OPENAI_API_KEY })` inside the POST handler in both routes, matching the pattern already used by every other OpenAI-backed route in the repo (`plans/generate`, `problems/generate`, `transcribe`, `questions/generate`).

## Test plan

- [x] `OPENAI_API_KEY='' npm run build` succeeds locally (reproduced the original failure first)
- [ ] Vercel deploy goes green on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)