### PR TITLE
fix: deploy unblockers — Stripe lazy-init, CSP for Google OAuth, SDK convention docs

### DIFF
--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -1,13 +1,34 @@
 /**
  * Stripe singleton client.
+ *
+ * Exposed as a Proxy so the underlying Stripe SDK is only constructed on
+ * first runtime access. This matters because Next.js evaluates every route
+ * module during `next build`'s "Collecting page data" phase — if the client
+ * were instantiated at module load, a missing STRIPE_SECRET_KEY would break
+ * the build even when the env var is correctly set in the deploy target's
+ * runtime environment.
+ *
  * Import `stripe` anywhere server-side; never expose it to client bundles.
+ * Integration tests can still mock the whole module via
+ * `vi.mock("@/lib/stripe", () => ({ stripe: { ... } }))` — the Proxy is
+ * replaced wholesale by the mock and is never accessed.
  */
 import Stripe from "stripe";
 
-if (!process.env.STRIPE_SECRET_KEY && process.env.NODE_ENV === "production") {
-  throw new Error("STRIPE_SECRET_KEY is not set");
+let cached: Stripe | null = null;
+
+function getStripeClient(): Stripe {
+  if (cached) return cached;
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) {
+    throw new Error("STRIPE_SECRET_KEY is not set");
+  }
+  cached = new Stripe(key, { apiVersion: "2026-03-25.dahlia" });
+  return cached;
 }
 
-export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY ?? "sk_test_placeholder", {
-  apiVersion: "2026-03-25.dahlia",
+export const stripe = new Proxy({} as Stripe, {
+  get(_target, prop, receiver) {
+    return Reflect.get(getStripeClient(), prop, receiver);
+  },
 });


### PR DESCRIPTION
## Summary

Three small fixes that together unblock the production deploy.

### 1. `lib/stripe.ts` — lazy-init via Proxy

`apps/web/lib/stripe.ts` instantiated the Stripe SDK at module load and threw eagerly when `NODE_ENV=production`. Vercel sets `NODE_ENV=production` during `next build`, so the "Collecting page data" phase crashed at module evaluation regardless of whether `STRIPE_SECRET_KEY` was set in the runtime env.

Replaced the eager singleton with a Proxy that only constructs the underlying Stripe client on first runtime property access. Module load no longer reads `process.env`. Existing `vi.mock("@/lib/stripe", () => ({ stripe: { ... } }))` test patterns work unchanged because they replace the module wholesale and never trigger the Proxy.

### 2. `next.config.ts` — allow Google OAuth in CSP

NextAuth's sign-in handler redirects via a `<form>` POST to `https://accounts.google.com/o/oauth2/v2/auth?...`. The deployed CSP had `form-action 'self'`, which blocked the redirect with `Refused to connect because it violates the document's Content Security Policy`. Adding `https://accounts.google.com` to both `form-action` (for the redirect) and `connect-src` (for any internal fetch from the NextAuth client helper).

### 3. `apps/web/CLAUDE.md` — document SDK lazy-init convention

So `feature-implementer` agents do not reintroduce the module-load bug that just broke deploys twice (PRs #52 + this one). New "SDK clients — lazy-init only" section documents both the inline-handler pattern and the Proxy pattern, with a hard rule against top-level `if (!process.env.X) throw`.

## Action item for the user (NOT a code fix)

The error trace also shows `redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fapi%2Fauth%2Fcallback%2Fgoogle` — NextAuth is generating localhost URLs because `AUTH_URL` is not set in Vercel. Add to your Vercel env vars (Production scope):

```
AUTH_URL=https://<your-vercel-domain>
```

(Or `NEXTAUTH_URL` — both work. NextAuth v5 also accepts `AUTH_TRUST_HOST=true` if you want it to derive the URL from the request host.)

## Test plan

- [x] `STRIPE_SECRET_KEY='' OPENAI_API_KEY='' npm run build` succeeds locally
- [x] `npx turbo lint typecheck test` — 446 unit tests green
- [x] `npm run test:integration` — 213 integration tests green (18 billing-specific using existing mock pattern)
- [ ] Vercel deploy succeeds
- [ ] Google sign-in works after `AUTH_URL` is set in Vercel

🤖 Generated with [Claude Code](https://claude.com/claude-code)