### PR TITLE
chore(deploy): run drizzle migrations on Vercel build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "node scripts/build.mjs",
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",

--- a/apps/web/scripts/build.mjs
+++ b/apps/web/scripts/build.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Vercel-aware build wrapper.
+ *
+ * On Vercel (`process.env.VERCEL === "1"`), runs `drizzle-kit migrate`
+ * against the production database BEFORE `next build`. A failed migration
+ * aborts the deploy, so the new code never goes live against a stale schema.
+ *
+ * Local builds (no VERCEL env var) and CI builds skip the migrate step —
+ * CI uses a dummy SUPABASE_DB_URL from .env.ci that would not connect, and
+ * developers should run `npm run db:migrate` manually against their local
+ * database when needed.
+ *
+ * Why this script and not just `drizzle-kit migrate && next build` in the
+ * package.json `build` field: that would break CI and local builds. A small
+ * Node wrapper is the cleanest gate.
+ */
+import { spawnSync } from "node:child_process";
+
+function run(cmd, args) {
+  console.log(`> ${cmd} ${args.join(" ")}`);
+  const result = spawnSync(cmd, args, { stdio: "inherit", shell: false });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+if (process.env.VERCEL === "1") {
+  if (!process.env.SUPABASE_DB_URL) {
+    console.error(
+      "ERROR: SUPABASE_DB_URL must be set in Vercel env vars for the build-time migrate step."
+    );
+    process.exit(1);
+  }
+  console.log("[vercel-build] Applying drizzle migrations against production DB...");
+  run("npx", ["drizzle-kit", "migrate"]);
+  console.log("[vercel-build] Migrations applied successfully.");
+}
+
+run("npx", ["next", "build"]);


### PR DESCRIPTION
## Summary

- Adds `apps/web/scripts/build.mjs`, a small Node wrapper that runs `npx drizzle-kit migrate` against the production database before `next build` — but only when `VERCEL=1` is set. Local and CI builds are unchanged.
- Updates `apps/web/package.json` so `npm run build` invokes the wrapper. Vercel auto-runs `npm run build` for Next.js projects, so no Vercel UI configuration is required.
- A failed migration aborts the deploy. New code never goes live against a stale schema again.

## Why

We've been bitten twice this week by deploys shipping schema-dependent code without applying the migrations. Most recently auth completely broke in production because `users.stripe_customer_id`, `users.past_due_at`, `interview_sessions.source_star_story_id` (etc.) didn't exist in the live DB. Manual `db:migrate` against prod is too easy to forget when working in parallel.

## ⚠️ One-time bootstrap required before merging

The current production `drizzle.__drizzle_migrations` table is in a non-standard state: it has 4 hand-inserted rows where the `hash` column contains migration *tag strings* (e.g. `"0001_bitter_vin_gonzales"`) instead of drizzle-kit's expected SHA-256 hash of the migration SQL. Rows for 0000, 0004, 0006, 0007, 0008 are missing entirely. If we merge this PR without fixing the tracking table, the next Vercel deploy will try to apply 0000–0008 from scratch and crash on every "table already exists."

**Run this in the Supabase SQL Editor before merging:**

```sql
BEGIN;
TRUNCATE drizzle.__drizzle_migrations RESTART IDENTITY;
INSERT INTO drizzle.__drizzle_migrations (hash, created_at) VALUES
  ('c7215a61b0b81142e2f0883f740ab7d2f2f186ec9da8cbf578e88bbccfe12391', 1775681869471),  -- 0000_certain_dreaming_celestial
  ('ff466f05953f3d2631d7cdfb657ab85d5cc1e15de1aac2d73a39ed5f18bfae27', 1775916211648),  -- 0001_bitter_vin_gonzales
  ('667255a51046e9d34a741e0596f1e338df217ff266fa8cf3d0191bb612d41720', 1775920201185),  -- 0002_user_achievements
  ('6d595b175715db9d95b61189d1a4e4a53cfe89626b98464fd0f1b5bc6bf8d7f2', 1775921055781),  -- 0003_polite_paibok
  ('14e580476e47b90c387aa2a46d54d04cfec6e32dc4901f233cdba2b3995f6178', 1775982016274),  -- 0004_steady_miek
  ('80d3eb5bba77f97dfb57d3f0f068a27a118f9f65526d13844861f0b914fabe65', 1775989756690),  -- 0005_thankful_sentry
  ('f0305d6ebcc076f19e83adc3761f83c799841e127165630d1690444dcd5dfd66', 1776254159957),  -- 0006_silly_banshee
  ('c2877188182aaf4d0a6f236b8a1ed674c5a7c632dfe16fc3f199e1fd02ea8f6d', 1776257828145),  -- 0007_slow_smasher
  ('705b976783c7c35f820eba35144dd63a4fadbd88d45f457160706498466db802', 1776261643845);  -- 0008_sweet_blink
COMMIT;
```

The hashes are SHA-256 of each migration's SQL file content, exactly the format `drizzle-kit migrate` expects. After this runs, the next Vercel deploy will see all 9 migrations as already applied and only run anything new (e.g. `0009_*` from a future PR).

## Verify before clicking merge

After running the SQL above, query `drizzle.__drizzle_migrations` and confirm 9 rows with hex hashes. Then merge this PR and watch the Vercel deploy log for the `[vercel-build] Migrations applied successfully.` line — it should appear with "0 migrations to apply" since the tracking table is up-to-date.

## Test plan

- [x] `rm -rf apps/web/.next && npm run build` locally — wrapper detects no VERCEL env, runs `next build` only, build passes
- [ ] Bootstrap SQL run against prod (see above)
- [ ] Vercel deploy after merge — watch for `[vercel-build]` log line, deploy goes green
- [ ] Future schema change (e.g. Wave 3 stories) auto-migrates without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)