### PR TITLE
feat(marketer): Reddit scraper, AI classifier, and approval queue (#40)

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -170,6 +170,9 @@ task definition / secrets manager.
 | `STRIPE_SECRET_KEY`        | RUNTIME_ONLY       | Stripe secret API key (`sk_test_...` for dev, `sk_live_...` for prod). Never expose to client. |
 | `STRIPE_WEBHOOK_SECRET`    | RUNTIME_ONLY       | Webhook signing secret from `stripe listen` or Stripe Dashboard. Used to verify inbound events. |
 | `STRIPE_PRO_PRICE_ID`      | RUNTIME_ONLY       | Stripe Price ID for the Pro subscription plan (`price_...`). |
+| `CRON_SECRET`              | RUNTIME_ONLY       | Bearer token that Vercel Cron passes in the `Authorization` header to authorize `POST /api/admin/marketer/run`. Generate with `openssl rand -hex 32`. |
+| `ADMIN_USER_IDS`           | RUNTIME_ONLY       | Comma-separated list of NextAuth user UUIDs that are allowed to access `/admin/*` routes and the marketer queue API. |
+| `MARKETER_FRESHNESS_HOURS` | RUNTIME_ONLY       | How many hours old a Reddit post can be before being skipped by the marketer cron job (default: 48). |
 
 Server-only secrets (`SUPABASE_DB_URL`, `OPENAI_API_KEY`, `GOOGLE_CLIENT_SECRET`,
 `SENTRY_DSN`) must never be referenced from a file marked `"use client"` and

--- a/apps/web/app/admin/marketer/page.test.tsx
+++ b/apps/web/app/admin/marketer/page.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import MarketerAdminPage from "./page";
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+  usePathname: vi.fn(() => "/admin/marketer"),
+}));
+
+const mockDraft = {
+  id: "draft-1",
+  postId: "post-1",
+  intent: "prepare",
+  reply: "This is my helpful reply about interview prep.",
+  status: "pending",
+  createdAt: new Date().toISOString(),
+  post: {
+    id: "post-1",
+    subreddit: "cscareerquestions",
+    title: "How to prepare for Google interview?",
+    body: "I have an interview in 3 weeks...",
+    permalink: "https://reddit.com/r/cscareerquestions/comments/abc/",
+    classification: "prepare",
+    summary: "User wants Google prep tips",
+    postedAt: new Date().toISOString(),
+  },
+};
+
+const mockCheatDraft = {
+  id: "draft-2",
+  postId: "post-2",
+  intent: "cheat",
+  reply: "This is a reply about why cheating is risky.",
+  status: "pending",
+  createdAt: new Date().toISOString(),
+  post: {
+    id: "post-2",
+    subreddit: "cscareerquestions",
+    title: "Can I use AI during a live interview?",
+    body: "Wondering if I can secretly use ChatGPT...",
+    permalink: "https://reddit.com/r/cscareerquestions/comments/def/",
+    classification: "cheat",
+    summary: "User asking about cheating",
+    postedAt: new Date().toISOString(),
+  },
+};
+
+function mockFetchSuccess(drafts = [mockDraft, mockCheatDraft], total = 2) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      drafts,
+      pagination: {
+        page: 1,
+        limit: 20,
+        total,
+        totalPages: 1,
+      },
+    }),
+  } as Response);
+}
+
+describe("MarketerAdminPage", () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("renders loading skeleton while data fetches", () => {
+    global.fetch = vi.fn().mockReturnValue(new Promise(() => {})); // never resolves
+    render(<MarketerAdminPage />);
+    // Should show skeleton loading states
+    expect(document.querySelector(".animate-pulse, [data-slot='skeleton']")).toBeTruthy();
+  });
+
+  it("renders draft cards with post info after loading", async () => {
+    mockFetchSuccess();
+    render(<MarketerAdminPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText("How to prepare for Google interview?")[0]).toBeTruthy();
+    });
+    expect(screen.getAllByText("Can I use AI during a live interview?")[0]).toBeTruthy();
+  });
+
+  it("shows empty state when no pending drafts", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        drafts: [],
+        pagination: { page: 1, limit: 20, total: 0, totalPages: 0 },
+      }),
+    } as Response);
+
+    render(<MarketerAdminPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText(/No pending drafts/)[0]).toBeTruthy();
+    });
+  });
+
+  it("shows prepare and cheat sections with correct draft counts", async () => {
+    mockFetchSuccess();
+    render(<MarketerAdminPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText(/Prepare/)[0]).toBeTruthy();
+      expect(screen.getAllByText(/Cheat/)[0]).toBeTruthy();
+    });
+  });
+
+  it("approve button calls fetch and removes card from list", async () => {
+    mockFetchSuccess([mockDraft]);
+    // Mock navigator.clipboard
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    // Mock window.open
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    render(<MarketerAdminPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Approve/)[0]).toBeTruthy();
+    });
+
+    // Set up the approve API call mock
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ...mockDraft, status: "approved" }),
+    } as Response);
+
+    const approveButtons = screen.getAllByText(/Approve/);
+    fireEvent.click(approveButtons[0]);
+
+    await waitFor(() => {
+      // The card should disappear after approval
+      expect(global.fetch).toHaveBeenCalledWith(
+        `/api/admin/marketer/drafts/${mockDraft.id}/approve`,
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    openSpy.mockRestore();
+  });
+
+  it("edit button switches textarea to editable mode", async () => {
+    mockFetchSuccess([mockDraft]);
+    render(<MarketerAdminPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Edit/)[0]).toBeTruthy();
+    });
+
+    const editButtons = screen.getAllByText(/Edit/);
+    fireEvent.click(editButtons[0]);
+
+    // Should now show a textarea that is editable
+    const textareas = document.querySelectorAll("textarea");
+    expect(textareas.length).toBeGreaterThan(0);
+  });
+
+  it("discard button requires selecting a reason before confirming", async () => {
+    mockFetchSuccess([mockDraft]);
+    render(<MarketerAdminPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Discard/)[0]).toBeTruthy();
+    });
+
+    const discardButtons = screen.getAllByText(/Discard/);
+    fireEvent.click(discardButtons[0]);
+
+    // Confirm button should appear but be disabled without a reason
+    await waitFor(() => {
+      const confirmBtn = screen.getAllByText(/Confirm/)[0] as HTMLButtonElement;
+      expect(confirmBtn.disabled).toBe(true);
+    });
+  });
+});

--- a/apps/web/app/admin/marketer/page.tsx
+++ b/apps/web/app/admin/marketer/page.tsx
@@ -1,0 +1,435 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ExternalLink, CheckCircle, Pencil, Trash2 } from "lucide-react";
+
+interface Post {
+  id: string;
+  subreddit: string;
+  title: string;
+  body: string;
+  permalink: string;
+  classification: string | null;
+  summary: string | null;
+  postedAt: string;
+}
+
+interface Draft {
+  id: string;
+  postId: string;
+  intent: string;
+  reply: string;
+  status: string;
+  createdAt: string;
+  post: Post;
+}
+
+const DISCARD_REASONS = [
+  { value: "spammy", label: "Spammy" },
+  { value: "off-topic", label: "Off-topic" },
+  { value: "duplicate", label: "Duplicate" },
+  { value: "low-quality", label: "Low quality" },
+  { value: "other", label: "Other" },
+];
+
+function DraftCard({
+  draft,
+  onApprove,
+  onEdit,
+  onDiscard,
+}: {
+  draft: Draft;
+  onApprove: (id: string) => Promise<void>;
+  onEdit: (id: string, reply: string) => Promise<void>;
+  onDiscard: (id: string, reason: string) => Promise<void>;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedReply, setEditedReply] = useState(draft.reply);
+  const [discardReason, setDiscardReason] = useState("");
+  const [showDiscard, setShowDiscard] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const handleApprove = async () => {
+    setLoading(true);
+    try {
+      await onApprove(draft.id);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSaveEdit = async () => {
+    setLoading(true);
+    try {
+      await onEdit(draft.id, editedReply);
+      setIsEditing(false);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDiscard = async () => {
+    if (!discardReason) return;
+    setLoading(true);
+    try {
+      await onDiscard(draft.id, discardReason);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card className="mb-4">
+      <CardHeader className="pb-2">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <Badge variant="outline" className="text-xs shrink-0">
+                r/{draft.post.subreddit}
+              </Badge>
+              <Badge
+                variant={draft.intent === "prepare" ? "default" : "destructive"}
+                className="text-xs shrink-0"
+              >
+                {draft.intent}
+              </Badge>
+            </div>
+            <CardTitle className="text-sm font-medium leading-tight">
+              {draft.post.title}
+            </CardTitle>
+            {draft.post.summary && (
+              <p className="text-xs text-muted-foreground mt-1 italic">
+                {draft.post.summary}
+              </p>
+            )}
+          </div>
+          <a
+            href={draft.post.permalink}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="shrink-0 text-muted-foreground hover:text-foreground"
+          >
+            <ExternalLink className="h-4 w-4" />
+          </a>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="mb-3">
+          <p className="text-xs font-medium text-muted-foreground mb-1">
+            Original post
+          </p>
+          <p className="text-xs text-muted-foreground line-clamp-3 bg-muted/50 rounded p-2">
+            {draft.post.body || "(no body)"}
+          </p>
+        </div>
+
+        <div className="mb-3">
+          <p className="text-xs font-medium text-muted-foreground mb-1">
+            Draft reply
+          </p>
+          {isEditing ? (
+            <textarea
+              className="w-full text-sm border rounded p-2 min-h-[120px] resize-y bg-background"
+              value={editedReply}
+              onChange={(e) => setEditedReply(e.target.value)}
+            />
+          ) : (
+            <p className="text-sm bg-muted/50 rounded p-2 whitespace-pre-wrap">
+              {draft.reply}
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {isEditing ? (
+            <>
+              <Button
+                size="sm"
+                onClick={handleSaveEdit}
+                disabled={loading}
+              >
+                Save
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setIsEditing(false);
+                  setEditedReply(draft.reply);
+                }}
+                disabled={loading}
+              >
+                Cancel
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button
+                size="sm"
+                onClick={handleApprove}
+                disabled={loading}
+                className="gap-1"
+              >
+                <CheckCircle className="h-3 w-3" />
+                Approve &amp; copy
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setIsEditing(true)}
+                disabled={loading}
+                className="gap-1"
+              >
+                <Pencil className="h-3 w-3" />
+                Edit
+              </Button>
+              {showDiscard ? (
+                <div className="flex items-center gap-2">
+                  <select
+                    className="h-8 rounded border border-input bg-background px-2 text-xs"
+                    value={discardReason}
+                    onChange={(e) => setDiscardReason(e.target.value)}
+                  >
+                    <option value="">Reason...</option>
+                    {DISCARD_REASONS.map((r) => (
+                      <option key={r.value} value={r.value}>
+                        {r.label}
+                      </option>
+                    ))}
+                  </select>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    onClick={handleDiscard}
+                    disabled={loading || !discardReason}
+                  >
+                    Confirm
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => {
+                      setShowDiscard(false);
+                      setDiscardReason("");
+                    }}
+                    disabled={loading}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              ) : (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setShowDiscard(true)}
+                  disabled={loading}
+                  className="gap-1 text-destructive hover:text-destructive"
+                >
+                  <Trash2 className="h-3 w-3" />
+                  Discard
+                </Button>
+              )}
+            </>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function MarketerAdminPage() {
+  const [drafts, setDrafts] = useState<Draft[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(0);
+
+  const fetchDrafts = useCallback(async (p: number) => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/admin/marketer/drafts?page=${p}&limit=20`);
+      if (!res.ok) {
+        console.error("Failed to fetch drafts", res.status);
+        return;
+      }
+      const data = await res.json();
+      setDrafts(data.drafts);
+      setTotalPages(data.pagination.totalPages);
+      setTotal(data.pagination.total);
+    } catch (err) {
+      console.error("Error fetching drafts", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchDrafts(page);
+  }, [page, fetchDrafts]);
+
+  const handleApprove = async (id: string) => {
+    const draft = drafts.find((d) => d.id === id);
+    if (draft) {
+      try {
+        await navigator.clipboard.writeText(draft.reply);
+      } catch {
+        // clipboard might fail in some browsers — don't block the approve
+      }
+      window.open(draft.post.permalink, "_blank", "noopener,noreferrer");
+    }
+
+    const res = await fetch(`/api/admin/marketer/drafts/${id}/approve`, {
+      method: "POST",
+    });
+    if (res.ok) {
+      setDrafts((prev) => prev.filter((d) => d.id !== id));
+      setTotal((prev) => prev - 1);
+    }
+  };
+
+  const handleEdit = async (id: string, reply: string) => {
+    const res = await fetch(`/api/admin/marketer/drafts/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ reply }),
+    });
+    if (res.ok) {
+      setDrafts((prev) =>
+        prev.map((d) => (d.id === id ? { ...d, reply } : d))
+      );
+    }
+  };
+
+  const handleDiscard = async (id: string, reason: string) => {
+    const res = await fetch(`/api/admin/marketer/drafts/${id}/discard`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ reason }),
+    });
+    if (res.ok) {
+      setDrafts((prev) => prev.filter((d) => d.id !== id));
+      setTotal((prev) => prev - 1);
+    }
+  };
+
+  const prepareDrafts = drafts.filter((d) => d.intent === "prepare");
+  const cheatDrafts = drafts.filter((d) => d.intent === "cheat");
+
+  if (loading) {
+    return (
+      <div className="max-w-6xl mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold mb-6">Marketer Queue</h1>
+        <div className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="animate-pulse bg-muted rounded-lg h-48 w-full"
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-8">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Marketer Queue</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            {total} pending draft{total !== 1 ? "s" : ""}
+          </p>
+        </div>
+      </div>
+
+      {drafts.length === 0 ? (
+        <div className="text-center py-16 text-muted-foreground">
+          <p className="text-lg font-medium">No pending drafts</p>
+          <p className="text-sm mt-1">
+            Run the cron job to fetch new posts and generate drafts.
+          </p>
+        </div>
+      ) : (
+        <div className="md:grid md:grid-cols-2 md:gap-6">
+          <div>
+            <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
+              <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                Prepare
+              </Badge>
+              <span className="text-sm text-muted-foreground font-normal">
+                {prepareDrafts.length} draft{prepareDrafts.length !== 1 ? "s" : ""}
+              </span>
+            </h2>
+            {prepareDrafts.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No prepare drafts pending.</p>
+            ) : (
+              prepareDrafts.map((draft) => (
+                <DraftCard
+                  key={draft.id}
+                  draft={draft}
+                  onApprove={handleApprove}
+                  onEdit={handleEdit}
+                  onDiscard={handleDiscard}
+                />
+              ))
+            )}
+          </div>
+
+          <div>
+            <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
+              <Badge variant="destructive">Cheat</Badge>
+              <span className="text-sm text-muted-foreground font-normal">
+                {cheatDrafts.length} draft{cheatDrafts.length !== 1 ? "s" : ""}
+              </span>
+            </h2>
+            {cheatDrafts.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No cheat drafts pending.</p>
+            ) : (
+              cheatDrafts.map((draft) => (
+                <DraftCard
+                  key={draft.id}
+                  draft={draft}
+                  onApprove={handleApprove}
+                  onEdit={handleEdit}
+                  onDiscard={handleDiscard}
+                />
+              ))
+            )}
+          </div>
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2 mt-8">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+          >
+            Previous
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            Page {page} of {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={page === totalPages}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/api/admin/marketer/drafts/[id]/approve/route.integration.test.ts
+++ b/apps/web/app/api/admin/marketer/drafts/[id]/approve/route.integration.test.ts
@@ -1,0 +1,146 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "vitest";
+import { NextRequest } from "next/server";
+import {
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../../../../../tests/setup-db";
+import { users, marketerPosts, marketerDrafts } from "@/lib/schema";
+import { eq } from "drizzle-orm";
+
+const mockAuth = vi.fn();
+vi.mock("@/lib/auth", () => ({ auth: () => mockAuth() }));
+vi.mock("@/lib/db", () => ({ get db() { return getTestDb(); } }));
+
+import { POST } from "./route";
+
+const ADMIN_USER = {
+  id: "00000000-0000-0000-0000-000000000001",
+  email: "admin@example.com",
+  name: "Admin User",
+};
+
+const OTHER_USER = {
+  id: "00000000-0000-0000-0000-000000000002",
+  email: "other@example.com",
+  name: "Other User",
+};
+
+function makeRequest(id: string) {
+  return new NextRequest(
+    `http://localhost/api/admin/marketer/drafts/${id}/approve`,
+    { method: "POST" }
+  );
+}
+
+describe("POST /api/admin/marketer/drafts/[id]/approve (integration)", () => {
+  let draftId: string;
+
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values([ADMIN_USER, OTHER_USER]).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env.ADMIN_USER_IDS = ADMIN_USER.id;
+    const { _resetAdminIdsCache } = await import("@/lib/admin-utils");
+    _resetAdminIdsCache();
+
+    const db = getTestDb();
+    await db.delete(marketerDrafts);
+    await db.delete(marketerPosts);
+
+    const [post] = await db
+      .insert(marketerPosts)
+      .values({
+        source: "reddit",
+        externalId: "approve-test-post",
+        subreddit: "cscareerquestions",
+        title: "Approve test post",
+        body: "Body",
+        permalink: "https://reddit.com/r/test/approve",
+        postedAt: new Date(),
+        classification: "prepare",
+        summary: "Summary",
+      })
+      .returning();
+
+    const [draft] = await db
+      .insert(marketerDrafts)
+      .values({
+        postId: post.id,
+        intent: "prepare",
+        reply: "Reply to approve",
+        status: "pending",
+      })
+      .returning();
+
+    draftId = draft.id;
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValueOnce(null);
+    const res = await POST(makeRequest(draftId), {
+      params: Promise.resolve({ id: draftId }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for non-admin user", async () => {
+    mockAuth.mockResolvedValueOnce({ user: OTHER_USER });
+    const res = await POST(makeRequest(draftId), {
+      params: Promise.resolve({ id: draftId }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for non-existent draft", async () => {
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    const res = await POST(
+      makeRequest("00000000-0000-0000-0000-999999999999"),
+      { params: Promise.resolve({ id: "00000000-0000-0000-0000-999999999999" }) }
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("marks draft as approved and returns 200", async () => {
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    const res = await POST(makeRequest(draftId), {
+      params: Promise.resolve({ id: draftId }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe("approved");
+    expect(data.reviewedBy).toBe(ADMIN_USER.id);
+  });
+
+  it("persists approval in the database", async () => {
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    await POST(makeRequest(draftId), {
+      params: Promise.resolve({ id: draftId }),
+    });
+
+    const db = getTestDb();
+    const [row] = await db
+      .select()
+      .from(marketerDrafts)
+      .where(eq(marketerDrafts.id, draftId));
+    expect(row.status).toBe("approved");
+    expect(row.reviewedBy).toBe(ADMIN_USER.id);
+    expect(row.reviewedAt).not.toBeNull();
+  });
+});

--- a/apps/web/app/api/admin/marketer/drafts/[id]/approve/route.ts
+++ b/apps/web/app/api/admin/marketer/drafts/[id]/approve/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { marketerDrafts } from "@/lib/schema";
+import { eq } from "drizzle-orm";
+import { createRequestLogger } from "@/lib/logger";
+import { isAdmin } from "@/lib/admin-utils";
+
+// POST /api/admin/marketer/drafts/[id]/approve — mark draft as approved
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!isAdmin(session.user.id)) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const { id } = await params;
+  const log = createRequestLogger({
+    route: "POST /api/admin/marketer/drafts/[id]/approve",
+    userId: session.user.id,
+  });
+
+  try {
+    const [draft] = await db
+      .update(marketerDrafts)
+      .set({
+        status: "approved",
+        reviewedAt: new Date(),
+        reviewedBy: session.user.id,
+      })
+      .where(eq(marketerDrafts.id, id))
+      .returning();
+
+    if (!draft) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    log.info({ draftId: id }, "draft approved");
+    return NextResponse.json(draft);
+  } catch (err) {
+    log.error({ err, draftId: id }, "failed to approve draft");
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/api/admin/marketer/drafts/[id]/discard/route.integration.test.ts
+++ b/apps/web/app/api/admin/marketer/drafts/[id]/discard/route.integration.test.ts
@@ -1,0 +1,186 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "vitest";
+import { NextRequest } from "next/server";
+import {
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../../../../../tests/setup-db";
+import { users, marketerPosts, marketerDrafts } from "@/lib/schema";
+import { eq } from "drizzle-orm";
+
+const mockAuth = vi.fn();
+vi.mock("@/lib/auth", () => ({ auth: () => mockAuth() }));
+vi.mock("@/lib/db", () => ({ get db() { return getTestDb(); } }));
+
+import { POST } from "./route";
+
+const ADMIN_USER = {
+  id: "00000000-0000-0000-0000-000000000001",
+  email: "admin@example.com",
+  name: "Admin User",
+};
+
+const OTHER_USER = {
+  id: "00000000-0000-0000-0000-000000000002",
+  email: "other@example.com",
+  name: "Other User",
+};
+
+function makeRequest(id: string, body: unknown) {
+  return new NextRequest(
+    `http://localhost/api/admin/marketer/drafts/${id}/discard`,
+    {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    }
+  );
+}
+
+describe("POST /api/admin/marketer/drafts/[id]/discard (integration)", () => {
+  let draftId: string;
+
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values([ADMIN_USER, OTHER_USER]).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env.ADMIN_USER_IDS = ADMIN_USER.id;
+    const { _resetAdminIdsCache } = await import("@/lib/admin-utils");
+    _resetAdminIdsCache();
+
+    const db = getTestDb();
+    await db.delete(marketerDrafts);
+    await db.delete(marketerPosts);
+
+    const [post] = await db
+      .insert(marketerPosts)
+      .values({
+        source: "reddit",
+        externalId: "discard-test-post",
+        subreddit: "cscareerquestions",
+        title: "Discard test post",
+        body: "Body",
+        permalink: "https://reddit.com/r/test/discard",
+        postedAt: new Date(),
+        classification: "cheat",
+        summary: "Summary",
+      })
+      .returning();
+
+    const [draft] = await db
+      .insert(marketerDrafts)
+      .values({
+        postId: post.id,
+        intent: "cheat",
+        reply: "Reply to discard",
+        status: "pending",
+      })
+      .returning();
+
+    draftId = draft.id;
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValueOnce(null);
+    const res = await POST(makeRequest(draftId, { reason: "spammy" }), {
+      params: Promise.resolve({ id: draftId }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for non-admin user", async () => {
+    mockAuth.mockResolvedValueOnce({ user: OTHER_USER });
+    const res = await POST(makeRequest(draftId, { reason: "spammy" }), {
+      params: Promise.resolve({ id: draftId }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for missing reason", async () => {
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    const res = await POST(makeRequest(draftId, {}), {
+      params: Promise.resolve({ id: draftId }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid reason value", async () => {
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    const res = await POST(makeRequest(draftId, { reason: "not-valid" }), {
+      params: Promise.resolve({ id: draftId }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for non-existent draft", async () => {
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    const res = await POST(
+      makeRequest("00000000-0000-0000-0000-999999999999", { reason: "spammy" }),
+      { params: Promise.resolve({ id: "00000000-0000-0000-0000-999999999999" }) }
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("marks draft as discarded with reason and returns 200", async () => {
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    const res = await POST(makeRequest(draftId, { reason: "off-topic" }), {
+      params: Promise.resolve({ id: draftId }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe("discarded");
+    expect(data.discardReason).toBe("off-topic");
+  });
+
+  it("persists discard in the database", async () => {
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    await POST(makeRequest(draftId, { reason: "low-quality" }), {
+      params: Promise.resolve({ id: draftId }),
+    });
+
+    const db = getTestDb();
+    const [row] = await db
+      .select()
+      .from(marketerDrafts)
+      .where(eq(marketerDrafts.id, draftId));
+    expect(row.status).toBe("discarded");
+    expect(row.discardReason).toBe("low-quality");
+    expect(row.reviewedBy).toBe(ADMIN_USER.id);
+    expect(row.reviewedAt).not.toBeNull();
+  });
+
+  it("accepts all valid discard reasons", async () => {
+    const reasons = ["spammy", "off-topic", "duplicate", "low-quality", "other"] as const;
+    const db = getTestDb();
+
+    for (const reason of reasons) {
+      // Reset draft to pending
+      await db
+        .update(marketerDrafts)
+        .set({ status: "pending", discardReason: null })
+        .where(eq(marketerDrafts.id, draftId));
+
+      mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+      const res = await POST(makeRequest(draftId, { reason }), {
+        params: Promise.resolve({ id: draftId }),
+      });
+      expect(res.status).toBe(200);
+    }
+  });
+});

--- a/apps/web/app/api/admin/marketer/drafts/[id]/discard/route.ts
+++ b/apps/web/app/api/admin/marketer/drafts/[id]/discard/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { marketerDrafts } from "@/lib/schema";
+import { eq } from "drizzle-orm";
+import { createRequestLogger } from "@/lib/logger";
+import { discardDraftSchema } from "@/lib/validations";
+import { isAdmin } from "@/lib/admin-utils";
+
+// POST /api/admin/marketer/drafts/[id]/discard — mark draft as discarded
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!isAdmin(session.user.id)) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const { id } = await params;
+  const log = createRequestLogger({
+    route: "POST /api/admin/marketer/drafts/[id]/discard",
+    userId: session.user.id,
+  });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const parsed = discardDraftSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request", details: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const [draft] = await db
+      .update(marketerDrafts)
+      .set({
+        status: "discarded",
+        discardReason: parsed.data.reason,
+        reviewedAt: new Date(),
+        reviewedBy: session.user.id,
+      })
+      .where(eq(marketerDrafts.id, id))
+      .returning();
+
+    if (!draft) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    log.info({ draftId: id, reason: parsed.data.reason }, "draft discarded");
+    return NextResponse.json(draft);
+  } catch (err) {
+    log.error({ err, draftId: id }, "failed to discard draft");
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/api/admin/marketer/drafts/[id]/route.integration.test.ts
+++ b/apps/web/app/api/admin/marketer/drafts/[id]/route.integration.test.ts
@@ -1,0 +1,167 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "vitest";
+import { NextRequest } from "next/server";
+import {
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../../../../tests/setup-db";
+import { users, marketerPosts, marketerDrafts } from "@/lib/schema";
+import { eq } from "drizzle-orm";
+
+const mockAuth = vi.fn();
+vi.mock("@/lib/auth", () => ({ auth: () => mockAuth() }));
+vi.mock("@/lib/db", () => ({ get db() { return getTestDb(); } }));
+
+import { PATCH } from "./route";
+
+const ADMIN_USER = {
+  id: "00000000-0000-0000-0000-000000000001",
+  email: "admin@example.com",
+  name: "Admin User",
+};
+
+const OTHER_USER = {
+  id: "00000000-0000-0000-0000-000000000002",
+  email: "other@example.com",
+  name: "Other User",
+};
+
+function makeRequest(id: string, body: unknown) {
+  const url = new URL(`http://localhost/api/admin/marketer/drafts/${id}`);
+  return new NextRequest(url, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("PATCH /api/admin/marketer/drafts/[id] (integration)", () => {
+  let draftId: string;
+
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values([ADMIN_USER, OTHER_USER]).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env.ADMIN_USER_IDS = ADMIN_USER.id;
+    const { _resetAdminIdsCache } = await import("@/lib/admin-utils");
+    _resetAdminIdsCache();
+
+    const db = getTestDb();
+    await db.delete(marketerDrafts);
+    await db.delete(marketerPosts);
+
+    const [post] = await db
+      .insert(marketerPosts)
+      .values({
+        source: "reddit",
+        externalId: "edit-test-post",
+        subreddit: "cscareerquestions",
+        title: "Test post",
+        body: "Body text",
+        permalink: "https://reddit.com/r/test/edit",
+        postedAt: new Date(),
+        classification: "prepare",
+        summary: "Test summary",
+      })
+      .returning();
+
+    const [draft] = await db
+      .insert(marketerDrafts)
+      .values({
+        postId: post.id,
+        intent: "prepare",
+        reply: "Original reply text",
+        status: "pending",
+      })
+      .returning();
+
+    draftId = draft.id;
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValueOnce(null);
+    const res = await PATCH(makeRequest(draftId, { reply: "New reply" }), {
+      params: Promise.resolve({ id: draftId }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for non-admin user", async () => {
+    mockAuth.mockResolvedValueOnce({ user: OTHER_USER });
+    const res = await PATCH(makeRequest(draftId, { reply: "New reply" }), {
+      params: Promise.resolve({ id: draftId }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for missing reply field", async () => {
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    const res = await PATCH(makeRequest(draftId, {}), {
+      params: Promise.resolve({ id: draftId }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for empty reply", async () => {
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    const res = await PATCH(makeRequest(draftId, { reply: "" }), {
+      params: Promise.resolve({ id: draftId }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for non-existent draft", async () => {
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    const res = await PATCH(
+      makeRequest("00000000-0000-0000-0000-999999999999", { reply: "test" }),
+      { params: Promise.resolve({ id: "00000000-0000-0000-0000-999999999999" }) }
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("updates reply and sets status to edited", async () => {
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    const newReply = "Updated reply text for testing";
+    const res = await PATCH(makeRequest(draftId, { reply: newReply }), {
+      params: Promise.resolve({ id: draftId }),
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.reply).toBe(newReply);
+    expect(data.status).toBe("edited");
+  });
+
+  it("persists edit in the database", async () => {
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    const newReply = "Persisted reply text";
+    await PATCH(makeRequest(draftId, { reply: newReply }), {
+      params: Promise.resolve({ id: draftId }),
+    });
+
+    const db = getTestDb();
+    const [row] = await db
+      .select()
+      .from(marketerDrafts)
+      .where(eq(marketerDrafts.id, draftId));
+    expect(row.reply).toBe(newReply);
+    expect(row.status).toBe("edited");
+    expect(row.reviewedBy).toBe(ADMIN_USER.id);
+    expect(row.reviewedAt).not.toBeNull();
+  });
+});

--- a/apps/web/app/api/admin/marketer/drafts/[id]/route.ts
+++ b/apps/web/app/api/admin/marketer/drafts/[id]/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { marketerDrafts } from "@/lib/schema";
+import { eq } from "drizzle-orm";
+import { createRequestLogger } from "@/lib/logger";
+import { editDraftSchema } from "@/lib/validations";
+import { isAdmin } from "@/lib/admin-utils";
+
+// PATCH /api/admin/marketer/drafts/[id] — update reply text + mark as edited
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!isAdmin(session.user.id)) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const { id } = await params;
+  const log = createRequestLogger({
+    route: "PATCH /api/admin/marketer/drafts/[id]",
+    userId: session.user.id,
+  });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const parsed = editDraftSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request", details: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const [draft] = await db
+      .update(marketerDrafts)
+      .set({
+        reply: parsed.data.reply,
+        status: "edited",
+        reviewedAt: new Date(),
+        reviewedBy: session.user.id,
+      })
+      .where(eq(marketerDrafts.id, id))
+      .returning();
+
+    if (!draft) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    log.info({ draftId: id }, "draft edited");
+    return NextResponse.json(draft);
+  } catch (err) {
+    log.error({ err, draftId: id }, "failed to edit draft");
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/api/admin/marketer/drafts/route.integration.test.ts
+++ b/apps/web/app/api/admin/marketer/drafts/route.integration.test.ts
@@ -1,0 +1,212 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "vitest";
+import { NextRequest } from "next/server";
+import {
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../../../tests/setup-db";
+import { users, marketerPosts, marketerDrafts } from "@/lib/schema";
+
+const mockAuth = vi.fn();
+vi.mock("@/lib/auth", () => ({ auth: () => mockAuth() }));
+vi.mock("@/lib/db", () => ({ get db() { return getTestDb(); } }));
+vi.mock("@/lib/admin-utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/admin-utils")>("@/lib/admin-utils");
+  return actual;
+});
+
+import { GET } from "./route";
+
+const ADMIN_USER = {
+  id: "00000000-0000-0000-0000-000000000001",
+  email: "admin@example.com",
+  name: "Admin User",
+};
+
+const OTHER_USER = {
+  id: "00000000-0000-0000-0000-000000000002",
+  email: "other@example.com",
+  name: "Other User",
+};
+
+function makeRequest(searchParams?: Record<string, string>) {
+  const url = new URL("http://localhost/api/admin/marketer/drafts");
+  if (searchParams) {
+    Object.entries(searchParams).forEach(([k, v]) => url.searchParams.set(k, v));
+  }
+  return new NextRequest(url);
+}
+
+describe("GET /api/admin/marketer/drafts (integration)", () => {
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values([ADMIN_USER, OTHER_USER]).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env.ADMIN_USER_IDS = ADMIN_USER.id;
+    // Reset admin cache
+    const { _resetAdminIdsCache } = await import("@/lib/admin-utils");
+    _resetAdminIdsCache();
+    // Clean marketer tables
+    const db = getTestDb();
+    await db.delete(marketerDrafts);
+    await db.delete(marketerPosts);
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValueOnce(null);
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for non-admin user", async () => {
+    mockAuth.mockResolvedValueOnce({ user: OTHER_USER });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 for invalid query params", async () => {
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    const res = await GET(makeRequest({ page: "not-a-number" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns empty list when no pending drafts", async () => {
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.drafts).toHaveLength(0);
+    expect(data.pagination.total).toBe(0);
+  });
+
+  it("returns pending drafts with post info", async () => {
+    const db = getTestDb();
+    const [post] = await db
+      .insert(marketerPosts)
+      .values({
+        source: "reddit",
+        externalId: "test123",
+        subreddit: "cscareerquestions",
+        title: "How do I prepare?",
+        body: "Test body",
+        permalink: "https://reddit.com/r/test/comments/test123/",
+        postedAt: new Date(),
+        classification: "prepare",
+        summary: "User wants prep tips",
+      })
+      .returning();
+
+    await db.insert(marketerDrafts).values({
+      postId: post.id,
+      intent: "prepare",
+      reply: "Here is my advice...",
+      status: "pending",
+    });
+
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.drafts).toHaveLength(1);
+    expect(data.drafts[0].intent).toBe("prepare");
+    expect(data.drafts[0].post.title).toBe("How do I prepare?");
+    expect(data.pagination.total).toBe(1);
+  });
+
+  it("excludes non-pending (approved/discarded) drafts", async () => {
+    const db = getTestDb();
+    const [post] = await db
+      .insert(marketerPosts)
+      .values({
+        source: "reddit",
+        externalId: "test456",
+        subreddit: "leetcode",
+        title: "Approved post",
+        body: "Body",
+        permalink: "https://reddit.com/r/test/456",
+        postedAt: new Date(),
+        classification: "prepare",
+        summary: "Summary",
+      })
+      .returning();
+
+    await db.insert(marketerDrafts).values([
+      {
+        postId: post.id,
+        intent: "prepare",
+        reply: "Approved reply",
+        status: "approved",
+      },
+      {
+        postId: post.id,
+        intent: "prepare",
+        reply: "Discarded reply",
+        status: "discarded",
+        discardReason: "spammy",
+      },
+    ]);
+
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.drafts).toHaveLength(0);
+    expect(data.pagination.total).toBe(0);
+  });
+
+  it("paginates correctly", async () => {
+    const db = getTestDb();
+    // Insert 3 posts and drafts
+    for (let i = 0; i < 3; i++) {
+      const [post] = await db
+        .insert(marketerPosts)
+        .values({
+          source: "reddit",
+          externalId: `paginate-${i}`,
+          subreddit: "cscareerquestions",
+          title: `Post ${i}`,
+          body: "Body",
+          permalink: `https://reddit.com/r/test/${i}`,
+          postedAt: new Date(),
+          classification: "prepare",
+          summary: `Summary ${i}`,
+        })
+        .returning();
+
+      await db.insert(marketerDrafts).values({
+        postId: post.id,
+        intent: "prepare",
+        reply: `Reply ${i}`,
+        status: "pending",
+      });
+    }
+
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    const res = await GET(makeRequest({ page: "1", limit: "2" }));
+    const data = await res.json();
+    expect(data.drafts).toHaveLength(2);
+    expect(data.pagination.total).toBe(3);
+    expect(data.pagination.totalPages).toBe(2);
+
+    mockAuth.mockResolvedValueOnce({ user: ADMIN_USER });
+    const res2 = await GET(makeRequest({ page: "2", limit: "2" }));
+    const data2 = await res2.json();
+    expect(data2.drafts).toHaveLength(1);
+  });
+});

--- a/apps/web/app/api/admin/marketer/drafts/route.ts
+++ b/apps/web/app/api/admin/marketer/drafts/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { marketerDrafts, marketerPosts } from "@/lib/schema";
+import { eq, count, desc } from "drizzle-orm";
+import { createRequestLogger } from "@/lib/logger";
+import { listMarketerDraftsQuerySchema } from "@/lib/validations";
+import { isAdmin } from "@/lib/admin-utils";
+
+// GET /api/admin/marketer/drafts — list pending drafts, paginated
+export async function GET(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!isAdmin(session.user.id)) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const log = createRequestLogger({
+    route: "GET /api/admin/marketer/drafts",
+    userId: session.user.id,
+  });
+
+  const searchParams = Object.fromEntries(request.nextUrl.searchParams);
+  const parsed = listMarketerDraftsQuerySchema.safeParse(searchParams);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid query parameters", details: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  const { page, limit } = parsed.data;
+  const offset = (page - 1) * limit;
+
+  try {
+    const [drafts, [{ total }]] = await Promise.all([
+      db
+        .select({
+          id: marketerDrafts.id,
+          postId: marketerDrafts.postId,
+          intent: marketerDrafts.intent,
+          reply: marketerDrafts.reply,
+          status: marketerDrafts.status,
+          createdAt: marketerDrafts.createdAt,
+          post: {
+            id: marketerPosts.id,
+            subreddit: marketerPosts.subreddit,
+            title: marketerPosts.title,
+            body: marketerPosts.body,
+            permalink: marketerPosts.permalink,
+            classification: marketerPosts.classification,
+            summary: marketerPosts.summary,
+            postedAt: marketerPosts.postedAt,
+          },
+        })
+        .from(marketerDrafts)
+        .innerJoin(marketerPosts, eq(marketerDrafts.postId, marketerPosts.id))
+        .where(eq(marketerDrafts.status, "pending"))
+        .orderBy(desc(marketerDrafts.createdAt))
+        .limit(limit)
+        .offset(offset),
+      db
+        .select({ total: count() })
+        .from(marketerDrafts)
+        .where(eq(marketerDrafts.status, "pending")),
+    ]);
+
+    log.info({ count: drafts.length }, "listed marketer drafts");
+    return NextResponse.json({
+      drafts,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    });
+  } catch (err) {
+    log.error({ err }, "failed to list marketer drafts");
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/api/admin/marketer/run/route.integration.test.ts
+++ b/apps/web/app/api/admin/marketer/run/route.integration.test.ts
@@ -1,0 +1,211 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "vitest";
+import { NextRequest } from "next/server";
+import {
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../../../tests/setup-db";
+import { users, marketerPosts, marketerDrafts } from "@/lib/schema";
+import { eq, count } from "drizzle-orm";
+
+// Mock auth (not used by the cron endpoint, but imported modules may require it)
+vi.mock("@/lib/auth", () => ({ auth: vi.fn() }));
+vi.mock("@/lib/db", () => ({ get db() { return getTestDb(); } }));
+
+// Mock Reddit fetcher to avoid real HTTP calls
+vi.mock("@/lib/marketer/reddit", () => ({
+  fetchSubredditPosts: vi.fn(),
+}));
+
+// Mock OpenAI to avoid real API calls
+// vi.hoisted ensures mockCreate is available before vi.mock hoisting
+const { mockCreate } = vi.hoisted(() => {
+  const mockCreate = vi.fn().mockResolvedValue({
+    choices: [
+      {
+        message: {
+          content: JSON.stringify({
+            classification: "prepare",
+            summary: "User wants interview prep help",
+          }),
+        },
+      },
+    ],
+  });
+  return { mockCreate };
+});
+
+vi.mock("openai", () => {
+  return {
+    default: class MockOpenAI {
+      chat = { completions: { create: mockCreate } };
+    },
+  };
+});
+
+import { POST } from "./route";
+import { fetchSubredditPosts } from "@/lib/marketer/reddit";
+
+const CRON_SECRET = "test-cron-secret-12345";
+
+function makeRequest(authHeader?: string) {
+  return new NextRequest("http://localhost/api/admin/marketer/run", {
+    method: "POST",
+    headers: authHeader ? { authorization: authHeader } : {},
+  });
+}
+
+const sampleRedditPost = {
+  id: "test-reddit-post-1",
+  subreddit: "cscareerquestions",
+  title: "How do I prepare for my Google interview?",
+  selftext: "I have an interview in 3 weeks and I'm nervous.",
+  permalink: "/r/cscareerquestions/comments/test1/how_do_i/",
+  created_utc: Math.floor(Date.now() / 1000) - 3600, // 1 hour ago
+};
+
+describe("POST /api/admin/marketer/run (integration)", () => {
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db
+      .insert(users)
+      .values({
+        id: "00000000-0000-0000-0000-000000000001",
+        email: "admin@example.com",
+        name: "Admin",
+      })
+      .onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = CRON_SECRET;
+
+    const db = getTestDb();
+    await db.delete(marketerDrafts);
+    await db.delete(marketerPosts);
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  it("returns 401 when no Authorization header", async () => {
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when CRON_SECRET is wrong", async () => {
+    const res = await POST(makeRequest("Bearer wrong-secret"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when CRON_SECRET env var is not set", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await POST(makeRequest(`Bearer ${CRON_SECRET}`));
+    expect(res.status).toBe(401);
+    process.env.CRON_SECRET = CRON_SECRET;
+  });
+
+  it("returns 200 with stats when authorized", async () => {
+    vi.mocked(fetchSubredditPosts).mockResolvedValue([]);
+
+    const res = await POST(makeRequest(`Bearer ${CRON_SECRET}`));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveProperty("totalFetched");
+    expect(data).toHaveProperty("totalInserted");
+    expect(data).toHaveProperty("totalDrafted");
+    expect(data).toHaveProperty("errors");
+  });
+
+  it("inserts posts and drafts for fetched content", async () => {
+    vi.mocked(fetchSubredditPosts).mockResolvedValue([sampleRedditPost]);
+
+    const res = await POST(makeRequest(`Bearer ${CRON_SECRET}`));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.totalInserted).toBeGreaterThan(0);
+    expect(data.totalDrafted).toBeGreaterThan(0);
+
+    const db = getTestDb();
+    const [{ total: postCount }] = await db
+      .select({ total: count() })
+      .from(marketerPosts);
+    expect(postCount).toBeGreaterThan(0);
+
+    const [{ total: draftCount }] = await db
+      .select({ total: count() })
+      .from(marketerDrafts);
+    expect(draftCount).toBeGreaterThan(0);
+  });
+
+  it("is idempotent — running twice produces no duplicate marketer_posts rows", async () => {
+    vi.mocked(fetchSubredditPosts).mockResolvedValue([sampleRedditPost]);
+
+    // First run
+    await POST(makeRequest(`Bearer ${CRON_SECRET}`));
+
+    vi.mocked(fetchSubredditPosts).mockResolvedValue([sampleRedditPost]);
+
+    // Second run
+    const res2 = await POST(makeRequest(`Bearer ${CRON_SECRET}`));
+    expect(res2.status).toBe(200);
+    const data2 = await res2.json();
+
+    // Second run should insert 0 new posts (already exists)
+    expect(data2.totalInserted).toBe(0);
+
+    const db = getTestDb();
+    const [{ total }] = await db
+      .select({ total: count() })
+      .from(marketerPosts)
+      .where(eq(marketerPosts.externalId, sampleRedditPost.id));
+    expect(total).toBe(1);
+  });
+
+  it("handles Reddit fetch failures gracefully and returns 200 with error count", async () => {
+    vi.mocked(fetchSubredditPosts).mockRejectedValue(new Error("Network error"));
+
+    const res = await POST(makeRequest(`Bearer ${CRON_SECRET}`));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.errors.length).toBeGreaterThan(0);
+  });
+
+  it("skips drafting for irrelevant posts", async () => {
+    // Override the mockCreate to return irrelevant classification
+    mockCreate.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              classification: "irrelevant",
+              summary: "Not relevant",
+            }),
+          },
+        },
+      ],
+    });
+
+    vi.mocked(fetchSubredditPosts).mockResolvedValue([sampleRedditPost]);
+
+    const res = await POST(makeRequest(`Bearer ${CRON_SECRET}`));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    // irrelevant posts should have 0 drafts
+    expect(data.totalDrafted).toBe(0);
+    // But it should be inserted as a post (classification=irrelevant)
+    expect(data.totalInserted).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/app/api/admin/marketer/run/route.ts
+++ b/apps/web/app/api/admin/marketer/run/route.ts
@@ -1,0 +1,211 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { marketerPosts, marketerDrafts } from "@/lib/schema";
+import { createRequestLogger } from "@/lib/logger";
+import { checkRateLimit } from "@/lib/api-utils";
+import { fetchSubredditPosts } from "@/lib/marketer/reddit";
+import { buildClassifierPrompt } from "@/lib/marketer-classifier-prompt";
+import {
+  buildPrepareReplyPrompt,
+  buildCheatReplyPrompt,
+} from "@/lib/marketer-reply-prompt";
+import { classificationResultSchema } from "@/lib/validations";
+import { OpenAIRetryError, withOpenAIRetry } from "@/lib/openai-retry";
+import OpenAI from "openai";
+
+const SUBREDDITS = ["cscareerquestions", "leetcode", "interviews"];
+const POSTS_PER_SUB = 25;
+
+// POST /api/admin/marketer/run — cron endpoint (authorized via CRON_SECRET)
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Paranoia rate-limit check against misconfigured schedule (use cron job ID as key)
+  const rateLimitResult = checkRateLimit("cron-marketer-run");
+  if (rateLimitResult) return rateLimitResult;
+
+  const log = createRequestLogger({
+    route: "POST /api/admin/marketer/run",
+    userId: "cron",
+  });
+
+  log.info("marketer cron run starting");
+
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+  let totalFetched = 0;
+  let totalInserted = 0;
+  let totalDrafted = 0;
+  const errors: string[] = [];
+
+  for (const sub of SUBREDDITS) {
+    log.info({ sub }, "fetching subreddit");
+
+    let posts;
+    try {
+      posts = await fetchSubredditPosts(sub, POSTS_PER_SUB, log);
+    } catch (err) {
+      log.error({ err, sub }, "failed to fetch subreddit");
+      errors.push(`fetch:${sub}`);
+      continue;
+    }
+
+    totalFetched += posts.length;
+    log.info({ sub, count: posts.length }, "fetched posts");
+
+    for (const post of posts) {
+      // Classify the post
+      let classification: "prepare" | "cheat" | "irrelevant";
+      let summary: string;
+
+      try {
+        const classifierPrompt = buildClassifierPrompt({
+          title: post.title,
+          body: post.selftext,
+          subreddit: post.subreddit,
+        });
+
+        const result = await withOpenAIRetry(
+          () =>
+            openai.chat.completions.create({
+              model: "gpt-5.4-mini",
+              messages: [{ role: "user", content: classifierPrompt }],
+              response_format: { type: "json_object" },
+              temperature: 0.1,
+              max_completion_tokens: 200,
+            }),
+          (raw) => {
+            let json: unknown;
+            try {
+              json = JSON.parse(raw);
+            } catch (e) {
+              throw new OpenAIRetryError("invalid_json", e);
+            }
+            const validated = classificationResultSchema.safeParse(json);
+            if (!validated.success) {
+              throw new OpenAIRetryError("schema_mismatch", validated.error);
+            }
+            return validated.data;
+          },
+          { service: "marketer-classifier", log }
+        );
+
+        classification = result.classification;
+        summary = result.summary;
+      } catch (err) {
+        log.error({ err, postId: post.id }, "classification failed, skipping");
+        errors.push(`classify:${post.id}`);
+        continue;
+      }
+
+      // Insert the post (ON CONFLICT DO NOTHING for idempotency)
+      let insertedPost: typeof marketerPosts.$inferSelect | null = null;
+      try {
+        const [row] = await db
+          .insert(marketerPosts)
+          .values({
+            source: "reddit",
+            externalId: post.id,
+            subreddit: post.subreddit,
+            title: post.title,
+            body: post.selftext,
+            permalink: `https://reddit.com${post.permalink}`,
+            postedAt: new Date(post.created_utc * 1000),
+            classification,
+            summary,
+          })
+          .onConflictDoNothing()
+          .returning();
+
+        if (row) {
+          insertedPost = row;
+          totalInserted++;
+        }
+        // If row is undefined, this post was already processed — skip drafting
+      } catch (err) {
+        log.error({ err, postId: post.id }, "failed to insert marketer post");
+        errors.push(`insert:${post.id}`);
+        continue;
+      }
+
+      // Only draft for newly inserted posts with actionable intent
+      if (!insertedPost || classification === "irrelevant") {
+        continue;
+      }
+
+      // Generate reply draft
+      let reply: string;
+      try {
+        const replyPrompt =
+          classification === "prepare"
+            ? buildPrepareReplyPrompt({
+                post: {
+                  title: post.title,
+                  selftext: post.selftext,
+                  subreddit: post.subreddit,
+                  permalink: post.permalink,
+                },
+                summary,
+              })
+            : buildCheatReplyPrompt({
+                post: {
+                  title: post.title,
+                  selftext: post.selftext,
+                  subreddit: post.subreddit,
+                  permalink: post.permalink,
+                },
+                summary,
+              });
+
+        const replyResponse = await openai.chat.completions.create({
+          model: "gpt-5.4-mini",
+          messages: [{ role: "user", content: replyPrompt }],
+          temperature: 0.8,
+          max_completion_tokens: 400,
+        });
+
+        reply = replyResponse.choices[0]?.message?.content ?? "";
+        if (!reply) {
+          log.warn({ postId: post.id }, "empty reply generated, skipping");
+          errors.push(`reply:${post.id}`);
+          continue;
+        }
+      } catch (err) {
+        log.error({ err, postId: post.id }, "reply generation failed");
+        errors.push(`reply:${post.id}`);
+        continue;
+      }
+
+      // Insert the draft
+      try {
+        await db.insert(marketerDrafts).values({
+          postId: insertedPost.id,
+          intent: classification,
+          reply,
+          status: "pending",
+        });
+        totalDrafted++;
+      } catch (err) {
+        log.error({ err, postId: post.id }, "failed to insert draft");
+        errors.push(`draft:${post.id}`);
+      }
+    }
+  }
+
+  log.info(
+    { totalFetched, totalInserted, totalDrafted, errors: errors.length },
+    "marketer cron run complete"
+  );
+
+  return NextResponse.json({
+    totalFetched,
+    totalInserted,
+    totalDrafted,
+    errors,
+  });
+}

--- a/apps/web/drizzle/0009_brief_network.sql
+++ b/apps/web/drizzle/0009_brief_network.sql
@@ -1,0 +1,29 @@
+CREATE TABLE "marketer_drafts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"post_id" uuid NOT NULL,
+	"intent" text NOT NULL,
+	"reply" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"discard_reason" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"reviewed_at" timestamp with time zone,
+	"reviewed_by" uuid
+);
+--> statement-breakpoint
+CREATE TABLE "marketer_posts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"source" text DEFAULT 'reddit' NOT NULL,
+	"external_id" text NOT NULL,
+	"subreddit" text NOT NULL,
+	"title" text NOT NULL,
+	"body" text NOT NULL,
+	"permalink" text NOT NULL,
+	"posted_at" timestamp with time zone NOT NULL,
+	"fetched_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"classification" text,
+	"summary" text
+);
+--> statement-breakpoint
+ALTER TABLE "marketer_drafts" ADD CONSTRAINT "marketer_drafts_post_id_marketer_posts_id_fk" FOREIGN KEY ("post_id") REFERENCES "public"."marketer_posts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "marketer_drafts" ADD CONSTRAINT "marketer_drafts_reviewed_by_users_id_fk" FOREIGN KEY ("reviewed_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "marketer_posts_external_id_unique" ON "marketer_posts" USING btree ("external_id");

--- a/apps/web/drizzle/meta/0009_snapshot.json
+++ b/apps/web/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,1362 @@
+{
+  "id": "ffce18b9-ab02-4e4a-a508-1e4d734c02d6",
+  "prevId": "d7f03b23-e3b4-4a37-9109-47b17c5c549c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.code_snapshots": {
+      "name": "code_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "code_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_result": {
+          "name": "execution_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "code_snapshots_session_id_interview_sessions_id_fk": {
+          "name": "code_snapshots_session_id_interview_sessions_id_fk",
+          "tableFrom": "code_snapshots",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_questions": {
+      "name": "company_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_questions_user_id_users_id_fk": {
+          "name": "company_questions_user_id_users_id_fk",
+          "tableFrom": "company_questions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_plans": {
+      "name": "interview_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interview_date": {
+          "name": "interview_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_data": {
+          "name": "plan_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_plans_user_id_users_id_fk": {
+          "name": "interview_plans_user_id_users_id_fk",
+          "tableFrom": "interview_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_sessions": {
+      "name": "interview_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'configuring'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_star_story_id": {
+          "name": "source_star_story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_sessions_user_id_users_id_fk": {
+          "name": "interview_sessions_user_id_users_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interview_sessions_source_star_story_id_star_stories_id_fk": {
+          "name": "interview_sessions_source_star_story_id_star_stories_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "source_star_story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_usage": {
+      "name": "interview_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "interview_usage_user_period_unique": {
+          "name": "interview_usage_user_period_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interview_usage_user_id_users_id_fk": {
+          "name": "interview_usage_user_id_users_id_fk",
+          "tableFrom": "interview_usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketer_drafts": {
+      "name": "marketer_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply": {
+          "name": "reply",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "discard_reason": {
+          "name": "discard_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "marketer_drafts_post_id_marketer_posts_id_fk": {
+          "name": "marketer_drafts_post_id_marketer_posts_id_fk",
+          "tableFrom": "marketer_drafts",
+          "tableTo": "marketer_posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "marketer_drafts_reviewed_by_users_id_fk": {
+          "name": "marketer_drafts_reviewed_by_users_id_fk",
+          "tableFrom": "marketer_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.marketer_posts": {
+      "name": "marketer_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reddit'"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subreddit": {
+          "name": "subreddit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permalink": {
+          "name": "permalink",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "marketer_posts_external_id_unique": {
+          "name": "marketer_posts_external_id_unique",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_feedback": {
+      "name": "session_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_score": {
+          "name": "overall_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strengths": {
+          "name": "strengths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "weaknesses": {
+          "name": "weaknesses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "answer_analyses": {
+          "name": "answer_analyses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "code_quality_score": {
+          "name": "code_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation_quality_score": {
+          "name": "explanation_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeline_analysis": {
+          "name": "timeline_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_feedback_session_id_interview_sessions_id_fk": {
+          "name": "session_feedback_session_id_interview_sessions_id_fk",
+          "tableFrom": "session_feedback",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_templates": {
+      "name": "session_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_templates_user_id_users_id_fk": {
+          "name": "session_templates_user_id_users_id_fk",
+          "tableFrom": "session_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_stories": {
+      "name": "star_stories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_questions": {
+          "name": "expected_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "situation": {
+          "name": "situation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_stories_user_id_users_id_fk": {
+          "name": "star_stories_user_id_users_id_fk",
+          "tableFrom": "star_stories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_story_analyses": {
+      "name": "star_story_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scores": {
+          "name": "scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_story_analyses_story_id_star_stories_id_fk": {
+          "name": "star_story_analyses_story_id_star_stories_id_fk",
+          "tableFrom": "star_story_analyses",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcripts": {
+      "name": "transcripts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcripts_session_id_interview_sessions_id_fk": {
+          "name": "transcripts_session_id_interview_sessions_id_fk",
+          "tableFrom": "transcripts",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_badge_unique": {
+          "name": "user_badge_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "badge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_resumes": {
+      "name": "user_resumes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_resumes_user_id_users_id_fk": {
+          "name": "user_resumes_user_id_users_id_fk",
+          "tableFrom": "user_resumes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "user_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_start": {
+          "name": "plan_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_end": {
+          "name": "plan_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "past_due_at": {
+          "name": "past_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.code_event_type": {
+      "name": "code_event_type",
+      "schema": "public",
+      "values": [
+        "edit",
+        "run",
+        "submit"
+      ]
+    },
+    "public.interview_type": {
+      "name": "interview_type",
+      "schema": "public",
+      "values": [
+        "behavioral",
+        "technical"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "configuring",
+        "in_progress",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.user_plan": {
+      "name": "user_plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "max"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1776261643845,
       "tag": "0008_sweet_blink",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1776289548380,
+      "tag": "0009_brief_network",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/admin-utils.ts
+++ b/apps/web/lib/admin-utils.ts
@@ -1,0 +1,31 @@
+/**
+ * Utility helpers for admin-only routes.
+ * Admin user IDs come from ADMIN_USER_IDS env var (comma-separated UUIDs).
+ */
+
+let cachedAdminIds: Set<string> | null = null;
+
+function getAdminIds(): Set<string> {
+  if (cachedAdminIds) return cachedAdminIds;
+  const raw = process.env.ADMIN_USER_IDS ?? "";
+  cachedAdminIds = new Set(
+    raw
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean)
+  );
+  return cachedAdminIds;
+}
+
+/**
+ * Returns true if the given user ID is in the ADMIN_USER_IDS list.
+ * Returns 404 (not 403) from routes when this is false — never leak existence.
+ */
+export function isAdmin(userId: string): boolean {
+  return getAdminIds().has(userId);
+}
+
+// Exported for testing purposes only
+export function _resetAdminIdsCache(): void {
+  cachedAdminIds = null;
+}

--- a/apps/web/lib/marketer-classifier-prompt.test.ts
+++ b/apps/web/lib/marketer-classifier-prompt.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { buildClassifierPrompt } from "./marketer-classifier-prompt";
+
+describe("buildClassifierPrompt", () => {
+  const preparePost = {
+    title: "How should I prepare for my Google SWE interview next month?",
+    body: "I have a Google interview in 4 weeks. I've been doing LeetCode but I'm not sure if I'm practicing effectively. Any advice on mock interviews or system design?",
+    subreddit: "cscareerquestions",
+  };
+
+  const cheatPost = {
+    title: "Best AI tools to use during a live coding interview?",
+    body: "I have an interview tomorrow and wondering if anyone has experience using AI tools discreetly during the technical round. Something that can suggest code without the interviewer noticing?",
+    subreddit: "cscareerquestions",
+  };
+
+  const irrelevantPost = {
+    title: "Got rejected from Amazon after 5 rounds",
+    body: "Just got the rejection email. 5 rounds of interviews, passed the technical but failed bar raiser. I'm devastated.",
+    subreddit: "cscareerquestions",
+  };
+
+  it("includes the post title in the prompt", () => {
+    const prompt = buildClassifierPrompt(preparePost);
+    expect(prompt).toContain(preparePost.title);
+  });
+
+  it("includes the post body in the prompt", () => {
+    const prompt = buildClassifierPrompt(preparePost);
+    expect(prompt).toContain("mock interviews");
+  });
+
+  it("includes the subreddit in the prompt", () => {
+    const prompt = buildClassifierPrompt(preparePost);
+    expect(prompt).toContain("r/cscareerquestions");
+  });
+
+  it("includes all three classification categories in the prompt", () => {
+    const prompt = buildClassifierPrompt(preparePost);
+    expect(prompt).toContain('"prepare"');
+    expect(prompt).toContain('"cheat"');
+    expect(prompt).toContain('"irrelevant"');
+  });
+
+  it("instructs to return JSON with classification and summary fields", () => {
+    const prompt = buildClassifierPrompt(preparePost);
+    expect(prompt).toContain("classification");
+    expect(prompt).toContain("summary");
+    expect(prompt).toContain("JSON");
+  });
+
+  it("truncates very long body text at 1500 characters", () => {
+    const longBody = "a".repeat(2000);
+    const prompt = buildClassifierPrompt({ ...preparePost, body: longBody });
+    expect(prompt).toContain("...");
+    // The full 2000-char body should not appear
+    expect(prompt).not.toContain(longBody);
+  });
+
+  it("produces different prompts for different posts", () => {
+    const prompt1 = buildClassifierPrompt(preparePost);
+    const prompt2 = buildClassifierPrompt(cheatPost);
+    const prompt3 = buildClassifierPrompt(irrelevantPost);
+    expect(prompt1).not.toEqual(prompt2);
+    expect(prompt2).not.toEqual(prompt3);
+  });
+
+  it("describes cheat signals in classification criteria", () => {
+    const prompt = buildClassifierPrompt(cheatPost);
+    expect(prompt).toContain("cheat");
+    // Prompt should describe what cheat means — includes something about unauthorized
+    expect(prompt.toLowerCase()).toMatch(/(cheat|unauthorized|unfairly)/);
+  });
+
+  it("works with empty body", () => {
+    const prompt = buildClassifierPrompt({ ...preparePost, body: "" });
+    expect(prompt).toContain(preparePost.title);
+    // Should not throw
+  });
+
+  it("includes the subreddit for a different subreddit", () => {
+    const prompt = buildClassifierPrompt({ ...cheatPost, subreddit: "leetcode" });
+    expect(prompt).toContain("r/leetcode");
+  });
+});

--- a/apps/web/lib/marketer-classifier-prompt.ts
+++ b/apps/web/lib/marketer-classifier-prompt.ts
@@ -1,0 +1,45 @@
+/**
+ * Builds the classification prompt for a Reddit post.
+ * Returns a prompt string that asks the LLM to classify intent and extract a summary.
+ * Pure function — no side effects, no API calls.
+ */
+
+export interface ClassifierInput {
+  title: string;
+  body: string;
+  subreddit: string;
+}
+
+export interface ClassificationResult {
+  classification: "prepare" | "cheat" | "irrelevant";
+  summary: string;
+}
+
+/**
+ * Build the classification prompt for a Reddit post.
+ * The LLM must respond with valid JSON matching ClassificationResult.
+ */
+export function buildClassifierPrompt(input: ClassifierInput): string {
+  const { title, body, subreddit } = input;
+
+  const truncatedBody = body.length > 1500 ? body.slice(0, 1500) + "..." : body;
+
+  return `You are classifying Reddit posts to determine whether they are relevant to interview preparation marketing.
+
+Subreddit: r/${subreddit}
+Post title: ${title}
+Post body: ${truncatedBody}
+
+Classify this post into exactly one of these three categories:
+
+- "prepare": The person genuinely wants to prepare for interviews the right way. They're asking for study strategies, practice resources, mock interview advice, tips on improving their skills, or seeking honest feedback on their preparation approach. Include posts where the person is anxious about upcoming interviews and looking for guidance.
+
+- "cheat": The person is looking for ways to cheat, use AI during a live interview without the interviewer knowing, look up answers in real time, use unauthorized tools, or circumvent the interview process unfairly. This includes posts asking about "AI assistance during interview," "undetected tools," "how do companies catch cheating," or similar.
+
+- "irrelevant": The post does not clearly fit either "prepare" or "cheat." This includes job postings, salary discussions, rants, success/failure stories without a question, or off-topic content.
+
+Also extract a one-line summary (under 100 characters) describing what the person is specifically asking.
+
+Respond with ONLY valid JSON in this exact format, nothing else:
+{"classification": "prepare" | "cheat" | "irrelevant", "summary": "<one line summary>"}`;
+}

--- a/apps/web/lib/marketer-reply-prompt.test.ts
+++ b/apps/web/lib/marketer-reply-prompt.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { buildPrepareReplyPrompt, buildCheatReplyPrompt } from "./marketer-reply-prompt";
+
+const CHAN_BIO =
+  "Chan is a current Google SWE who got in by practicing voice-to-voice mock interviews until the real one felt easy.";
+
+const post1 = {
+  title: "How do I prepare for a Google SWE interview in 3 weeks?",
+  selftext: "I have a final round at Google coming up and I'm panicking. I've been grinding LeetCode but not sure if it's enough.",
+  subreddit: "cscareerquestions",
+  permalink: "/r/cscareerquestions/comments/abc123/how_do_i_prepare/",
+};
+
+const post2 = {
+  title: "Best way to practice behavioral interviews?",
+  selftext: "Amazon loop is coming up. I know I need to practice STAR stories but I keep blanking in the moment.",
+  subreddit: "interviews",
+  permalink: "/r/interviews/comments/def456/best_way_to_practice/",
+};
+
+const post3 = {
+  title: "Tips for system design interviews?",
+  selftext: "Senior SWE role at Meta. System design has always been my weak point. How do I improve quickly?",
+  subreddit: "leetcode",
+  permalink: "/r/leetcode/comments/ghi789/tips_for_system_design/",
+};
+
+const cheatPost1 = {
+  title: "Using AI during a live coding interview — will they catch me?",
+  selftext: "Wondering if anyone has used Copilot or ChatGPT during a live coding round without the interviewer noticing.",
+  subreddit: "cscareerquestions",
+  permalink: "/r/cscareerquestions/comments/xyz123/using_ai_during/",
+};
+
+const cheatPost2 = {
+  title: "How do companies detect cheating in technical interviews?",
+  selftext: "Not planning to cheat, just curious about what signals interviewers look for.",
+  subreddit: "cscareerquestions",
+  permalink: "/r/cscareerquestions/comments/uvw456/how_detect/",
+};
+
+describe("buildPrepareReplyPrompt", () => {
+  it("includes Chan's bio verbatim", () => {
+    const prompt = buildPrepareReplyPrompt({ post: post1, summary: "How to prepare for Google SWE interview" });
+    expect(prompt).toContain(CHAN_BIO);
+  });
+
+  it("includes the post title", () => {
+    const prompt = buildPrepareReplyPrompt({ post: post1, summary: "Google prep advice needed" });
+    expect(prompt).toContain(post1.title);
+  });
+
+  it("includes the subreddit", () => {
+    const prompt = buildPrepareReplyPrompt({ post: post1, summary: "Google prep advice needed" });
+    expect(prompt).toContain(post1.subreddit);
+  });
+
+  it("includes the summary", () => {
+    const summary = "Person wants Google prep tips";
+    const prompt = buildPrepareReplyPrompt({ post: post1, summary });
+    expect(prompt).toContain(summary);
+  });
+
+  it("instructs to mention Preploy exactly once", () => {
+    const prompt = buildPrepareReplyPrompt({ post: post1, summary: "Google prep" });
+    expect(prompt).toContain("exactly once");
+  });
+
+  it("includes word count guidance (80-200 words)", () => {
+    const prompt = buildPrepareReplyPrompt({ post: post1, summary: "Google prep" });
+    expect(prompt).toContain("80");
+    expect(prompt).toContain("200");
+  });
+
+  it("forbids template phrases", () => {
+    const prompt = buildPrepareReplyPrompt({ post: post1, summary: "Google prep" });
+    expect(prompt).toContain("In today's competitive job market");
+    expect(prompt).toContain("game-changing");
+  });
+
+  it("produces different prompts for different posts", () => {
+    const summary = "Interview prep question";
+    const prompt1 = buildPrepareReplyPrompt({ post: post1, summary });
+    const prompt2 = buildPrepareReplyPrompt({ post: post2, summary });
+    const prompt3 = buildPrepareReplyPrompt({ post: post3, summary });
+    expect(prompt1).not.toEqual(prompt2);
+    expect(prompt2).not.toEqual(prompt3);
+    expect(prompt1).not.toEqual(prompt3);
+  });
+
+  it("truncates very long selftext at 800 characters", () => {
+    const longSelftext = "x".repeat(1500);
+    const prompt = buildPrepareReplyPrompt({
+      post: { ...post1, selftext: longSelftext },
+      summary: "test",
+    });
+    expect(prompt).toContain("...");
+    expect(prompt).not.toContain(longSelftext);
+  });
+
+  it("instructs NOT to embellish or invent credentials", () => {
+    const prompt = buildPrepareReplyPrompt({ post: post1, summary: "test" });
+    expect(prompt).toContain("NOT embellish");
+  });
+});
+
+describe("buildCheatReplyPrompt", () => {
+  it("includes Chan's bio verbatim", () => {
+    const prompt = buildCheatReplyPrompt({ post: cheatPost1, summary: "Asking about AI tools during interview" });
+    expect(prompt).toContain(CHAN_BIO);
+  });
+
+  it("includes the post title", () => {
+    const prompt = buildCheatReplyPrompt({ post: cheatPost1, summary: "test" });
+    expect(prompt).toContain(cheatPost1.title);
+  });
+
+  it("instructs to mention specific cheat detection signals", () => {
+    const prompt = buildCheatReplyPrompt({ post: cheatPost1, summary: "test" });
+    expect(prompt.toLowerCase()).toMatch(/(eye movement|latency|tab.switching|off.camera)/);
+  });
+
+  it("includes word count guidance (60-150 words)", () => {
+    const prompt = buildCheatReplyPrompt({ post: cheatPost1, summary: "test" });
+    expect(prompt).toContain("60");
+    expect(prompt).toContain("150");
+  });
+
+  it("forbids template phrases", () => {
+    const prompt = buildCheatReplyPrompt({ post: cheatPost1, summary: "test" });
+    expect(prompt).toContain("In today's competitive job market");
+    expect(prompt).toContain("game-changing");
+  });
+
+  it("produces different prompts for different posts", () => {
+    const summary = "Cheat related question";
+    const prompt1 = buildCheatReplyPrompt({ post: cheatPost1, summary });
+    const prompt2 = buildCheatReplyPrompt({ post: cheatPost2, summary });
+    expect(prompt1).not.toEqual(prompt2);
+  });
+
+  it("instructs to mention Preploy as one option (not the only option)", () => {
+    const prompt = buildCheatReplyPrompt({ post: cheatPost1, summary: "test" });
+    expect(prompt).toContain("Preploy");
+    expect(prompt.toLowerCase()).toContain("one option");
+  });
+
+  it("instructs NOT to embellish or invent credentials", () => {
+    const prompt = buildCheatReplyPrompt({ post: cheatPost1, summary: "test" });
+    expect(prompt).toContain("NOT embellish");
+  });
+});

--- a/apps/web/lib/marketer-reply-prompt.ts
+++ b/apps/web/lib/marketer-reply-prompt.ts
@@ -1,0 +1,114 @@
+/**
+ * Builds reply prompts for the Reddit marketer drafting pipeline.
+ * Pure functions — no side effects, no API calls.
+ *
+ * Chan's bio (used verbatim in both prompts, not embellished):
+ * "Chan is a current Google SWE who got in by practicing voice-to-voice mock
+ *  interviews until the real one felt easy."
+ */
+
+export interface ReplyPromptInput {
+  post: {
+    title: string;
+    selftext: string;
+    subreddit: string;
+    permalink: string;
+  };
+  summary: string;
+}
+
+const CHAN_BIO =
+  "Chan is a current Google SWE who got in by practicing voice-to-voice mock interviews until the real one felt easy.";
+
+const FORBIDDEN_PHRASES = [
+  "In today's competitive job market",
+  "As someone who",
+  "I leveraged",
+  "game-changing",
+  "game changer",
+  "I hope this helps",
+  "Good luck on your journey",
+  "Best of luck",
+  "I totally understand",
+  "I completely understand",
+  "I know how you feel",
+  "I feel you",
+  "Don't give up",
+  "You've got this",
+  "Trust the process",
+  "grinding LeetCode",
+];
+
+const FORBIDDEN_LIST = FORBIDDEN_PHRASES.map((p) => `"${p}"`).join(", ");
+
+/**
+ * Build the reply prompt for a "prepare" intent post.
+ * The reply should be 80–200 words, first-person, honest, and mention Preploy exactly once.
+ */
+export function buildPrepareReplyPrompt(input: ReplyPromptInput): string {
+  const { post, summary } = input;
+  const truncatedBody =
+    post.selftext.length > 800
+      ? post.selftext.slice(0, 800) + "..."
+      : post.selftext;
+
+  return `You are drafting a Reddit reply for Chan to post on r/${post.subreddit}.
+
+Chan's background (use VERBATIM, do NOT embellish or invent credentials):
+"${CHAN_BIO}"
+
+The Reddit post:
+Title: ${post.title}
+Body: ${truncatedBody}
+
+What they're asking: ${summary}
+
+Write a helpful first-person reply (80–200 words) that:
+1. Opens with a varied, natural opener — NOT the same opener every time. Vary the structure: sometimes lead with a tip, sometimes with a quick personal observation, sometimes with a concrete fact. Never start with "I" as the first word.
+2. Mentions Chan's specific method: voice-to-voice mock interviews practiced until the real interview felt easy. Explain WHY this worked — be specific and honest.
+3. Mentions Preploy exactly once, naturally. Don't make it sound like an ad. Name it as the tool Chan used, briefly.
+4. Includes one concrete tip beyond just "use Preploy" — something actionable the person can do right now.
+5. Sounds like a real person sharing genuine experience, not a marketing pitch.
+
+STRICTLY FORBIDDEN phrases (do not use any of these): ${FORBIDDEN_LIST}
+
+Vary your opener, structure, and tone each time. The goal is for every reply to feel distinct.
+
+Respond with ONLY the reply text, no preamble, no quotation marks around the whole reply.`;
+}
+
+/**
+ * Build the reply prompt for a "cheat" intent post.
+ * The reply should be 60–150 words, firm but not preachy, and mention Preploy as one option.
+ */
+export function buildCheatReplyPrompt(input: ReplyPromptInput): string {
+  const { post, summary } = input;
+  const truncatedBody =
+    post.selftext.length > 800
+      ? post.selftext.slice(0, 800) + "..."
+      : post.selftext;
+
+  return `You are drafting a Reddit reply for Chan to post on r/${post.subreddit}.
+
+Chan's background (use VERBATIM, do NOT embellish or invent credentials):
+"${CHAN_BIO}"
+
+The Reddit post:
+Title: ${post.title}
+Body: ${truncatedBody}
+
+What they're asking: ${summary}
+
+Write a firm but not preachy reply (60–150 words) that:
+1. Opens without lecturing. Acknowledge the temptation briefly, then pivot quickly.
+2. States clearly that interviewers catch cheating through specific signals — be concrete: eye movement patterns, response latency spikes, tab-switching artifacts, off-camera glances, inconsistent coding style. Pick 2–3 that feel most relevant.
+3. Names the career cost plainly: failing the loop, being flagged in the ATS, referral relationships damaged.
+4. Redirects to preparing properly instead. Mentions Preploy as one option (not THE only option).
+5. Ends without moralizing — one sentence max on consequences is enough.
+
+STRICTLY FORBIDDEN phrases (do not use any of these): ${FORBIDDEN_LIST}
+
+Vary your opener, structure, and tone each time. Do NOT start with "I" as the first word.
+
+Respond with ONLY the reply text, no preamble, no quotation marks around the whole reply.`;
+}

--- a/apps/web/lib/marketer/reddit.test.ts
+++ b/apps/web/lib/marketer/reddit.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Logger } from "pino";
+import { fetchSubredditPosts } from "./reddit";
+
+// Fake pino logger
+const fakeLog = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+} as unknown as Logger;
+
+const now = Date.now();
+const freshPost = {
+  kind: "t3",
+  data: {
+    id: "post1",
+    subreddit: "cscareerquestions",
+    title: "How do I prepare?",
+    selftext: "I have an interview coming up.",
+    permalink: "/r/cscareerquestions/comments/post1/",
+    created_utc: Math.floor((now - 24 * 60 * 60 * 1000) / 1000), // 24h ago (within 48h window)
+    is_self: true,
+  },
+};
+
+const stalePost = {
+  kind: "t3",
+  data: {
+    id: "post2",
+    subreddit: "cscareerquestions",
+    title: "Old post",
+    selftext: "This is old.",
+    permalink: "/r/cscareerquestions/comments/post2/",
+    created_utc: Math.floor((now - 72 * 60 * 60 * 1000) / 1000), // 72h ago (outside 48h window)
+    is_self: true,
+  },
+};
+
+const linkPost = {
+  kind: "t3",
+  data: {
+    id: "post3",
+    subreddit: "cscareerquestions",
+    title: "Link post",
+    selftext: "",
+    permalink: "/r/cscareerquestions/comments/post3/",
+    created_utc: Math.floor((now - 1 * 60 * 60 * 1000) / 1000), // 1h ago
+    is_self: false, // Link post — should be filtered
+  },
+};
+
+function makeApiResponse(children: unknown[]) {
+  return {
+    data: {
+      children,
+    },
+  };
+}
+
+describe("fetchSubredditPosts", () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("returns fresh self posts from a 200 response", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => makeApiResponse([freshPost]),
+    } as Response);
+
+    const posts = await fetchSubredditPosts("cscareerquestions", 25, fakeLog);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].id).toBe("post1");
+    expect(posts[0].title).toBe("How do I prepare?");
+  });
+
+  it("filters out stale posts older than freshness window", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => makeApiResponse([freshPost, stalePost]),
+    } as Response);
+
+    const posts = await fetchSubredditPosts("cscareerquestions", 25, fakeLog);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].id).toBe("post1");
+  });
+
+  it("filters out non-self (link) posts", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => makeApiResponse([linkPost, freshPost]),
+    } as Response);
+
+    const posts = await fetchSubredditPosts("cscareerquestions", 25, fakeLog);
+    expect(posts).toHaveLength(1);
+    expect(posts[0].id).toBe("post1");
+  });
+
+  it("retries once on 429 and returns posts on success", async () => {
+    vi.useFakeTimers();
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        json: async () => ({}),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => makeApiResponse([freshPost]),
+      } as Response);
+
+    const fetchPromise = fetchSubredditPosts("cscareerquestions", 25, fakeLog);
+    await vi.advanceTimersByTimeAsync(5_001);
+    const posts = await fetchPromise;
+
+    expect(posts).toHaveLength(1);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(fakeLog.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ sub: "cscareerquestions" }),
+      expect.stringContaining("429")
+    );
+    vi.useRealTimers();
+  });
+
+  it("returns empty array on persistent 429 after retry", async () => {
+    vi.useFakeTimers();
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({
+        ok: false,
+        status: 429,
+      } as Response);
+
+    const fetchPromise = fetchSubredditPosts("cscareerquestions", 25, fakeLog);
+    await vi.advanceTimersByTimeAsync(5_001);
+    const posts = await fetchPromise;
+
+    expect(posts).toHaveLength(0);
+    expect(fakeLog.error).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("returns empty array on network error", async () => {
+    global.fetch = vi.fn().mockRejectedValueOnce(new Error("Network error"));
+
+    const posts = await fetchSubredditPosts("cscareerquestions", 25, fakeLog);
+    expect(posts).toHaveLength(0);
+    expect(fakeLog.error).toHaveBeenCalled();
+  });
+
+  it("returns empty array on non-OK non-429 status", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    } as Response);
+
+    const posts = await fetchSubredditPosts("cscareerquestions", 25, fakeLog);
+    expect(posts).toHaveLength(0);
+    expect(fakeLog.error).toHaveBeenCalled();
+  });
+
+  it("returns empty array on invalid JSON response", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => { throw new Error("Invalid JSON"); },
+    } as unknown as Response);
+
+    const posts = await fetchSubredditPosts("cscareerquestions", 25, fakeLog);
+    expect(posts).toHaveLength(0);
+    expect(fakeLog.error).toHaveBeenCalled();
+  });
+
+  it("handles empty children array gracefully", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => makeApiResponse([]),
+    } as Response);
+
+    const posts = await fetchSubredditPosts("cscareerquestions", 25, fakeLog);
+    expect(posts).toHaveLength(0);
+  });
+});

--- a/apps/web/lib/marketer/reddit.ts
+++ b/apps/web/lib/marketer/reddit.ts
@@ -1,0 +1,125 @@
+/**
+ * Reddit public JSON API fetcher for the marketer cron job.
+ * Uses the public (no-auth) .json endpoint with a real User-Agent.
+ * Handles rate limiting with a single retry after 5 s.
+ */
+
+import type pino from "pino";
+
+export interface RedditPost {
+  id: string;
+  subreddit: string;
+  title: string;
+  selftext: string;
+  permalink: string;
+  created_utc: number; // Unix seconds
+}
+
+interface RedditApiChild {
+  kind: string;
+  data: {
+    id: string;
+    subreddit: string;
+    title: string;
+    selftext: string;
+    permalink: string;
+    created_utc: number;
+    is_self: boolean;
+  };
+}
+
+interface RedditApiResponse {
+  data: {
+    children: RedditApiChild[];
+  };
+}
+
+const USER_AGENT = "Preploy/0.1 (interview prep helper)";
+const DEFAULT_FRESHNESS_HOURS = 48;
+
+function getFreshnessHours(): number {
+  const raw = process.env.MARKETER_FRESHNESS_HOURS;
+  if (!raw) return DEFAULT_FRESHNESS_HOURS;
+  const parsed = parseInt(raw, 10);
+  return isNaN(parsed) || parsed <= 0 ? DEFAULT_FRESHNESS_HOURS : parsed;
+}
+
+async function fetchWithTimeout(url: string): Promise<Response> {
+  return fetch(url, {
+    signal: AbortSignal.timeout(10_000),
+    headers: {
+      "User-Agent": USER_AGENT,
+      Accept: "application/json",
+    },
+  });
+}
+
+/**
+ * Fetch the latest posts from a subreddit via the Reddit public JSON API.
+ * Filters out posts older than MARKETER_FRESHNESS_HOURS (default 48h).
+ * Retries once on 429 after 5 s; logs and returns [] on persistent failure.
+ */
+export async function fetchSubredditPosts(
+  sub: string,
+  limit: number,
+  log: pino.Logger
+): Promise<RedditPost[]> {
+  const url = `https://www.reddit.com/r/${sub}/new.json?limit=${limit}`;
+  const freshnessMs = getFreshnessHours() * 60 * 60 * 1000;
+  const cutoff = Date.now() - freshnessMs;
+
+  let res: Response;
+
+  try {
+    res = await fetchWithTimeout(url);
+  } catch (err) {
+    log.error({ err, sub }, "reddit fetch failed (network/timeout)");
+    return [];
+  }
+
+  if (res.status === 429) {
+    log.warn({ sub }, "reddit 429, retrying after 5s");
+    await new Promise((r) => setTimeout(r, 5_000));
+    try {
+      res = await fetchWithTimeout(url);
+    } catch (err) {
+      log.error({ err, sub }, "reddit fetch failed after 429 retry");
+      return [];
+    }
+    if (res.status === 429) {
+      log.error({ sub }, "reddit still rate-limited after retry, skipping");
+      return [];
+    }
+  }
+
+  if (!res.ok) {
+    log.error({ sub, status: res.status }, "reddit fetch non-OK status");
+    return [];
+  }
+
+  let json: RedditApiResponse;
+  try {
+    json = (await res.json()) as RedditApiResponse;
+  } catch (err) {
+    log.error({ err, sub }, "reddit response JSON parse failed");
+    return [];
+  }
+
+  const children = json?.data?.children ?? [];
+
+  return children
+    .filter(
+      (c) =>
+        c.kind === "t3" &&
+        c.data.is_self &&
+        c.data.created_utc * 1000 >= cutoff
+    )
+    .map((c) => ({
+      id: c.data.id,
+      subreddit: c.data.subreddit,
+      title: c.data.title,
+      selftext: c.data.selftext,
+      permalink: c.data.permalink,
+      created_utc: c.data.created_utc,
+    }));
+}

--- a/apps/web/lib/schema.ts
+++ b/apps/web/lib/schema.ts
@@ -266,6 +266,46 @@ export const sessionTemplates = pgTable("session_templates", {
     .defaultNow(),
 });
 
+export const marketerPosts = pgTable(
+  "marketer_posts",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    source: text("source").notNull().default("reddit"),
+    externalId: text("external_id").notNull(),
+    subreddit: text("subreddit").notNull(),
+    title: text("title").notNull(),
+    body: text("body").notNull(),
+    permalink: text("permalink").notNull(),
+    postedAt: timestamp("posted_at", { withTimezone: true }).notNull(),
+    fetchedAt: timestamp("fetched_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    classification: text("classification"),
+    summary: text("summary"),
+  },
+  (table) => [
+    uniqueIndex("marketer_posts_external_id_unique").on(table.externalId),
+  ]
+);
+
+export const marketerDrafts = pgTable("marketer_drafts", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  postId: uuid("post_id")
+    .notNull()
+    .references(() => marketerPosts.id, { onDelete: "cascade" }),
+  intent: text("intent").notNull(),
+  reply: text("reply").notNull(),
+  status: text("status").notNull().default("pending"),
+  discardReason: text("discard_reason"),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  reviewedAt: timestamp("reviewed_at", { withTimezone: true }),
+  reviewedBy: uuid("reviewed_by").references(() => users.id, {
+    onDelete: "set null",
+  }),
+});
+
 // ---- Relations ----
 
 export const usersRelations = relations(users, ({ many }) => ({
@@ -408,6 +448,27 @@ export const interviewUsageRelations = relations(
   ({ one }) => ({
     user: one(users, {
       fields: [interviewUsage.userId],
+      references: [users.id],
+    }),
+  })
+);
+
+export const marketerPostsRelations = relations(
+  marketerPosts,
+  ({ many }) => ({
+    drafts: many(marketerDrafts),
+  })
+);
+
+export const marketerDraftsRelations = relations(
+  marketerDrafts,
+  ({ one }) => ({
+    post: one(marketerPosts, {
+      fields: [marketerDrafts.postId],
+      references: [marketerPosts.id],
+    }),
+    reviewer: one(users, {
+      fields: [marketerDrafts.reviewedBy],
       references: [users.id],
     }),
   })

--- a/apps/web/lib/validations.ts
+++ b/apps/web/lib/validations.ts
@@ -99,3 +99,42 @@ export const listStarStoriesQuerySchema = z.object({
     .pipe(z.number().int().min(1).max(100)),
 });
 export type ListStarStoriesQuery = z.infer<typeof listStarStoriesQuerySchema>;
+
+// ---- Marketer schemas ----
+
+export const listMarketerDraftsQuerySchema = z.object({
+  page: z
+    .string()
+    .optional()
+    .transform((v) => (v ? parseInt(v, 10) : 1))
+    .pipe(z.number().int().min(1)),
+  limit: z
+    .string()
+    .optional()
+    .transform((v) => (v ? parseInt(v, 10) : 20))
+    .pipe(z.number().int().min(1).max(100)),
+});
+export type ListMarketerDraftsQuery = z.infer<
+  typeof listMarketerDraftsQuerySchema
+>;
+
+export const discardDraftSchema = z.object({
+  reason: z.enum([
+    "spammy",
+    "off-topic",
+    "duplicate",
+    "low-quality",
+    "other",
+  ]),
+});
+export type DiscardDraftInput = z.infer<typeof discardDraftSchema>;
+
+export const editDraftSchema = z.object({
+  reply: z.string().min(1).max(2000),
+});
+export type EditDraftInput = z.infer<typeof editDraftSchema>;
+
+export const classificationResultSchema = z.object({
+  classification: z.enum(["prepare", "cheat", "irrelevant"]),
+  summary: z.string().max(200),
+});

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,7 +1,7 @@
 import { auth } from "@/lib/auth";
 import { NextResponse } from "next/server";
 
-const protectedPaths = ["/interview", "/dashboard", "/coaching", "/profile", "/planner", "/resume", "/star"];
+const protectedPaths = ["/interview", "/dashboard", "/coaching", "/profile", "/planner", "/resume", "/star", "/admin"];
 
 // Production canonical host. Vercel exposes every deploy under a stable
 // alias (`preploy.vercel.app`) AND a unique per-deployment hash like
@@ -59,5 +59,7 @@ export const config = {
     "/resume/:path*",
     "/star",
     "/star/:path*",
+    "/admin",
+    "/admin/:path*",
   ],
 };

--- a/apps/web/tests/setup-db.ts
+++ b/apps/web/tests/setup-db.ts
@@ -17,6 +17,8 @@ export function getTestDb() {
 
 export async function cleanupTestDb() {
   const db = getTestDb();
+  await db.delete(schema.marketerDrafts);
+  await db.delete(schema.marketerPosts);
   await db.delete(schema.starStoryAnalyses);
   await db.delete(schema.sessionTemplates);
   await db.delete(schema.companyQuestions);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/admin/marketer/run",
+      "schedule": "0 14 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Daily Vercel Cron job (`vercel.json`, `0 14 * * *`) hits `POST /api/admin/marketer/run`, which fetches the latest posts from a configured list of subreddits, classifies each as `prepare | cheat | irrelevant` via an LLM, and drafts a tailored reply for actionable posts.
- New admin UI at `/admin/marketer` lets an admin (gated on `ADMIN_USER_IDS`) review pending drafts and approve-and-copy, edit, or discard them. **The system never writes to Reddit** — this is an approval queue only, by deliberate design.
- New `marketer_posts` and `marketer_drafts` tables (migration `0009_brief_network.sql`), drafted replies use Chan's actual bio verbatim with a forbidden-phrase list and variety instructions to avoid the model collapsing to templates that subreddits would flag as spam.

Closes #40

## Why approval queue, not auto-poster

Subreddit anti-spam rules and our reputation both require human review for v1. Auto-posting will be reconsidered later. The architecture is set up so flipping this to auto-post is a small change (a new background worker that consumes the `approved` rows), but it isn't part of this PR.

## Schema changes

New migration: `apps/web/drizzle/0009_brief_network.sql`

- `marketer_posts (id uuid pk, source text, external_id text UNIQUE, subreddit text, title text, body text, permalink text, posted_at, fetched_at, classification text, summary text)` — `source` defaults to `reddit`; `external_id` UNIQUE makes the cron run idempotent.
- `marketer_drafts (id uuid pk, post_id uuid FK CASCADE, intent text, reply text, status text default 'pending', discard_reason text, reviewed_at, reviewed_by uuid FK SET NULL, created_at)` — status is one of `pending | approved | edited | discarded`.

`apps/web/drizzle/` was staged as a directory (not individual files), so `_journal.json` is included — no repeat of the missing-journal bug from #36.

## Manual setup required

New env vars (documented in `apps/web/README.md`):

| Variable | Purpose |
|---|---|
| `CRON_SECRET` | Bearer token Vercel Cron sends to `/api/admin/marketer/run`. Generate with `openssl rand -hex 32`. Set in Vercel **and** add to `turbo.json` build env list before merging if the build needs it (it doesn't — runtime only). |
| `ADMIN_USER_IDS` | Comma-separated NextAuth user UUIDs allowed to access `/admin/**`. |
| `MARKETER_FRESHNESS_HOURS` | Post age cutoff in hours (default `48`). |

Vercel will auto-detect `vercel.json` and register the cron after the first deploy.

## Test plan

- [x] `npx turbo lint typecheck test` — 511 unit/component tests green
- [x] `npm run test:integration` — 288 integration tests green
  - 37 new unit: classifier prompt builder (10), reply prompt builders incl. Chan bio + variety + forbidden phrases (18), Reddit fetcher with mocked fetch covering 200, 429 retry, timeout, network error, non-OK (9)
  - 30 new integration across all 5 admin routes: 401 unauth, 401 wrong CRON_SECRET, 401 missing env, 404 non-admin, 400 invalid input, happy path, idempotency (run twice → no dupes), persistence verified with SELECT, discarded drafts excluded from pending list
  - 7 component tests for the admin page (cards render, approve calls fetch, edit textarea updates, discard requires reason)
- [ ] Reviewer approves
- [ ] Set `CRON_SECRET` + `ADMIN_USER_IDS` in Vercel before first deploy
- [ ] Verify Vercel detects the cron after deploy (Project → Settings → Crons)
- [ ] Manual test: hit the cron endpoint with the secret, verify drafts appear in `/admin/marketer`

## Pre-merge notes

**Migration is `0009`, no collision** — Wave 3's other two stories (#37 and #38) don't add migrations, so #40 has the slot uncontested. The `_journal.json` update is included in the commit (per the post-#36 rule of staging the entire `drizzle/` directory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)