### PR TITLE
fix(security): remove self-serve plan upgrade — close /api/users/me plan bypass

### DIFF
--- a/apps/web/app/api/users/me/route.integration.test.ts
+++ b/apps/web/app/api/users/me/route.integration.test.ts
@@ -106,22 +106,37 @@ describe("API /api/users/me (integration)", () => {
     expect(res.status).toBe(400);
   });
 
-  it("PATCH updates plan", async () => {
+  it("PATCH rejects any attempt to change plan (security: must go through Stripe)", async () => {
     mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
     const res = await PATCH(makePatchRequest({ plan: "pro" }));
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(403);
     const data = await res.json();
-    expect(data.plan).toBe("pro");
+    expect(data.error).toMatch(/Stripe billing/i);
 
-    // Reset
+    // Verify the DB row is still on the original plan (no silent write)
     const db = getTestDb();
-    await db.update(users).set({ plan: "free" }).where(eq(users.id, TEST_USER.id));
+    const [row] = await db
+      .select({ plan: users.plan })
+      .from(users)
+      .where(eq(users.id, TEST_USER.id));
+    expect(row.plan).toBe("free");
   });
 
-  it("PATCH rejects invalid plan", async () => {
+  it("PATCH rejects plan even when paired with a valid name update", async () => {
     mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
-    const res = await PATCH(makePatchRequest({ plan: "enterprise" }));
-    expect(res.status).toBe(400);
+    const res = await PATCH(
+      makePatchRequest({ name: "Hacked", plan: "pro" })
+    );
+    expect(res.status).toBe(403);
+
+    // Name should NOT have been written either — the request was rejected wholesale
+    const db = getTestDb();
+    const [row] = await db
+      .select({ name: users.name, plan: users.plan })
+      .from(users)
+      .where(eq(users.id, TEST_USER.id));
+    expect(row.name).toBe("Test User");
+    expect(row.plan).toBe("free");
   });
 
   it("PATCH rejects empty body", async () => {

--- a/apps/web/app/api/users/me/route.ts
+++ b/apps/web/app/api/users/me/route.ts
@@ -3,10 +3,6 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { users } from "@/lib/schema";
 import { eq } from "drizzle-orm";
-import type { PlanId } from "@/lib/plans";
-import { PLANS } from "@/lib/plans";
-
-const VALID_PLANS = new Set(Object.keys(PLANS));
 
 // GET /api/users/me — get current user profile
 export async function GET() {
@@ -37,6 +33,13 @@ export async function GET() {
 }
 
 // PATCH /api/users/me — update current user profile
+//
+// SECURITY: this endpoint must NEVER accept the `plan` field. Plan changes
+// are gated entirely through the Stripe webhook (`POST /api/billing/webhook`)
+// which flips `users.plan` to `"pro"` on `checkout.session.completed` and
+// back to `"free"` on `customer.subscription.deleted`. Accepting a `plan`
+// field here would let any signed-in user upgrade themselves for free —
+// this exact bug was reported and fixed in this PR.
 export async function PATCH(request: NextRequest) {
   const session = await auth();
   if (!session?.user?.id) {
@@ -63,15 +66,16 @@ export async function PATCH(request: NextRequest) {
     updates.image = body.image.trim() || null;
   }
 
-  // Plan update
-  if (typeof body.plan === "string") {
-    if (!VALID_PLANS.has(body.plan)) {
-      return NextResponse.json(
-        { error: `Invalid plan. Must be one of: ${[...VALID_PLANS].join(", ")}` },
-        { status: 400 }
-      );
-    }
-    updates.plan = body.plan as PlanId;
+  // `plan` is intentionally not in the allowlist above. Reject any
+  // attempt to send it so a confused client doesn't get a silent 200.
+  if ("plan" in body) {
+    return NextResponse.json(
+      {
+        error:
+          "Plan changes are managed through Stripe billing. Use /api/billing/checkout to upgrade.",
+      },
+      { status: 403 }
+    );
   }
 
   if (Object.keys(updates).length === 0) {

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -7,7 +7,6 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { PLANS } from "@/lib/plans";
 import type { PlanId } from "@/lib/plans";
 
@@ -22,19 +21,15 @@ interface UserProfile {
   createdAt: string;
 }
 
-const PLAN_OPTIONS = Object.values(PLANS);
-
 export default function ProfilePage() {
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   // Editable fields
   const [name, setName] = useState("");
-  const [selectedPlan, setSelectedPlan] = useState<PlanId>("free");
 
   // UI state
   const [isSavingName, setIsSavingName] = useState(false);
-  const [isSavingPlan, setIsSavingPlan] = useState(false);
   const [isDisabling, setIsDisabling] = useState(false);
   const [isBillingLoading, setIsBillingLoading] = useState(false);
   const [showDisableConfirm, setShowDisableConfirm] = useState(false);
@@ -48,7 +43,6 @@ export default function ProfilePage() {
           const data: UserProfile = await res.json();
           setProfile(data);
           setName(data.name ?? "");
-          setSelectedPlan(data.plan);
         }
       } catch {
         // Silent
@@ -85,30 +79,6 @@ export default function ProfilePage() {
       showMessage("error", "Failed to update name");
     } finally {
       setIsSavingName(false);
-    }
-  };
-
-  const handleSavePlan = async () => {
-    if (selectedPlan === profile?.plan) return;
-    setIsSavingPlan(true);
-    try {
-      const res = await fetch("/api/users/me", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ plan: selectedPlan }),
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setProfile((p) => (p ? { ...p, plan: data.plan } : p));
-        showMessage("success", `Plan changed to ${PLANS[data.plan as PlanId].name}`);
-      } else {
-        const err = await res.json();
-        showMessage("error", err.error || "Failed to change plan");
-      }
-    } catch {
-      showMessage("error", "Failed to change plan");
-    } finally {
-      setIsSavingPlan(false);
     }
   };
 
@@ -269,36 +239,12 @@ export default function ProfilePage() {
                 <Badge variant="secondary">{PLANS[profile.plan].name}</Badge>
               </div>
             </CardHeader>
-            <CardContent className="space-y-4">
-              <RadioGroup
-                value={selectedPlan}
-                onValueChange={(v) => setSelectedPlan(v as PlanId)}
-              >
-                {PLAN_OPTIONS.map((plan) => (
-                  <label
-                    key={plan.id}
-                    className="flex cursor-pointer items-center justify-between rounded-md border px-4 py-3 hover:bg-accent has-[data-checked]:border-primary has-[data-checked]:bg-primary/5"
-                  >
-                    <div className="flex items-center gap-3">
-                      <RadioGroupItem value={plan.id} />
-                      <div>
-                        <p className="text-sm font-medium">{plan.name}</p>
-                        <p className="text-xs text-muted-foreground">
-                          {plan.dailySessionLimit} sessions/day
-                        </p>
-                      </div>
-                    </div>
-                  </label>
-                ))}
-              </RadioGroup>
-
-              <Button
-                onClick={handleSavePlan}
-                disabled={isSavingPlan || selectedPlan === profile.plan}
-                className="w-full"
-              >
-                {isSavingPlan ? "Updating..." : "Update Plan"}
-              </Button>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                {profile.plan === "free"
+                  ? "You're on the Free plan with 3 mock interviews per month. Upgrade below to remove the limit."
+                  : "You're on the Pro plan with unlimited mock interviews. Manage your subscription below."}
+              </p>
             </CardContent>
           </Card>
 

--- a/apps/web/app/profile/profile.test.tsx
+++ b/apps/web/app/profile/profile.test.tsx
@@ -73,13 +73,17 @@ describe("ProfilePage", () => {
     });
   });
 
-  it("renders plan options after loading", async () => {
+  it("renders the read-only Plan card showing the user's current plan", async () => {
     render(<ProfilePage />);
     await vi.waitFor(() => {
+      // Plan card title and the user's tier badge
+      expect(screen.getAllByText("Plan").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("Free").length).toBeGreaterThanOrEqual(1);
     });
-    expect(screen.getAllByText("Pro").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText("Max").length).toBeGreaterThanOrEqual(1);
+    // No interactive plan-change UI — the radio group + Update Plan button
+    // were removed because they let any user upgrade themselves to Pro/Max
+    // without paying.
+    expect(screen.queryByText("Update Plan")).toBeNull();
   });
 
   it("renders danger zone section", async () => {


### PR DESCRIPTION
## ⚠️ Critical security fix — merge ASAP

Any signed-in user could upgrade themselves to Pro or Max **for free** by:
1. Visiting `/profile`
2. Clicking the "Pro" or "Max" radio button under the Plan card
3. Clicking "Update Plan"

…or by POSTing `{ plan: "pro" }` directly to `PATCH /api/users/me`. The UI surfaced a RadioGroup of `free | pro | max` options, and the API blindly accepted any valid plan string and wrote it to `users.plan`.

Reported by the author during manual prod testing on a fresh Google account.

## What changed

### Server (`apps/web/app/api/users/me/route.ts`)
- `PATCH` now returns **403** if the request body contains a `plan` key, with an explicit error message: *"Plan changes are managed through Stripe billing. Use /api/billing/checkout to upgrade."*
- The check fires **before** any other field is applied, so `{ name: "Hacked", plan: "pro" }` rolls back the entire update — no partial writes.
- Removed the `VALID_PLANS` set and `PlanId` import (no longer needed).
- Plan changes now flow exclusively through the Stripe webhook (`POST /api/billing/webhook` → `users.plan = "pro"` on `checkout.session.completed`).

### Client (`apps/web/app/profile/page.tsx`)
- Removed the RadioGroup + "Update Plan" button + `handleSavePlan` + `isSavingPlan` + `selectedPlan` state.
- The Plan card now renders as a **read-only label** showing the current tier with a short description.
- The Billing card directly below it is the only path to upgrade — `POST /api/billing/checkout`.

### Tests
- New: `PATCH rejects any attempt to change plan (security: must go through Stripe)` — asserts 403, error message pattern, and that the DB row is unchanged.
- New: `PATCH rejects plan even when paired with a valid name update` — asserts the name is **not** written either, so attackers can't sneak the plan through via field mixing.
- Removed the old positive `PATCH updates plan` test (it was the test that documented the vulnerability).
- Updated the profile component test to assert the radio group is gone.

## Test plan

- [x] `npx turbo lint typecheck test` — 483 unit/component tests green
- [x] `npm run test:integration` — 269 integration tests green
- [ ] **Merge immediately** and verify on prod that `PATCH /api/users/me` with `{plan: "pro"}` returns 403
- [ ] Manually verify on prod that `/profile` no longer shows the radio group

## Why this happened

The plan radio group was originally added as a development affordance so the team could test free-tier vs pro-tier flows without needing real Stripe checkout. It was never gated behind an admin or env-var check, and survived the Wave 2 billing rollout because no one cross-checked the existing `/profile` page when adding the proper Stripe checkout flow in PR #50 + #58.

**Lesson for `apps/web/CLAUDE.md`:** I'll add a follow-up rule that any in-app affordance for changing security-relevant fields (plan, role, account status) must be either gated behind `isAdmin()` or removed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)