### PR TITLE
fix(billing): route Profile billing card by plan, not stripe_customer_id

### DIFF
--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -85,9 +85,15 @@ export default function ProfilePage() {
   const handleBillingPortal = async () => {
     setIsBillingLoading(true);
     try {
-      const endpoint = profile?.stripeCustomerId
-        ? "/api/billing/portal"
-        : "/api/billing/checkout";
+      // Route by ACTUAL plan, not by `stripeCustomerId` existence.
+      // A free user who started checkout but never completed it (e.g.
+      // a misconfigured price ID) has a `stripe_customer_id` row but no
+      // active subscription — they should still see "Upgrade to Pro" and
+      // hit checkout, not the empty Stripe Billing Portal.
+      const endpoint =
+        profile?.plan === "pro"
+          ? "/api/billing/portal"
+          : "/api/billing/checkout";
       const res = await fetch(endpoint, { method: "POST" });
       if (res.ok) {
         const data = await res.json();
@@ -253,7 +259,7 @@ export default function ProfilePage() {
               <CardTitle>Billing</CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
-              {profile.stripeCustomerId ? (
+              {profile.plan === "pro" ? (
                 <>
                   <p className="text-sm text-muted-foreground">
                     Update your card, view invoices, or cancel your subscription

--- a/apps/web/app/profile/profile.test.tsx
+++ b/apps/web/app/profile/profile.test.tsx
@@ -6,13 +6,22 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 
-const baseProfile = {
+const baseProfile: {
+  id: string;
+  email: string;
+  name: string;
+  image: null;
+  plan: "free" | "pro" | "max";
+  stripeCustomerId: string | null;
+  disabledAt: null;
+  createdAt: string;
+} = {
   id: "user-1",
   email: "test@example.com",
   name: "Test User",
   image: null,
-  plan: "free" as const,
-  stripeCustomerId: null as string | null,
+  plan: "free",
+  stripeCustomerId: null,
   disabledAt: null,
   createdAt: "2026-01-01T00:00:00Z",
 };
@@ -100,18 +109,35 @@ describe("ProfilePage", () => {
     });
   });
 
-  it("shows Upgrade to Pro button for a user without a stripe customer", async () => {
-    global.fetch = mockFetchWithProfile({ ...baseProfile, stripeCustomerId: null });
+  it("shows Upgrade to Pro button for a free-plan user", async () => {
+    global.fetch = mockFetchWithProfile({ ...baseProfile, plan: "free" });
     render(<ProfilePage />);
     await vi.waitFor(() => {
       expect(screen.getByTestId("upgrade-button")).toBeTruthy();
     });
     expect(screen.getAllByText("Upgrade to Pro").length).toBeGreaterThanOrEqual(1);
+    // Free users should NEVER see "Manage billing" — even ones with a
+    // dangling stripe_customer_id from a previous failed checkout attempt.
+    expect(screen.queryByTestId("manage-billing-button")).toBeNull();
   });
 
-  it("shows Manage billing button for a user with a stripe customer", async () => {
+  it("shows Upgrade to Pro for a free user even if they have a dangling stripe_customer_id", async () => {
     global.fetch = mockFetchWithProfile({
       ...baseProfile,
+      plan: "free",
+      stripeCustomerId: "cus_left_over_from_failed_checkout",
+    });
+    render(<ProfilePage />);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("upgrade-button")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("manage-billing-button")).toBeNull();
+  });
+
+  it("shows Manage billing button for a pro-plan user", async () => {
+    global.fetch = mockFetchWithProfile({
+      ...baseProfile,
+      plan: "pro",
       stripeCustomerId: "cus_test_123",
     });
     render(<ProfilePage />);
@@ -119,11 +145,12 @@ describe("ProfilePage", () => {
       expect(screen.getByTestId("manage-billing-button")).toBeTruthy();
     });
     expect(screen.getAllByText("Manage billing").length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByTestId("upgrade-button")).toBeNull();
   });
 
   it("clicking Upgrade to Pro calls /api/billing/checkout and redirects", async () => {
     const { fireEvent } = await import("@testing-library/react");
-    const profile = { ...baseProfile, stripeCustomerId: null };
+    const profile = { ...baseProfile, plan: "free" as const, stripeCustomerId: null };
     const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
       if (url.includes("/api/templates")) {
         return Promise.resolve({ ok: true, json: async () => [] });
@@ -162,7 +189,7 @@ describe("ProfilePage", () => {
 
   it("clicking Manage billing calls /api/billing/portal and redirects", async () => {
     const { fireEvent } = await import("@testing-library/react");
-    const profile = { ...baseProfile, stripeCustomerId: "cus_test_123" };
+    const profile = { ...baseProfile, plan: "pro" as const, stripeCustomerId: "cus_test_123" };
     const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
       if (url.includes("/api/templates")) {
         return Promise.resolve({ ok: true, json: async () => [] });


### PR DESCRIPTION
Reported by the user: their account showed "Manage billing" with no Upgrade to Pro option, even though they were on the Free plan. Root cause: the conditional in the Billing card was

    profile.stripeCustomerId ? <ManageBilling /> : <UpgradeToPro />

A free user who started checkout but never completed it (e.g. their earlier Stripe test where STRIPE_PRO_PRICE_ID pointed at a product ID instead of a price ID) has a `stripe_customer_id` row from the customer creation step but no active subscription. The UI saw the customer ID and showed "Manage billing", but the Stripe portal would render empty because there's nothing to manage.

Fix: route by ACTUAL plan instead.

    profile.plan === "pro" ? <ManageBilling /> : <UpgradeToPro />

Also updated `handleBillingPortal` to pick `/api/billing/portal` vs `/api/billing/checkout` based on the same condition. The checkout route already reuses an existing customer ID if one is present, so clicking "Upgrade to Pro" on a user with a dangling customer ID will correctly resume the same Stripe customer.

Tests:
- New: "shows Upgrade to Pro for a free user even if they have a dangling stripe_customer_id" — exact regression case.
- New: assertions that the alternate button is NOT rendered (queryByTestId returns null) so a regression that shows BOTH would fail.
- Updated existing tests to set `plan` instead of `stripeCustomerId` as the discriminator.

483 unit/component + 269 integration tests pass.