### PR TITLE
fix(billing): derive Stripe success/cancel URLs from request origin

### DIFF
--- a/apps/web/app/api/billing/checkout/route.integration.test.ts
+++ b/apps/web/app/api/billing/checkout/route.integration.test.ts
@@ -194,6 +194,36 @@ describe("POST /api/billing/checkout (integration)", () => {
     );
   });
 
+  it("derives success_url from the request origin when NEXTAUTH_URL and AUTH_URL are unset", async () => {
+    delete process.env.NEXTAUTH_URL;
+    delete process.env.AUTH_URL;
+
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    mockCustomersCreate.mockResolvedValue({ id: "cus_origin_test" });
+    mockCheckoutSessionsCreate.mockResolvedValue({
+      id: "cs_origin",
+      url: "https://checkout.stripe.com/pay/cs_origin",
+    });
+
+    // Simulate a request coming in on the deployed Vercel host.
+    const req = new NextRequest(
+      "https://preploy.vercel.app/api/billing/checkout",
+      { method: "POST" }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    expect(mockCheckoutSessionsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success_url: "https://preploy.vercel.app/profile?billing=success",
+        cancel_url: "https://preploy.vercel.app/profile?billing=cancelled",
+      })
+    );
+
+    // Reset for other tests
+    process.env.NEXTAUTH_URL = "http://localhost:3000";
+  });
+
   it("returns 404 when user is not found in db", async () => {
     mockAuth.mockResolvedValue({
       user: { id: "00000000-0000-0000-0000-000000000099" },

--- a/apps/web/app/api/billing/checkout/route.ts
+++ b/apps/web/app/api/billing/checkout/route.ts
@@ -8,13 +8,31 @@ import { checkRateLimit } from "@/lib/api-utils";
 import { createRequestLogger } from "@/lib/logger";
 
 /**
+ * Resolve the public base URL the deployed app is running at, in priority
+ * order: NEXTAUTH_URL → AUTH_URL → the actual request's origin → localhost.
+ *
+ * Stripe's success_url and cancel_url are HARD failures if they point at a
+ * host the user can't reach (e.g. `localhost:3000` from a Vercel deployment),
+ * so the most defensive fallback is the request's own origin — that is by
+ * definition reachable by the caller, regardless of how Vercel/Turbo handed
+ * env vars to the function.
+ */
+function resolveBaseUrl(request: NextRequest): string {
+  return (
+    process.env.NEXTAUTH_URL ??
+    process.env.AUTH_URL ??
+    new URL(request.url).origin ??
+    "http://localhost:3000"
+  );
+}
+
+/**
  * POST /api/billing/checkout
  * Creates a Stripe Checkout Session for the Pro plan.
  * Looks up or creates a Stripe customer for the current user, persisting
  * stripe_customer_id on the users row for re-use on subsequent calls.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export async function POST(_request: NextRequest) {
+export async function POST(request: NextRequest) {
   const session = await auth();
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -76,7 +94,7 @@ export async function POST(_request: NextRequest) {
     log.info({ stripeCustomerId: customerId }, "reusing existing stripe customer");
   }
 
-  const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
+  const baseUrl = resolveBaseUrl(request);
   const checkoutSession = await stripe.checkout.sessions.create({
     customer: customerId,
     mode: "subscription",

--- a/apps/web/app/api/billing/portal/route.integration.test.ts
+++ b/apps/web/app/api/billing/portal/route.integration.test.ts
@@ -158,6 +158,32 @@ describe("POST /api/billing/portal (integration)", () => {
     delete process.env.AUTH_URL;
   });
 
+  it("falls back to the request origin when neither NEXTAUTH_URL nor AUTH_URL is set", async () => {
+    delete process.env.NEXTAUTH_URL;
+    delete process.env.AUTH_URL;
+
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER_PRO.id } });
+    mockPortalCreate.mockResolvedValueOnce({
+      id: "bps_test_origin",
+      url: "https://billing.stripe.com/session/test_origin",
+    });
+
+    // Build the request from a deployed-looking origin so the route
+    // derives the return_url from `request.url`'s host.
+    const req = new NextRequest(
+      "https://preploy.vercel.app/api/billing/portal",
+      { method: "POST" }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(mockPortalCreate).toHaveBeenCalledWith({
+      customer: "cus_portal_pro",
+      return_url: "https://preploy.vercel.app/profile",
+    });
+
+    process.env.NEXTAUTH_URL = "http://localhost:3000";
+  });
+
   it("returns 429 when the rate limiter rejects the request", async () => {
     mockAuth.mockResolvedValue({ user: { id: TEST_USER_PRO.id } });
     mockCheckRateLimit.mockReturnValueOnce(

--- a/apps/web/app/api/billing/portal/route.ts
+++ b/apps/web/app/api/billing/portal/route.ts
@@ -8,14 +8,29 @@ import { checkRateLimit } from "@/lib/api-utils";
 import { createRequestLogger } from "@/lib/logger";
 
 /**
+ * Resolve the public base URL the deployed app is running at, in priority
+ * order: NEXTAUTH_URL → AUTH_URL → the actual request's origin → localhost.
+ * The request-origin fallback is the most defensive option because it works
+ * regardless of how Vercel/Turbo handed env vars to the function — Stripe's
+ * return_url is a hard failure if it points at an unreachable host.
+ */
+function resolveBaseUrl(request: NextRequest): string {
+  return (
+    process.env.NEXTAUTH_URL ??
+    process.env.AUTH_URL ??
+    new URL(request.url).origin ??
+    "http://localhost:3000"
+  );
+}
+
+/**
  * POST /api/billing/portal
  * Creates a Stripe Billing Portal session for the current user so they can
  * manage their subscription, payment methods, and invoices on Stripe's
  * hosted UI. Requires the user to already have a stripe_customer_id (i.e.
  * to have completed checkout at least once).
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export async function POST(_request: NextRequest) {
+export async function POST(request: NextRequest) {
   const session = await auth();
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -50,8 +65,7 @@ export async function POST(_request: NextRequest) {
     );
   }
 
-  const baseUrl =
-    process.env.NEXTAUTH_URL ?? process.env.AUTH_URL ?? "http://localhost:3000";
+  const baseUrl = resolveBaseUrl(request);
 
   const portalSession = await stripe.billingPortal.sessions.create({
     customer: user.stripeCustomerId,


### PR DESCRIPTION
## Bug

Completing Stripe checkout in test mode on prod redirected to \`http://localhost:3000/profile?billing=success\` instead of \`https://preploy.vercel.app/profile?billing=success\`, giving a browser connection error.

## Root cause

Both \`POST /api/billing/checkout\` and \`POST /api/billing/portal\` derived their Stripe return URLs from a single env var:

\`\`\`ts
const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3000";
\`\`\`

The user has \`AUTH_URL=https://preploy.vercel.app\` set in Vercel (NextAuth v5 prefers \`AUTH_URL\` over \`NEXTAUTH_URL\`) but **not** \`NEXTAUTH_URL\`. The Stripe route only read the latter, so it fell back to \`http://localhost:3000\` in production. Stripe accepted the URL because it's HTTPS-optional in test mode, the user completed checkout successfully, and then the browser tried to navigate to localhost from a Vercel deployment → connection error.

## Fix

Adds a \`resolveBaseUrl(request)\` helper to both routes that walks through:

1. \`process.env.NEXTAUTH_URL\` (if set, use it)
2. \`process.env.AUTH_URL\` (NextAuth v5 canonical name)
3. \`new URL(request.url).origin\` (load-bearing fallback — the request itself knows the host)
4. \`http://localhost:3000\` (only reachable on localhost dev)

The request-origin fallback is the actual fix. It works regardless of how Vercel/Turbo handed env vars to the function, because it derives the host from the request the user just made — by definition reachable. Step 1 and 2 are kept so anyone who *does* configure them still gets the canonical host even on a request via a non-canonical alias.

## Same lesson as #57

PR #57 was about Turbo stripping env vars unless declared in \`turbo.json\`. This is the generalised version of that lesson: **never trust a single env var for a public URL when the request itself can tell you.** Updated both billing routes to follow the new pattern; will fold this into \`apps/web/CLAUDE.md\` as a follow-up if the pattern repeats anywhere else.

## Test plan

- [x] \`npx turbo lint typecheck test\` — 483 unit/component tests green
- [x] \`npm run test:integration\` — 271 integration tests green (2 new fallback tests)
- [ ] Merge, redeploy
- [ ] Manually retest checkout flow on prod with a Stripe test card → confirm redirect to \`https://preploy.vercel.app/profile?billing=success\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)