### PR TITLE
feat(billing): enforce free-tier monthly interview limit + upgrade prompt (#38)

### DIFF
--- a/apps/web/app/api/sessions/route.integration.test.ts
+++ b/apps/web/app/api/sessions/route.integration.test.ts
@@ -51,14 +51,20 @@ describe("API /api/sessions (integration)", () => {
   });
 
   beforeEach(async () => {
-    // Clean sessions between tests but keep the user
+    // Clean sessions and usage between tests but keep the user
     const db = getTestDb();
-    const { interviewSessions, sessionFeedback, transcripts } = await import(
-      "@/lib/schema"
-    );
+    const { interviewSessions, sessionFeedback, transcripts, interviewUsage } =
+      await import("@/lib/schema");
     await db.delete(sessionFeedback);
     await db.delete(transcripts);
     await db.delete(interviewSessions);
+    await db.delete(interviewUsage);
+    // Reset plan to free between tests
+    const { eq } = await import("drizzle-orm");
+    await db
+      .update(users)
+      .set({ plan: "free" })
+      .where(eq(users.id, TEST_USER.id));
   });
 
   afterAll(async () => {
@@ -390,6 +396,152 @@ describe("API /api/sessions (integration)", () => {
     // 3rd should succeed
     const res = await POST(makePostRequest({ type: "behavioral" }));
     expect(res.status).toBe(201);
+  });
+
+  // ---- Free-tier monthly limit (#38) ----
+
+  it("POST returns 402 free_tier_limit_reached when monthly limit hit (free plan)", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const db = getTestDb();
+    const { interviewUsage } = await import("@/lib/schema");
+    const periodStart = new Date(
+      Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1)
+    );
+
+    // Pre-seed the usage row at the limit (3/3)
+    await db.insert(interviewUsage).values({
+      userId: TEST_USER.id,
+      periodStart,
+      count: 3,
+    });
+
+    const res = await POST(makePostRequest({ type: "behavioral" }));
+    expect(res.status).toBe(402);
+    const data = await res.json();
+    expect(data.error).toBe("free_tier_limit_reached");
+    expect(data.limit).toBe(3);
+    expect(data.used).toBe(3);
+    expect(data.plan).toBe("free");
+    expect(data.upgradeUrl).toBe("/api/billing/checkout");
+
+    // No new session row was created — the transaction rolled back
+    const { interviewSessions } = await import("@/lib/schema");
+    const allSessions = await db.select().from(interviewSessions);
+    expect(allSessions.length).toBe(0);
+  });
+
+  it("POST increments interview_usage on successful session creation", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const db = getTestDb();
+    const { interviewUsage } = await import("@/lib/schema");
+    const { eq } = await import("drizzle-orm");
+
+    const res = await POST(makePostRequest({ type: "behavioral" }));
+    expect(res.status).toBe(201);
+
+    // Usage row should now exist with count=1
+    const [usage] = await db
+      .select()
+      .from(interviewUsage)
+      .where(eq(interviewUsage.userId, TEST_USER.id));
+    expect(usage).toBeDefined();
+    expect(usage.count).toBe(1);
+  });
+
+  it("POST does not gate pro users on monthly count", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const db = getTestDb();
+    const { interviewUsage } = await import("@/lib/schema");
+    const { eq } = await import("drizzle-orm");
+
+    // Upgrade user to pro
+    await db.update(users).set({ plan: "pro" }).where(eq(users.id, TEST_USER.id));
+
+    // Even with 99 prior usage rows, pro users should pass
+    const periodStart = new Date(
+      Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1)
+    );
+    await db.insert(interviewUsage).values({
+      userId: TEST_USER.id,
+      periodStart,
+      count: 99,
+    });
+
+    const res = await POST(makePostRequest({ type: "behavioral" }));
+    expect(res.status).toBe(201);
+
+    // Pro users should NOT have their counter touched
+    const [usage] = await db
+      .select()
+      .from(interviewUsage)
+      .where(eq(interviewUsage.userId, TEST_USER.id));
+    expect(usage.count).toBe(99); // unchanged
+  });
+
+  it("POST treats a fresh calendar month as 1/3, not 4/3", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const db = getTestDb();
+    const { interviewUsage } = await import("@/lib/schema");
+    const { eq } = await import("drizzle-orm");
+
+    // Insert an OLD-month usage row at the limit
+    const oldPeriodStart = new Date(Date.UTC(2025, 0, 1));
+    await db.insert(interviewUsage).values({
+      userId: TEST_USER.id,
+      periodStart: oldPeriodStart,
+      count: 3,
+    });
+
+    // New month should not see the old row
+    const res = await POST(makePostRequest({ type: "behavioral" }));
+    expect(res.status).toBe(201);
+
+    // A fresh row for the current period should be inserted with count=1
+    const currentPeriodStart = new Date(
+      Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1)
+    );
+    const [currentUsage] = await db
+      .select()
+      .from(interviewUsage)
+      .where(eq(interviewUsage.periodStart, currentPeriodStart));
+    expect(currentUsage.count).toBe(1);
+  });
+
+  it("POST concurrent requests at 2/3 — exactly one succeeds, the other gets 402", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const db = getTestDb();
+    const { interviewUsage } = await import("@/lib/schema");
+    const periodStart = new Date(
+      Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1)
+    );
+
+    // Pre-seed at 2/3
+    await db.insert(interviewUsage).values({
+      userId: TEST_USER.id,
+      periodStart,
+      count: 2,
+    });
+
+    const [resA, resB] = await Promise.all([
+      POST(makePostRequest({ type: "behavioral" })),
+      POST(makePostRequest({ type: "behavioral" })),
+    ]);
+
+    const statuses = [resA.status, resB.status].sort();
+    expect(statuses).toEqual([201, 402]);
+
+    // Final usage should be exactly 3 (one increment)
+    const { eq } = await import("drizzle-orm");
+    const [finalUsage] = await db
+      .select()
+      .from(interviewUsage)
+      .where(eq(interviewUsage.userId, TEST_USER.id));
+    expect(finalUsage.count).toBe(3);
   });
 
   it("POST returns 403 when account is disabled", async () => {

--- a/apps/web/app/api/sessions/route.ts
+++ b/apps/web/app/api/sessions/route.ts
@@ -3,13 +3,14 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { interviewSessions, sessionFeedback, users } from "@/lib/schema";
 import { and, desc, eq, gte, lte, sql, ne } from "drizzle-orm";
-import { getPlanConfig } from "@/lib/plans";
+import { getPlanConfig, FREE_PLAN_MONTHLY_INTERVIEW_LIMIT } from "@/lib/plans";
 import {
   createSessionSchema,
   behavioralConfigSchema,
   technicalConfigSchema,
 } from "@/lib/validations";
 import { checkRateLimit } from "@/lib/api-utils";
+import { tryConsumeInterviewSlot } from "@/lib/usage";
 
 // GET /api/sessions — list sessions with pagination, type/score filters
 // Query params: page (1-based), limit, type, minScore, maxScore
@@ -163,14 +164,54 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  const [created] = await db
-    .insert(interviewSessions)
-    .values({
-      userId: session.user.id,
-      type,
-      config: config ?? {},
-    })
-    .returning();
+  // Capture once so the transaction callback closure has a narrowed string
+  // (TypeScript loses the `session.user.id` non-null narrowing across the
+  // async boundary).
+  const userId = session.user.id;
 
-  return NextResponse.json(created, { status: 201 });
+  // Free-tier monthly limit gate. Pro users short-circuit out of the
+  // counter entirely; free users at the limit get a 402 with a documented
+  // body the client uses to trigger the upgrade dialog. The slot consume
+  // and the session insert run in the same transaction so two parallel
+  // requests at 2/3 cannot both succeed.
+  try {
+    const created = await db.transaction(async (tx) => {
+      const slot = await tryConsumeInterviewSlot(userId, tx);
+      if (!slot.allowed) {
+        // Throwing rolls back the transaction (no usage row written, no
+        // session row written). The catch below maps it to 402.
+        const err = new Error("free_tier_limit_reached") as Error & {
+          httpBody?: Record<string, unknown>;
+        };
+        err.httpBody = {
+          error: "free_tier_limit_reached",
+          limit: slot.limit ?? FREE_PLAN_MONTHLY_INTERVIEW_LIMIT,
+          used: slot.used,
+          plan: "free",
+          upgradeUrl: "/api/billing/checkout",
+        };
+        throw err;
+      }
+
+      const [row] = await tx
+        .insert(interviewSessions)
+        .values({
+          userId,
+          type,
+          config: config ?? {},
+        })
+        .returning();
+      return row;
+    });
+    return NextResponse.json(created, { status: 201 });
+  } catch (err) {
+    if (err instanceof Error && err.message === "free_tier_limit_reached") {
+      const httpBody = (err as Error & { httpBody?: Record<string, unknown> })
+        .httpBody;
+      return NextResponse.json(httpBody ?? { error: err.message }, {
+        status: 402,
+      });
+    }
+    throw err;
+  }
 }

--- a/apps/web/app/api/usage/current/route.integration.test.ts
+++ b/apps/web/app/api/usage/current/route.integration.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
+import {
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../../tests/setup-db";
+import { users, interviewUsage } from "@/lib/schema";
+import { eq } from "drizzle-orm";
+
+const mockAuth = vi.fn();
+vi.mock("@/lib/auth", () => ({ auth: () => mockAuth() }));
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return getTestDb();
+  },
+}));
+
+import { GET } from "./route";
+
+const TEST_USER = {
+  id: "00000000-0000-0000-0000-000000000040",
+  email: "usage-test@example.com",
+  name: "Usage Test User",
+};
+
+describe("GET /api/usage/current (integration)", () => {
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values(TEST_USER).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const db = getTestDb();
+    await db.delete(interviewUsage).where(eq(interviewUsage.userId, TEST_USER.id));
+    await db
+      .update(users)
+      .set({ plan: "free" })
+      .where(eq(users.id, TEST_USER.id));
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns plan=free, used=0, limit=3 for a brand-new free user", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.plan).toBe("free");
+    expect(data.used).toBe(0);
+    expect(data.limit).toBe(3);
+  });
+
+  it("returns the current period count for a free user with prior usage", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const db = getTestDb();
+    const periodStart = new Date(
+      Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1)
+    );
+    await db.insert(interviewUsage).values({
+      userId: TEST_USER.id,
+      periodStart,
+      count: 2,
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.plan).toBe("free");
+    expect(data.used).toBe(2);
+    expect(data.limit).toBe(3);
+  });
+
+  it("returns plan=pro, used=0, limit=null for a pro user (counter not consulted)", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const db = getTestDb();
+    await db
+      .update(users)
+      .set({ plan: "pro" })
+      .where(eq(users.id, TEST_USER.id));
+
+    // Even with prior usage rows, pro users always see used=0 / limit=null
+    const periodStart = new Date(
+      Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1)
+    );
+    await db.insert(interviewUsage).values({
+      userId: TEST_USER.id,
+      periodStart,
+      count: 99,
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.plan).toBe("pro");
+    expect(data.used).toBe(0);
+    expect(data.limit).toBeNull();
+  });
+
+  it("ignores usage rows from other periods (calendar rollover)", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const db = getTestDb();
+    // Insert a usage row from January 2025 (well in the past)
+    await db.insert(interviewUsage).values({
+      userId: TEST_USER.id,
+      periodStart: new Date(Date.UTC(2025, 0, 1)),
+      count: 3,
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    // Old-month row should be invisible — current period is empty
+    expect(data.used).toBe(0);
+  });
+});

--- a/apps/web/app/api/usage/current/route.ts
+++ b/apps/web/app/api/usage/current/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { getCurrentPeriodUsage } from "@/lib/usage";
+import { getCurrentUserPlan } from "@/lib/user-plan";
+import { FREE_PLAN_MONTHLY_INTERVIEW_LIMIT } from "@/lib/plans";
+import { createRequestLogger } from "@/lib/logger";
+
+/**
+ * GET /api/usage/current
+ *
+ * Returns the authenticated user's current period interview usage and plan.
+ * Used by the dashboard usage meter and the upgrade prompt dialog.
+ */
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const log = createRequestLogger({
+    route: "GET /api/usage/current",
+    userId: session.user.id,
+  });
+
+  const plan = await getCurrentUserPlan(session.user.id);
+  const used = plan === "pro" ? 0 : await getCurrentPeriodUsage(session.user.id);
+  const limit = plan === "pro" ? null : FREE_PLAN_MONTHLY_INTERVIEW_LIMIT;
+
+  log.info({ plan, used, limit }, "fetched current usage");
+
+  return NextResponse.json({ plan, used, limit });
+}

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { StreakCard } from "@/components/dashboard/StreakCard";
 import { BadgeGrid } from "@/components/dashboard/BadgeGrid";
 import { ScoreTrendChart, ScoreTrendPoint } from "@/components/dashboard/ScoreTrendChart";
 import { WeakAreas, WeakArea } from "@/components/dashboard/WeakAreas";
+import { MonthlyUsageMeter } from "@/components/dashboard/MonthlyUsageMeter";
 
 interface SessionRow {
   id: string;
@@ -196,6 +197,11 @@ export default function DashboardPage() {
       <p className="text-muted-foreground mb-8">
         View your interview history and track your progress.
       </p>
+
+      {/* Free-tier monthly usage meter (renders nothing for Pro users). */}
+      <div className="mb-6">
+        <MonthlyUsageMeter />
+      </div>
 
       {/* Stats cards */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">

--- a/apps/web/components/billing/UpgradePromptDialog.test.tsx
+++ b/apps/web/components/billing/UpgradePromptDialog.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { UpgradePromptDialog } from "./UpgradePromptDialog";
+
+describe("UpgradePromptDialog", () => {
+  const originalFetch = global.fetch;
+  const originalLocation = window.location;
+  let assignSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    assignSpy = vi.fn();
+    // @ts-expect-error — relaxing types for the test stub
+    delete window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: {
+        ...originalLocation,
+        assign: assignSpy as unknown as Location["assign"],
+        replace: vi.fn() as unknown as Location["replace"],
+        reload: vi.fn() as unknown as Location["reload"],
+      },
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    // @ts-expect-error — relaxing types for the test stub
+    delete window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    });
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when open is false", () => {
+    render(
+      <UpgradePromptDialog open={false} onClose={() => {}} used={3} limit={3} />
+    );
+    expect(screen.queryByTestId("upgrade-dialog")).toBeNull();
+  });
+
+  it("shows the current usage numbers from props", () => {
+    render(
+      <UpgradePromptDialog open={true} onClose={() => {}} used={3} limit={3} />
+    );
+    expect(screen.getByTestId("upgrade-dialog-used").textContent).toBe("3");
+    expect(screen.getByTestId("upgrade-dialog-limit").textContent).toBe("3");
+  });
+
+  it("renders the Pro benefits list", () => {
+    render(
+      <UpgradePromptDialog open={true} onClose={() => {}} used={3} limit={3} />
+    );
+    expect(
+      screen.getAllByText(/Unlimited mock interviews/).length
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("clicking 'Maybe later' calls onClose", () => {
+    const onClose = vi.fn();
+    render(
+      <UpgradePromptDialog open={true} onClose={onClose} used={3} limit={3} />
+    );
+    fireEvent.click(screen.getByText("Maybe later"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("clicking 'Upgrade to Pro' POSTs to /api/billing/checkout and redirects", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: "https://checkout.stripe.com/test_session" }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(
+      <UpgradePromptDialog open={true} onClose={() => {}} used={3} limit={3} />
+    );
+
+    fireEvent.click(screen.getByTestId("upgrade-dialog-cta"));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/billing/checkout",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+    await waitFor(() => {
+      expect(assignSpy).toHaveBeenCalledWith(
+        "https://checkout.stripe.com/test_session"
+      );
+    });
+  });
+
+  it("shows an error message when the checkout endpoint fails", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "stripe is down" }),
+    }) as unknown as typeof fetch;
+
+    render(
+      <UpgradePromptDialog open={true} onClose={() => {}} used={3} limit={3} />
+    );
+
+    fireEvent.click(screen.getByTestId("upgrade-dialog-cta"));
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/stripe is down/).length).toBeGreaterThanOrEqual(1);
+    });
+    expect(assignSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/components/billing/UpgradePromptDialog.tsx
+++ b/apps/web/components/billing/UpgradePromptDialog.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { PLAN_DEFINITIONS } from "@/lib/plans";
+
+interface UpgradePromptDialogProps {
+  open: boolean;
+  onClose: () => void;
+  used: number;
+  limit: number;
+}
+
+const PRO_BENEFITS = [
+  "Unlimited mock interviews — no monthly cap",
+  "Behavioral and technical interviews, both formats",
+  "Voice-to-voice practice with scored feedback",
+  "Save and revisit your STAR stories with AI scoring",
+];
+
+/**
+ * Modal that surfaces when the API returns a 402 free_tier_limit_reached
+ * response. Shows current usage, the Pro benefits list pulled from
+ * `PLAN_DEFINITIONS.pro`, and an "Upgrade to Pro" button that POSTs to
+ * `/api/billing/checkout` and redirects to the returned Stripe URL.
+ */
+export function UpgradePromptDialog({
+  open,
+  onClose,
+  used,
+  limit,
+}: UpgradePromptDialogProps) {
+  const [isUpgrading, setIsUpgrading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Close on Escape.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const handleUpgrade = async () => {
+    setIsUpgrading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/billing/checkout", { method: "POST" });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || "Failed to start checkout");
+        return;
+      }
+      const data = await res.json();
+      if (data.url) {
+        window.location.assign(data.url);
+        return;
+      }
+      setError("Checkout returned no URL");
+    } catch {
+      setError("Failed to start checkout");
+    } finally {
+      setIsUpgrading(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="upgrade-dialog-title"
+      data-testid="upgrade-dialog"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+    >
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+        data-testid="upgrade-dialog-backdrop"
+      />
+      <div className="relative z-10 w-full max-w-md rounded-lg border bg-background p-6 shadow-lg">
+        <h2
+          id="upgrade-dialog-title"
+          className="text-xl font-semibold mb-2"
+        >
+          You&apos;ve hit your monthly limit
+        </h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          You&apos;ve used <strong data-testid="upgrade-dialog-used">{used}</strong>{" "}
+          of <strong data-testid="upgrade-dialog-limit">{limit}</strong>{" "}
+          interviews this month. Upgrade to Pro for unlimited practice.
+        </p>
+
+        <div className="rounded-md border p-4 mb-4 bg-muted/30">
+          <p className="text-sm font-medium mb-2">
+            Pro — ${PLAN_DEFINITIONS.pro.priceUsd}/month
+          </p>
+          <ul className="text-sm space-y-1.5">
+            {PRO_BENEFITS.map((benefit) => (
+              <li key={benefit} className="flex items-start gap-2">
+                <span aria-hidden className="mt-0.5">✓</span>
+                <span>{benefit}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {error && (
+          <p
+            role="alert"
+            className="text-sm text-destructive mb-3"
+          >
+            {error}
+          </p>
+        )}
+
+        <div className="flex gap-2 justify-end">
+          <Button variant="outline" onClick={onClose} disabled={isUpgrading}>
+            Maybe later
+          </Button>
+          <Button
+            onClick={handleUpgrade}
+            disabled={isUpgrading}
+            data-testid="upgrade-dialog-cta"
+          >
+            {isUpgrading ? "Loading..." : "Upgrade to Pro"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/MonthlyUsageMeter.tsx
+++ b/apps/web/components/dashboard/MonthlyUsageMeter.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface UsageResponse {
+  plan: "free" | "pro";
+  used: number;
+  limit: number | null;
+}
+
+/**
+ * Dashboard widget that shows "X / Y interviews used this month" for free
+ * users only. Pro users render nothing (returns null). Fetches from
+ * `GET /api/usage/current`.
+ */
+export function MonthlyUsageMeter() {
+  const [usage, setUsage] = useState<UsageResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchUsage() {
+      try {
+        const res = await fetch("/api/usage/current");
+        if (!res.ok) return;
+        const data: UsageResponse = await res.json();
+        if (!cancelled) setUsage(data);
+      } catch {
+        // Silent — meter is non-critical UX.
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+    fetchUsage();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (isLoading) {
+    return (
+      <Card data-testid="usage-meter-loading">
+        <CardContent className="p-6">
+          <div className="h-5 w-40 animate-pulse rounded bg-muted" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Pro users (or unknown) get nothing.
+  if (!usage || usage.plan === "pro" || usage.limit === null) {
+    return null;
+  }
+
+  const { used, limit } = usage;
+  const percent = Math.min(100, Math.round((used / limit) * 100));
+  const isAtLimit = used >= limit;
+
+  return (
+    <Card data-testid="usage-meter">
+      <CardHeader>
+        <CardTitle className="text-base">This month&apos;s interviews</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-baseline justify-between mb-2">
+          <span
+            className="text-2xl font-bold tabular-nums"
+            data-testid="usage-meter-count"
+          >
+            {used} / {limit}
+          </span>
+          {isAtLimit && (
+            <span className="text-xs text-destructive font-medium">
+              Limit reached
+            </span>
+          )}
+        </div>
+        <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
+          <div
+            className={`h-full transition-all ${
+              isAtLimit ? "bg-destructive" : "bg-primary"
+            }`}
+            style={{ width: `${percent}%` }}
+            data-testid="usage-meter-bar"
+          />
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">
+          {isAtLimit
+            ? "Upgrade to Pro for unlimited practice."
+            : `${limit - used} interviews remaining this month.`}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/interview/BehavioralSetupForm.tsx
+++ b/apps/web/components/interview/BehavioralSetupForm.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useInterviewStore } from "@/stores/interviewStore";
 import { TemplateControls } from "./TemplateControls";
 import { ResumeSelector } from "./ResumeSelector";
+import { UpgradePromptDialog } from "@/components/billing/UpgradePromptDialog";
 import { usePrefillStore } from "@/stores/prefillStore";
 import type { BehavioralSessionConfig } from "@interview-assistant/shared";
 
@@ -23,6 +24,8 @@ interface CompanyQuestion {
 export function BehavioralSetupForm() {
   const router = useRouter();
   const { config, setConfig, setType, createSession } = useInterviewStore();
+  const quotaError = useInterviewStore((s) => s.quotaError);
+  const clearQuotaError = useInterviewStore((s) => s.clearQuotaError);
   const [questionInput, setQuestionInput] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -358,6 +361,15 @@ export function BehavioralSetupForm() {
       <Button type="submit" size="lg" className="w-full" disabled={isSubmitting}>
         {isSubmitting ? "Creating Session..." : "Start Interview"}
       </Button>
+
+      {quotaError && (
+        <UpgradePromptDialog
+          open={true}
+          onClose={clearQuotaError}
+          used={quotaError.used}
+          limit={quotaError.limit}
+        />
+      )}
     </form>
   );
 }

--- a/apps/web/components/interview/TechnicalSetupForm.tsx
+++ b/apps/web/components/interview/TechnicalSetupForm.tsx
@@ -18,6 +18,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useInterviewStore } from "@/stores/interviewStore";
 import { TemplateControls } from "./TemplateControls";
 import { ResumeSelector } from "./ResumeSelector";
+import { UpgradePromptDialog } from "@/components/billing/UpgradePromptDialog";
 import {
   SUPPORTED_LANGUAGES,
   FOCUS_AREAS_BY_TYPE,
@@ -51,6 +52,8 @@ function formatFocusArea(area: string): string {
 export function TechnicalSetupForm() {
   const router = useRouter();
   const { config, setConfig, setType, createSession } = useInterviewStore();
+  const quotaError = useInterviewStore((s) => s.quotaError);
+  const clearQuotaError = useInterviewStore((s) => s.clearQuotaError);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -268,6 +271,15 @@ export function TechnicalSetupForm() {
       >
         {isSubmitting ? "Creating Session..." : "Start Interview"}
       </Button>
+
+      {quotaError && (
+        <UpgradePromptDialog
+          open={true}
+          onClose={clearQuotaError}
+          used={quotaError.used}
+          limit={quotaError.limit}
+        />
+      )}
     </form>
   );
 }

--- a/apps/web/lib/usage.test.ts
+++ b/apps/web/lib/usage.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { currentFreePeriodStart } from "./usage";
+
+describe("currentFreePeriodStart", () => {
+  it("returns the first day of the current UTC month at midnight", () => {
+    const now = new Date(Date.UTC(2026, 4, 17, 13, 42, 19, 999)); // 2026-05-17T13:42:19Z
+    const period = currentFreePeriodStart(now);
+    expect(period.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+  });
+
+  it("uses UTC, not local time, so a Sydney user at midnight local does not get a new period", () => {
+    // 2026-05-31 14:30 UTC is 2026-06-01 00:30 in Sydney, but UTC says May.
+    const now = new Date(Date.UTC(2026, 4, 31, 14, 30, 0));
+    const period = currentFreePeriodStart(now);
+    expect(period.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+  });
+
+  it("rolls over on UTC month boundary", () => {
+    const before = new Date(Date.UTC(2026, 4, 31, 23, 59, 59, 999));
+    const after = new Date(Date.UTC(2026, 5, 1, 0, 0, 0, 0));
+    expect(currentFreePeriodStart(before).toISOString()).toBe(
+      "2026-05-01T00:00:00.000Z"
+    );
+    expect(currentFreePeriodStart(after).toISOString()).toBe(
+      "2026-06-01T00:00:00.000Z"
+    );
+  });
+
+  it("handles January correctly (month index 0)", () => {
+    const now = new Date(Date.UTC(2026, 0, 15, 12, 0, 0));
+    expect(currentFreePeriodStart(now).toISOString()).toBe(
+      "2026-01-01T00:00:00.000Z"
+    );
+  });
+
+  it("handles December correctly (month index 11)", () => {
+    const now = new Date(Date.UTC(2026, 11, 31, 23, 59, 59));
+    expect(currentFreePeriodStart(now).toISOString()).toBe(
+      "2026-12-01T00:00:00.000Z"
+    );
+  });
+
+  it("returns a Date object, not a string", () => {
+    expect(currentFreePeriodStart()).toBeInstanceOf(Date);
+  });
+});

--- a/apps/web/lib/usage.ts
+++ b/apps/web/lib/usage.ts
@@ -1,0 +1,166 @@
+/**
+ * Free-tier interview-usage tracking.
+ *
+ * Free users get FREE_PLAN_MONTHLY_INTERVIEW_LIMIT mock interviews per
+ * calendar month. Pro users are unlimited and short-circuit out before
+ * any DB read.
+ *
+ * Usage rows live in `interview_usage(user_id, period_start, count)` with
+ * a unique index on `(user_id, period_start)` so the increment is a single
+ * indexed UPSERT. Free users' period_start is `date_trunc('month', now())`;
+ * old months naturally roll over because the new month produces a new
+ * period_start key that doesn't match any existing row.
+ */
+import { sql } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { interviewUsage } from "@/lib/schema";
+import { FREE_PLAN_MONTHLY_INTERVIEW_LIMIT } from "@/lib/plans";
+import { getCurrentUserPlan } from "@/lib/user-plan";
+
+/**
+ * Accepts the top-level `db` instance OR a transaction handle from
+ * `db.transaction(async (tx) => ...)`. Both expose the same query API.
+ * Using `typeof db` for the tx case is too narrow because Drizzle's
+ * transaction type carries different generic parameters; we accept any
+ * compatible client and rely on duck typing.
+ */
+type DbOrTx =
+  | typeof db
+  | Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/**
+ * The period-start key for the current user. For Free users this is the
+ * first day of the current calendar month at UTC midnight. Using UTC keeps
+ * the boundary stable across timezones — a user in Sydney crossing midnight
+ * local time should not get a fresh quota until UTC also rolls over.
+ */
+export function currentFreePeriodStart(now: Date = new Date()): Date {
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0)
+  );
+}
+
+/** Returns the current period's used-interview count for the given user. */
+export async function getCurrentPeriodUsage(userId: string): Promise<number> {
+  const periodStart = currentFreePeriodStart();
+  const [row] = await db
+    .select({ count: interviewUsage.count })
+    .from(interviewUsage)
+    .where(
+      and(
+        eq(interviewUsage.userId, userId),
+        eq(interviewUsage.periodStart, periodStart)
+      )
+    );
+  return row?.count ?? 0;
+}
+
+/**
+ * Returns true if the user is allowed to start another interview this period.
+ * Pro users always allowed (short-circuit, no DB read).
+ */
+export async function isWithinFreeLimit(userId: string): Promise<boolean> {
+  const plan = await getCurrentUserPlan(userId);
+  if (plan === "pro") return true;
+  const used = await getCurrentPeriodUsage(userId);
+  return used < FREE_PLAN_MONTHLY_INTERVIEW_LIMIT;
+}
+
+/**
+ * Atomically increments the current period's interview count.
+ *
+ * Accepts an optional transaction handle so callers (the session-creation
+ * route) can run the increment in the same transaction as the session
+ * insert. Without `tx`, runs in its own connection.
+ *
+ * Uses INSERT ... ON CONFLICT DO UPDATE to be both idempotent on first
+ * insertion and safe under concurrent increments — Postgres serialises the
+ * row-level lock on the unique index, so two simultaneous +1's both land.
+ */
+export async function incrementInterviewUsage(
+  userId: string,
+  txOrDb: DbOrTx = db
+): Promise<void> {
+  const periodStart = currentFreePeriodStart();
+  await (txOrDb as typeof db)
+    .insert(interviewUsage)
+    .values({ userId, periodStart, count: 1 })
+    .onConflictDoUpdate({
+      target: [interviewUsage.userId, interviewUsage.periodStart],
+      set: { count: sql`${interviewUsage.count} + 1` },
+    });
+}
+
+/**
+ * Read-and-bump used by interview-start endpoints. Returns the new count
+ * if the slot was successfully consumed, or `allowed: false` if the user
+ * is at the limit. Pro users always allowed (no counter touched).
+ *
+ * **Concurrency-safe** via a single atomic UPSERT with a guarded DO UPDATE:
+ *
+ *   INSERT INTO interview_usage (user_id, period_start, count)
+ *   VALUES ($1, $2, 1)
+ *   ON CONFLICT (user_id, period_start)
+ *   DO UPDATE SET count = interview_usage.count + 1
+ *     WHERE interview_usage.count < $limit
+ *   RETURNING count;
+ *
+ * - Brand-new user → INSERT runs, returns count=1.
+ * - User at count=2 (limit 3) → conflict, WHERE 2<3 passes, UPDATE to 3,
+ *   returns count=3.
+ * - User at count=3 → conflict, WHERE 3<3 fails, UPDATE skipped, RETURNING
+ *   yields zero rows.
+ *
+ * Two parallel callers serialize on the row lock taken by the upsert; the
+ * second one sees the first's commit and applies the WHERE against the
+ * incremented value, so only one can ever cross the threshold.
+ */
+export async function tryConsumeInterviewSlot(
+  userId: string,
+  txOrDb: DbOrTx = db
+): Promise<{ allowed: boolean; used: number; limit: number | null }> {
+  const plan = await getCurrentUserPlan(userId);
+  if (plan === "pro") {
+    return { allowed: true, used: 0, limit: null };
+  }
+
+  const periodStart = currentFreePeriodStart();
+  const limit = FREE_PLAN_MONTHLY_INTERVIEW_LIMIT;
+
+  const rows = await (txOrDb as typeof db)
+    .insert(interviewUsage)
+    .values({ userId, periodStart, count: 1 })
+    .onConflictDoUpdate({
+      target: [interviewUsage.userId, interviewUsage.periodStart],
+      set: { count: sql`${interviewUsage.count} + 1` },
+      setWhere: sql`${interviewUsage.count} < ${limit}`,
+    })
+    .returning({ count: interviewUsage.count });
+
+  if (rows.length === 0) {
+    // The conflict's WHERE filtered out the update — user is at or over
+    // the limit. Re-read the actual count for the response body.
+    const current = await getCurrentPeriodUsageWithDb(userId, txOrDb);
+    return { allowed: false, used: current, limit };
+  }
+
+  return { allowed: true, used: rows[0].count, limit };
+}
+
+async function getCurrentPeriodUsageWithDb(
+  userId: string,
+  txOrDb: DbOrTx
+): Promise<number> {
+  const periodStart = currentFreePeriodStart();
+  const [row] = await (txOrDb as typeof db)
+    .select({ count: interviewUsage.count })
+    .from(interviewUsage)
+    .where(
+      and(
+        eq(interviewUsage.userId, userId),
+        eq(interviewUsage.periodStart, periodStart)
+      )
+    );
+  return row?.count ?? 0;
+}

--- a/apps/web/stores/interviewStore.ts
+++ b/apps/web/stores/interviewStore.ts
@@ -8,6 +8,12 @@ import type {
   TranscriptEntry,
 } from "@interview-assistant/shared";
 
+/** Set on the store when POST /api/sessions returns 402 free_tier_limit_reached. */
+export interface QuotaError {
+  used: number;
+  limit: number;
+}
+
 interface InterviewState {
   // Session data
   sessionId: string | null;
@@ -16,6 +22,13 @@ interface InterviewState {
   status: SessionStatus;
   transcript: TranscriptEntry[];
   error: string | null;
+  /**
+   * Captures the body of a 402 free_tier_limit_reached response from
+   * `POST /api/sessions` so the setup form can render the
+   * `<UpgradePromptDialog>`. Cleared on the next successful createSession()
+   * or via clearQuotaError().
+   */
+  quotaError: QuotaError | null;
 
   // Timing
   startedAt: Date | null;
@@ -24,6 +37,7 @@ interface InterviewState {
   setType: (type: InterviewType) => void;
   setConfig: (partial: Partial<SessionConfig>) => void;
   createSession: () => Promise<string | null>;
+  clearQuotaError: () => void;
   startSession: () => Promise<void>;
   endSession: () => Promise<void>;
   addTranscriptEntry: (entry: TranscriptEntry) => void;
@@ -49,6 +63,7 @@ export const useInterviewStore = create<InterviewState>((set, get) => ({
   status: "configuring",
   transcript: [],
   error: null,
+  quotaError: null,
   startedAt: null,
 
   setType: (type) => {
@@ -67,7 +82,7 @@ export const useInterviewStore = create<InterviewState>((set, get) => ({
   createSession: async () => {
     const { config, type } = get();
     const sessionType = type ?? "behavioral";
-    set({ error: null });
+    set({ error: null, quotaError: null });
 
     try {
       const res = await fetch("/api/sessions", {
@@ -77,7 +92,21 @@ export const useInterviewStore = create<InterviewState>((set, get) => ({
       });
 
       if (!res.ok) {
-        const data = await res.json();
+        const data = await res.json().catch(() => ({}));
+        // Capture the 402 free_tier_limit_reached body so the setup form
+        // can render the upgrade dialog with the exact used/limit numbers.
+        if (
+          res.status === 402 &&
+          data?.error === "free_tier_limit_reached" &&
+          typeof data.used === "number" &&
+          typeof data.limit === "number"
+        ) {
+          set({
+            error: data.error,
+            quotaError: { used: data.used, limit: data.limit },
+          });
+          return null;
+        }
         set({ error: data.error || "Failed to create session" });
         return null;
       }
@@ -93,6 +122,8 @@ export const useInterviewStore = create<InterviewState>((set, get) => ({
       return null;
     }
   },
+
+  clearQuotaError: () => set({ quotaError: null, error: null }),
 
   startSession: async () => {
     const { sessionId } = get();
@@ -171,6 +202,7 @@ export const useInterviewStore = create<InterviewState>((set, get) => ({
       status: "configuring",
       transcript: [],
       error: null,
+      quotaError: null,
       startedAt: null,
     }),
 }));


### PR DESCRIPTION
## Summary

- New `lib/usage.ts` helper with an **atomic, race-safe** slot consume — single UPSERT with `DO UPDATE SET count = count + 1 WHERE count < limit RETURNING count`. Two parallel callers serialize on the row lock and only one can ever cross the threshold.
- `POST /api/sessions` wraps the slot consume + session insert in a single `db.transaction`. If the slot is denied, the transaction rolls back and the route returns **402** with body `{ error: "free_tier_limit_reached", limit, used, plan: "free", upgradeUrl }`. Pro users short-circuit out of the counter entirely.
- New `<UpgradePromptDialog>`, `<MonthlyUsageMeter>` (dashboard, free users only), and `GET /api/usage/current` for both. The interview store captures the 402 body into `quotaError`; both setup forms render the dialog when set.

Closes #38
Part of #34

## How concurrency is enforced

The original spec said "transaction with concurrency safety." A naive SELECT-then-decide-then-INSERT inside a transaction does **not** prevent two parallel callers at 2/3 from both succeeding — the SELECT happens outside the row lock, both observe count=2, both decide allowed=true, both insert count=3 → user lands on 4. I caught this in the concurrency test (it failed first on `[ 201, 201 ]` instead of `[ 201, 402 ]`).

The fix is a single conditional UPSERT:

```sql
INSERT INTO interview_usage (user_id, period_start, count) VALUES ($1, $2, 1)
ON CONFLICT (user_id, period_start)
DO UPDATE SET count = interview_usage.count + 1 WHERE interview_usage.count < $limit
RETURNING count;
```

- Brand-new user → INSERT runs, returns count=1.
- User at count=2 → conflict, `2 < 3` passes, UPDATE to 3, returns 3.
- User at count=3 → conflict, `3 < 3` fails, UPDATE skipped, RETURNING is empty.

Two parallel callers serialize on the row lock taken by the upsert. The second one sees the first's commit, applies the WHERE against the incremented value, and the WHERE filters it out. Only one ever crosses the threshold. The concurrency test now passes deterministically.

## Schema changes

None — `interview_usage(user_id, period_start, count)` already exists from #35.

## Test plan

- [x] `npx turbo lint typecheck test` — 446 unit/component tests green
- [x] `npm run test:integration` — 263 integration tests green
  - 5 new on `POST /api/sessions`: 402 at limit, increment-on-success, pro user bypass at 99/3, calendar rollover from old month, **true concurrency** with `Promise.all` (2/3 → exactly one 201 + one 402)
  - 5 new on `GET /api/usage/current`: 401, free user 0/3, free user with prior usage, pro user (used=0 limit=null), old-month rollover
  - 6 unit tests for `currentFreePeriodStart` (UTC boundaries, Jan/Dec)
  - 6 component tests for `<UpgradePromptDialog>`
- [x] Reviewer approves
- [ ] Manual smoke: free user account → start 4 interviews → 4th opens upgrade dialog with "3 of 3 used"

## Notes for reviewers

- **Existing daily session limit** (line 128 of route.ts) returns 429 and runs **before** the new monthly check. Both gates coexist — the daily check is a per-day quota, the monthly check is a per-month free-tier counter. Pro users skip both.
- **`window.location` mock pattern** in `UpgradePromptDialog.test.tsx` and `profile.test.tsx` uses `Object.defineProperty` to replace the whole `window.location` object because jsdom locks down `window.location.assign`. The `@ts-expect-error` comments are intentional.
- **Routes gated:** `POST /api/sessions` only — that's the single route in the codebase that creates session rows. `app/api/questions/**` routes do not create sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)