### PR TITLE
fix(turbo): declare build env vars so Turborepo stops stripping them

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalEnv": [
+    "NODE_ENV",
+    "CI",
+    "VERCEL",
+    "VERCEL_ENV",
+    "VERCEL_URL"
+  ],
   "tasks": {
     "dev": {
       "cache": false,
@@ -7,14 +14,41 @@
     },
     "build": {
       "dependsOn": ["^build"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"],
+      "env": [
+        "SUPABASE_DB_URL",
+        "SUPABASE_URL",
+        "SUPABASE_ANON_KEY",
+        "AUTH_SECRET",
+        "NEXTAUTH_SECRET",
+        "AUTH_URL",
+        "NEXTAUTH_URL",
+        "AUTH_TRUST_HOST",
+        "GOOGLE_CLIENT_ID",
+        "GOOGLE_CLIENT_SECRET",
+        "OPENAI_API_KEY",
+        "STRIPE_SECRET_KEY",
+        "STRIPE_WEBHOOK_SECRET",
+        "STRIPE_PRO_PRICE_ID",
+        "SENTRY_DSN",
+        "NEXT_PUBLIC_SENTRY_DSN",
+        "SENTRY_AUTH_TOKEN",
+        "NEXT_PUBLIC_BASE_URL",
+        "LOG_LEVEL"
+      ]
     },
     "lint": {
       "dependsOn": ["^build"]
     },
     "test": {
       "dependsOn": ["^build"],
-      "cache": false
+      "cache": false,
+      "env": [
+        "SUPABASE_DB_URL",
+        "TEST_DATABASE_URL",
+        "AUTH_SECRET",
+        "OPENAI_API_KEY"
+      ]
     },
     "typecheck": {
       "dependsOn": ["^build"]


### PR DESCRIPTION
## Root cause

Turborepo 2.x runs in **strict env-var mode** by default. Any env var not declared in `task.env` or `globalEnv` is **removed from `process.env`** before the task runs, even when Vercel has the variable correctly set in the project. Only a small allowlist of system vars (`NODE_ENV`, `CI`, `VERCEL`, `PATH`) pass through automatically.

`turbo.json` had no `env` field on the `build` task at all → Turbo stripped every user-defined env var on every Vercel build. The repeated "missing env var" failures we've been chasing this week were all the same root cause:

| PR | Symptom | What I "fixed" | Real cause |
|---|---|---|---|
| #52 | `OPENAI_API_KEY` missing at module load | Lazy-init OpenAI client | Turbo stripped `OPENAI_API_KEY` |
| #53 | `STRIPE_SECRET_KEY is not set` at module load | Proxy lazy-init for Stripe | Turbo stripped `STRIPE_SECRET_KEY` |
| #56 | `SUPABASE_DB_URL` missing at build script | Wrote `scripts/build.mjs` precondition check | Turbo stripped `SUPABASE_DB_URL` |

The lazy-init fixes from #52 and #53 are still good (defensive against module-load init bugs in general) but they were treating symptoms.

## Fix

Adds an explicit `env` field to `build` and `test` tasks listing every env var the app reads at build/test time, plus a `globalEnv` for system markers. Vars listed here become part of the turbo cache key — correct, because a deploy with a different secret is genuinely a different build.

## Test plan

- [ ] Merge to main
- [ ] Vercel auto-deploys to production
- [ ] Build log shows `[vercel-build] Applying drizzle migrations against production DB...` followed by `Migrations applied successfully.`
- [ ] Sign-in works on `https://preploy.vercel.app`

## Reminder before merging

The Supabase tracking-table bootstrap SQL from PR #56 still needs to be run before the first build-time `drizzle-kit migrate` succeeds. If you haven't run it yet, do that first or the deploy will fail with "table already exists." (PR #56's body has the exact SQL.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)