### PR TITLE
fix(csp,docs): allow Google OAuth in CSP and document SDK lazy-init p…

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -22,6 +22,39 @@ covers monorepo-wide rules (Tasks.md workflow, pre-commit checklist).
 - Use `createRequestLogger({ route, userId })` from `@/lib/logger` — never `console.log` server-side.
 - On 404 for another user's resource, never leak existence (return 404, not 403).
 
+## SDK clients (OpenAI, Stripe, etc.) — lazy-init only
+
+**Never instantiate an SDK client at module load.** Next.js evaluates every
+route module during `next build`'s "Collecting page data" phase, and any SDK
+that throws synchronously when its API key is missing (OpenAI, Stripe, …)
+will crash the build before runtime env vars are read. This has burned us
+twice (PRs #52, #53).
+
+- For SDK clients used in **one** route, construct inside the handler:
+  ```ts
+  export async function POST(req: NextRequest) {
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    // ...
+  }
+  ```
+- For SDK clients shared across **multiple** routes (e.g. `lib/stripe.ts`),
+  expose a Proxy that defers construction until first property access:
+  ```ts
+  let cached: Stripe | null = null;
+  function getClient(): Stripe {
+    if (cached) return cached;
+    if (!process.env.STRIPE_SECRET_KEY) throw new Error("STRIPE_SECRET_KEY is not set");
+    cached = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: "..." });
+    return cached;
+  }
+  export const stripe = new Proxy({} as Stripe, {
+    get(_t, prop, recv) { return Reflect.get(getClient(), prop, recv); },
+  });
+  ```
+  The Proxy keeps the existing named export shape so `vi.mock("@/lib/stripe", () => ({ stripe: {...} }))` test patterns work unchanged.
+- **Never** put `if (!process.env.X) throw` at module top level — the build
+  will hit it before your runtime env is in place.
+
 ## Database
 
 - Schema lives in `lib/schema.ts`. Relations are defined in the same file.

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -12,8 +12,8 @@ const cspDirectives = [
   "img-src 'self' data: blob: https://*.googleusercontent.com",
   // Fonts: self + Monaco editor fonts (Codicon)
   "font-src 'self' https://cdn.jsdelivr.net",
-  // Connect: self + OpenAI + Supabase + Sentry + Python API + Monaco CDN
-  "connect-src 'self' https://api.openai.com wss://api.openai.com https://*.supabase.co https://*.sentry.io https://*.ingest.us.sentry.io http://localhost:8000 https://cdn.jsdelivr.net",
+  // Connect: self + OpenAI + Supabase + Sentry + Python API + Monaco CDN + Google OAuth
+  "connect-src 'self' https://api.openai.com wss://api.openai.com https://*.supabase.co https://*.sentry.io https://*.ingest.us.sentry.io http://localhost:8000 https://cdn.jsdelivr.net https://accounts.google.com",
   // Media: self + blob (audio recording)
   "media-src 'self' blob:",
   // Workers: self + blob (Monaco editor workers)
@@ -26,8 +26,8 @@ const cspDirectives = [
   "object-src 'none'",
   // Base URI: self
   "base-uri 'self'",
-  // Form action: self
-  "form-action 'self'",
+  // Form action: self + Google OAuth (NextAuth redirects to accounts.google.com on sign-in)
+  "form-action 'self' https://accounts.google.com",
 ].join("; ");
 
 const nextConfig: NextConfig = {


### PR DESCRIPTION
…attern

CSP fix:
- `form-action 'self'` blocked NextAuth's sign-in redirect to https://accounts.google.com — every Google OAuth attempt died with "Refused to connect because it violates the document's Content Security Policy". Adding `https://accounts.google.com` to both `form-action` (for the redirect) and `connect-src` (for any internal fetch from the NextAuth client helper).

Docs:
- Add an "SDK clients (OpenAI, Stripe, etc.) — lazy-init only" section to apps/web/CLAUDE.md so feature-implementer agents do not reintroduce the module-load instantiation bug that broke deploys twice in PRs #52 and #53. Documents both the inline-handler pattern (single-route SDKs) and the Proxy pattern (multi-route singletons), with a hard rule against top-level `if (!process.env.X) throw`.

Note: the `redirect_uri=http://localhost:3000/...` shown in the original error is a *separate* config issue — the user must set `AUTH_URL` (or `NEXTAUTH_URL`) to the deployed domain in Vercel env vars. No code change can fix that.