### PR TITLE
fix(auth): redirect Vercel preview hosts to canonical alias

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -3,7 +3,30 @@ import { NextResponse } from "next/server";
 
 const protectedPaths = ["/interview", "/dashboard", "/coaching", "/profile", "/planner", "/resume", "/star"];
 
+// Production canonical host. Vercel exposes every deploy under a stable
+// alias (`preploy.vercel.app`) AND a unique per-deployment hash like
+// `preploy-<hash>-samuels-projects-3cac4324.vercel.app`. NextAuth v5 sets
+// the PKCE verifier cookie on whichever host the OAuth flow starts at; if
+// the user begins on a hashed alias and Google redirects them back to the
+// canonical alias (the only redirect URI in `AUTH_URL` and the Google
+// Cloud allowlist), the cookie is invisible during the callback and auth
+// dies with `InvalidCheck: pkceCodeVerifier`. Force every request to land
+// on the canonical host so the cookie domain stays consistent through the
+// whole OAuth round-trip.
+const CANONICAL_HOST = "preploy.vercel.app";
+
 export default auth((req) => {
+  const host = req.headers.get("host") ?? "";
+
+  // Canonical-host redirect — only on Vercel preview/deploy aliases, never
+  // on localhost (dev) or custom domains.
+  if (host.endsWith(".vercel.app") && host !== CANONICAL_HOST) {
+    const canonical = new URL(req.url);
+    canonical.host = CANONICAL_HOST;
+    canonical.protocol = "https:";
+    return NextResponse.redirect(canonical, 308);
+  }
+
   const { pathname } = req.nextUrl;
   const isProtected = protectedPaths.some((path) =>
     pathname.startsWith(path)
@@ -19,5 +42,22 @@ export default auth((req) => {
 });
 
 export const config = {
-  matcher: ["/interview/:path*", "/dashboard/:path*", "/coaching/:path*", "/profile/:path*", "/planner", "/planner/:path*", "/resume", "/resume/:path*", "/star", "/star/:path*"],
+  matcher: [
+    // Landing + login + auth routes need the host check so the OAuth
+    // round-trip starts and ends on the same host. Protected paths keep
+    // the auth gate.
+    "/",
+    "/login",
+    "/api/auth/:path*",
+    "/interview/:path*",
+    "/dashboard/:path*",
+    "/coaching/:path*",
+    "/profile/:path*",
+    "/planner",
+    "/planner/:path*",
+    "/resume",
+    "/resume/:path*",
+    "/star",
+    "/star/:path*",
+  ],
 };


### PR DESCRIPTION
## Summary

- Adds a 308 redirect at the top of `apps/web/middleware.ts` that forces any `*.vercel.app` host other than `preploy.vercel.app` onto the canonical alias before any auth logic runs. Fixes `InvalidCheck: pkceCodeVerifier value could not be parsed` when users start sign-in on a per-deployment hashed alias and Google redirects them back to the canonical alias mid-flow.
- Expands the matcher to include `/`, `/login`, and `/api/auth/:path*` so the redirect catches every OAuth entry point, not just protected pages.
- Localhost and custom domains are untouched (the check only fires on `*.vercel.app` aliases).

## Why

Vercel exposes every deploy under both a stable alias and a unique per-deployment hash. NextAuth's PKCE cookie is host-scoped, so an OAuth flow that starts on `preploy-<hash>-...vercel.app` and ends on `preploy.vercel.app` (the host in `AUTH_URL` and the Google Cloud allowlist) crashes with a missing cookie. The redirect makes that mid-flow host change impossible.

## Test plan

- [x] `npx turbo lint typecheck test` — 446 unit tests green
- [x] `npm run test:integration` — 253 integration tests green
- [ ] Deploy to Vercel, hit `https://preploy-<hash>-...vercel.app/login`, confirm 308 → `https://preploy.vercel.app/login`
- [ ] Sign in works in non-incognito after merging (clear cookies for both hosts first if needed)

## Note for users

Existing browsers that already have stale cookies on the wrong host need them cleared once before sign-in works. After this PR merges, the wrong host will redirect immediately so the bad cookies stop accumulating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)