### PR TITLE
feat(billing): new pricing model ($15/40 + annual) and 20-min behavioral session cap

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -182,7 +182,8 @@ task definition / secrets manager.
 | `NEXTAUTH_URL`             | RUNTIME_ONLY       | Public URL of the app — used to build Stripe redirect URLs. Alias of `AUTH_URL`. |
 | `STRIPE_SECRET_KEY`        | RUNTIME_ONLY       | Stripe secret API key (`sk_test_...` for dev, `sk_live_...` for prod). Never expose to client. |
 | `STRIPE_WEBHOOK_SECRET`    | RUNTIME_ONLY       | Webhook signing secret from `stripe listen` or Stripe Dashboard. Used to verify inbound events. |
-| `STRIPE_PRO_PRICE_ID`      | RUNTIME_ONLY       | Stripe Price ID for the Pro subscription plan (`price_...`). |
+| `STRIPE_PRO_PRICE_ID`      | RUNTIME_ONLY       | Stripe Price ID for the MONTHLY Pro subscription plan (`price_...`). |
+| `STRIPE_PRO_PRICE_ID_ANNUAL` | RUNTIME_ONLY     | Stripe Price ID for the ANNUAL Pro subscription plan (`price_...`). Separate recurring price on the same Pro product. |
 
 Server-only secrets (`SUPABASE_DB_URL`, `OPENAI_API_KEY`, `GOOGLE_CLIENT_SECRET`,
 `SENTRY_DSN`) must never be referenced from a file marked `"use client"` and

--- a/apps/web/app/api/billing/checkout/route.ts
+++ b/apps/web/app/api/billing/checkout/route.ts
@@ -28,9 +28,14 @@ function resolveBaseUrl(request: NextRequest): string {
 
 /**
  * POST /api/billing/checkout
- * Creates a Stripe Checkout Session for the Pro plan.
+ *
+ * Creates a Stripe Checkout Session for the Pro plan. The caller may
+ * optionally pass `{ "interval": "month" | "year" }` in the request body
+ * to select the monthly ($15/mo) or annual ($120/year, = $10/mo effective)
+ * price. Defaults to "month" if missing or invalid.
+ *
  * Looks up or creates a Stripe customer for the current user, persisting
- * stripe_customer_id on the users row for re-use on subsequent calls.
+ * `stripe_customer_id` on the users row for reuse on subsequent calls.
  */
 export async function POST(request: NextRequest) {
   const session = await auth();
@@ -46,11 +51,32 @@ export async function POST(request: NextRequest) {
   const rateLimited = checkRateLimit(session.user.id);
   if (rateLimited) return rateLimited;
 
-  const proPriceId = process.env.STRIPE_PRO_PRICE_ID;
-  if (!proPriceId) {
-    log.error("STRIPE_PRO_PRICE_ID is not configured");
+  // Parse the optional interval from the body. Tolerate missing/empty bodies
+  // since older callers POSTed with no body at all.
+  let interval: "month" | "year" = "month";
+  try {
+    const body = await request.json().catch(() => ({}));
+    if (body && body.interval === "year") interval = "year";
+  } catch {
+    // Empty body is fine — default to monthly.
+  }
+
+  const monthlyPriceId = process.env.STRIPE_PRO_PRICE_ID;
+  const annualPriceId = process.env.STRIPE_PRO_PRICE_ID_ANNUAL;
+  const priceId = interval === "year" ? annualPriceId : monthlyPriceId;
+
+  if (!priceId) {
+    log.error(
+      { interval, hasMonthly: !!monthlyPriceId, hasAnnual: !!annualPriceId },
+      "Stripe price ID not configured for requested interval"
+    );
     return NextResponse.json(
-      { error: "Billing is not configured" },
+      {
+        error:
+          interval === "year"
+            ? "Annual billing is not configured. Try the monthly option."
+            : "Billing is not configured",
+      },
       { status: 500 }
     );
   }
@@ -98,13 +124,16 @@ export async function POST(request: NextRequest) {
   const checkoutSession = await stripe.checkout.sessions.create({
     customer: customerId,
     mode: "subscription",
-    line_items: [{ price: proPriceId, quantity: 1 }],
+    line_items: [{ price: priceId, quantity: 1 }],
     success_url: `${baseUrl}/profile?billing=success`,
     cancel_url: `${baseUrl}/profile?billing=cancelled`,
-    metadata: { userId: user.id },
+    metadata: { userId: user.id, interval },
   });
 
-  log.info({ checkoutSessionId: checkoutSession.id }, "checkout session created");
+  log.info(
+    { checkoutSessionId: checkoutSession.id, interval },
+    "checkout session created"
+  );
 
   return NextResponse.json({ url: checkoutSession.url });
 }

--- a/apps/web/app/api/sessions/route.integration.test.ts
+++ b/apps/web/app/api/sessions/route.integration.test.ts
@@ -450,7 +450,7 @@ describe("API /api/sessions (integration)", () => {
     expect(usage.count).toBe(1);
   });
 
-  it("POST does not gate pro users on monthly count", async () => {
+  it("POST gates pro users at the 40-session monthly cap (not unlimited)", async () => {
     mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
 
     const db = getTestDb();
@@ -460,25 +460,45 @@ describe("API /api/sessions (integration)", () => {
     // Upgrade user to pro
     await db.update(users).set({ plan: "pro" }).where(eq(users.id, TEST_USER.id));
 
-    // Even with 99 prior usage rows, pro users should pass
+    // Pro user at 39/40 → one more session allowed, then blocked
     const periodStart = new Date(
       Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1)
     );
     await db.insert(interviewUsage).values({
       userId: TEST_USER.id,
       periodStart,
-      count: 99,
+      count: 39,
     });
 
-    const res = await POST(makePostRequest({ type: "behavioral" }));
-    expect(res.status).toBe(201);
+    // 40th interview should succeed
+    const res1 = await POST(makePostRequest({ type: "behavioral" }));
+    expect(res1.status).toBe(201);
 
-    // Pro users should NOT have their counter touched
-    const [usage] = await db
+    const [usage1] = await db
       .select()
       .from(interviewUsage)
       .where(eq(interviewUsage.userId, TEST_USER.id));
-    expect(usage.count).toBe(99); // unchanged
+    expect(usage1.count).toBe(40);
+
+    // 41st should be blocked with 402 and the new pro-tier limit in the body
+    const res2 = await POST(makePostRequest({ type: "behavioral" }));
+    expect(res2.status).toBe(402);
+    const data = await res2.json();
+    expect(data.error).toBe("free_tier_limit_reached");
+    expect(data.limit).toBe(40);
+    expect(data.used).toBe(40);
+  });
+
+  it("POST allows a pro user well below the 40-session cap", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const db = getTestDb();
+    const { eq } = await import("drizzle-orm");
+    await db.update(users).set({ plan: "pro" }).where(eq(users.id, TEST_USER.id));
+
+    // Fresh pro user, no prior usage — should succeed
+    const res = await POST(makePostRequest({ type: "behavioral" }));
+    expect(res.status).toBe(201);
   });
 
   it("POST treats a fresh calendar month as 1/3, not 4/3", async () => {

--- a/apps/web/app/interview/behavioral/session/page.tsx
+++ b/apps/web/app/interview/behavioral/session/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useInterviewStore } from "@/stores/interviewStore";
 import { useRealtimeVoice } from "@/hooks/useRealtimeVoice";
 import { buildBehavioralSystemPrompt } from "@/lib/prompts";
+import { BEHAVIORAL_SESSION_MAX_DURATION_SECONDS } from "@/lib/plans";
 import type { BehavioralSessionConfig } from "@interview-assistant/shared";
 import { VideoCallLayout } from "@/components/interview/VideoCallLayout";
 import { SessionControls } from "@/components/interview/SessionControls";
@@ -12,7 +13,10 @@ import { SessionControls } from "@/components/interview/SessionControls";
 export default function BehavioralSessionPage() {
   const router = useRouter();
   const [showTranscript, setShowTranscript] = useState(false);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const transcriptEndRef = useRef<HTMLDivElement>(null);
+  const sessionStartRef = useRef<number | null>(null);
+  const autoEndTriggeredRef = useRef(false);
 
   const {
     sessionId,
@@ -43,6 +47,7 @@ export default function BehavioralSessionPage() {
   useEffect(() => {
     if (sessionId && status === "configuring" && !hasStartedRef.current) {
       hasStartedRef.current = true;
+      sessionStartRef.current = Date.now();
       startSession();
       voice.connect();
     }
@@ -72,6 +77,32 @@ export default function BehavioralSessionPage() {
   useEffect(() => {
     transcriptEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [voice.transcript.length]);
+
+  // Wall-clock timer: ticks every 500ms, updates elapsed seconds state, and
+  // auto-ends the session at BEHAVIORAL_SESSION_MAX_DURATION_SECONDS. The
+  // cap is the primary cost gate for behavioral sessions (a runaway session
+  // with continuous voice streaming is the most expensive thing this product
+  // can do). Enforced client-side for v1; the backend spend cap from issue
+  // #68 is the eventual belt-and-suspenders.
+  useEffect(() => {
+    if (!sessionStartRef.current) return;
+    const interval = setInterval(() => {
+      if (!sessionStartRef.current) return;
+      const elapsed = Math.floor((Date.now() - sessionStartRef.current) / 1000);
+      setElapsedSeconds(elapsed);
+      if (
+        elapsed >= BEHAVIORAL_SESSION_MAX_DURATION_SECONDS &&
+        !autoEndTriggeredRef.current
+      ) {
+        autoEndTriggeredRef.current = true;
+        handleEndSession();
+      }
+    }, 500);
+    return () => clearInterval(interval);
+    // handleEndSession is stable via useCallback; including it would create
+    // a recreate-interval loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId]);
 
   // End session handler
   const handleEndSession = useCallback(async () => {
@@ -107,8 +138,33 @@ export default function BehavioralSessionPage() {
   // Don't render until we have a session
   if (!sessionId) return null;
 
+  const remainingSeconds = Math.max(
+    0,
+    BEHAVIORAL_SESSION_MAX_DURATION_SECONDS - elapsedSeconds
+  );
+  const remainingMin = Math.floor(remainingSeconds / 60);
+  const remainingSec = remainingSeconds % 60;
+  const isLastMinute = remainingSeconds <= 60 && remainingSeconds > 0;
+  const formattedRemaining = `${remainingMin}:${remainingSec
+    .toString()
+    .padStart(2, "0")}`;
+
   return (
     <div className="flex h-[calc(100vh-3.5rem)] flex-col">
+      {/* Session timer — top-right, counts down from 20:00. Turns destructive
+          red in the last minute so the user knows the session will auto-end. */}
+      <div
+        className={`absolute top-4 right-4 z-10 rounded-md border bg-background/90 px-3 py-1.5 text-sm font-medium shadow backdrop-blur ${
+          isLastMinute
+            ? "border-destructive/60 text-destructive"
+            : "text-muted-foreground"
+        }`}
+        data-testid="session-timer"
+        aria-label={`Time remaining: ${formattedRemaining}`}
+      >
+        {formattedRemaining} left
+      </div>
+
       {/* Video call area */}
       <VideoCallLayout
         isSpeaking={voice.isSpeaking}

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
-import { PLANS } from "@/lib/plans";
+import { PLANS, PLAN_DEFINITIONS } from "@/lib/plans";
 import type { PlanId } from "@/lib/plans";
 
 interface UserProfile {
@@ -82,19 +82,10 @@ export default function ProfilePage() {
     }
   };
 
-  const handleBillingPortal = async () => {
+  const handleManageBilling = async () => {
     setIsBillingLoading(true);
     try {
-      // Route by ACTUAL plan, not by `stripeCustomerId` existence.
-      // A free user who started checkout but never completed it (e.g.
-      // a misconfigured price ID) has a `stripe_customer_id` row but no
-      // active subscription — they should still see "Upgrade to Pro" and
-      // hit checkout, not the empty Stripe Billing Portal.
-      const endpoint =
-        profile?.plan === "pro"
-          ? "/api/billing/portal"
-          : "/api/billing/checkout";
-      const res = await fetch(endpoint, { method: "POST" });
+      const res = await fetch("/api/billing/portal", { method: "POST" });
       if (res.ok) {
         const data = await res.json();
         if (data.url) {
@@ -108,6 +99,32 @@ export default function ProfilePage() {
       }
     } catch {
       showMessage("error", "Failed to open billing");
+    } finally {
+      setIsBillingLoading(false);
+    }
+  };
+
+  const handleUpgrade = async (interval: "month" | "year") => {
+    setIsBillingLoading(true);
+    try {
+      const res = await fetch("/api/billing/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ interval }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (data.url) {
+          window.location.assign(data.url);
+          return;
+        }
+        showMessage("error", "Checkout returned no URL");
+      } else {
+        const err = await res.json().catch(() => ({}));
+        showMessage("error", err.error || "Failed to start checkout");
+      }
+    } catch {
+      showMessage("error", "Failed to start checkout");
     } finally {
       setIsBillingLoading(false);
     }
@@ -295,8 +312,8 @@ export default function ProfilePage() {
             <CardContent>
               <p className="text-sm text-muted-foreground">
                 {profile.plan === "free"
-                  ? "You're on the Free plan with 3 mock interviews per month. Upgrade below to remove the limit."
-                  : "You're on the Pro plan with unlimited mock interviews. Manage your subscription below."}
+                  ? `You're on the Free plan with ${PLAN_DEFINITIONS.free.limits.monthlyInterviews} mock interviews per month. Upgrade below for ${PLAN_DEFINITIONS.pro.limits.monthlyInterviews}/month.`
+                  : `You're on the Pro plan with ${PLAN_DEFINITIONS.pro.limits.monthlyInterviews} mock interviews per month. Manage your subscription below.`}
               </p>
             </CardContent>
           </Card>
@@ -313,7 +330,7 @@ export default function ProfilePage() {
                     on Stripe&apos;s secure portal.
                   </p>
                   <Button
-                    onClick={handleBillingPortal}
+                    onClick={handleManageBilling}
                     disabled={isBillingLoading}
                     data-testid="manage-billing-button"
                     className="w-full"
@@ -324,16 +341,30 @@ export default function ProfilePage() {
               ) : (
                 <>
                   <p className="text-sm text-muted-foreground">
-                    Upgrade to Pro to remove the monthly interview limit and
-                    unlock all features.
+                    Upgrade to Pro for {PLAN_DEFINITIONS.pro.limits.monthlyInterviews} mock
+                    interviews per month. Pick monthly or annual — annual saves
+                    about 33%.
                   </p>
                   <Button
-                    onClick={handleBillingPortal}
+                    onClick={() => handleUpgrade("month")}
                     disabled={isBillingLoading}
                     data-testid="upgrade-button"
                     className="w-full"
                   >
-                    {isBillingLoading ? "Loading..." : "Upgrade to Pro"}
+                    {isBillingLoading
+                      ? "Loading..."
+                      : `Upgrade — $${PLAN_DEFINITIONS.pro.priceUsd}/month`}
+                  </Button>
+                  <Button
+                    onClick={() => handleUpgrade("year")}
+                    disabled={isBillingLoading}
+                    data-testid="upgrade-annual-button"
+                    variant="outline"
+                    className="w-full"
+                  >
+                    {isBillingLoading
+                      ? "Loading..."
+                      : `Upgrade — $${PLAN_DEFINITIONS.pro.annualMonthlyEquivalentUsd}/month billed annually ($${PLAN_DEFINITIONS.pro.annualTotalUsd}/year)`}
                   </Button>
                 </>
               )}

--- a/apps/web/app/profile/profile.test.tsx
+++ b/apps/web/app/profile/profile.test.tsx
@@ -109,13 +109,15 @@ describe("ProfilePage", () => {
     });
   });
 
-  it("shows Upgrade to Pro button for a free-plan user", async () => {
+  it("shows Upgrade monthly + annual buttons for a free-plan user", async () => {
     global.fetch = mockFetchWithProfile({ ...baseProfile, plan: "free" });
     render(<ProfilePage />);
     await vi.waitFor(() => {
       expect(screen.getByTestId("upgrade-button")).toBeTruthy();
     });
-    expect(screen.getAllByText("Upgrade to Pro").length).toBeGreaterThanOrEqual(1);
+    // Both upgrade CTAs render for free users — monthly (primary) and
+    // annual (outline variant).
+    expect(screen.getByTestId("upgrade-annual-button")).toBeTruthy();
     // Free users should NEVER see "Manage billing" — even ones with a
     // dangling stripe_customer_id from a previous failed checkout attempt.
     expect(screen.queryByTestId("manage-billing-button")).toBeNull();

--- a/apps/web/lib/plans.test.ts
+++ b/apps/web/lib/plans.test.ts
@@ -5,6 +5,7 @@ import {
   PLAN_DEFINITIONS,
   getPlanLimits,
   FREE_PLAN_MONTHLY_INTERVIEW_LIMIT,
+  PRO_PLAN_MONTHLY_INTERVIEW_LIMIT,
 } from "./plans";
 import type { Plan } from "./plans";
 
@@ -17,18 +18,18 @@ describe("plans (legacy)", () => {
     expect(PLANS.free.dailySessionLimit).toBe(3);
   });
 
-  it("pro plan has 10 daily sessions", () => {
-    expect(PLANS.pro.dailySessionLimit).toBe(10);
+  it("pro plan has 40 daily sessions (fair-use ceiling — monthly cap is primary)", () => {
+    expect(PLANS.pro.dailySessionLimit).toBe(40);
   });
 
-  it("max plan has 30 daily sessions", () => {
-    expect(PLANS.max.dailySessionLimit).toBe(30);
+  it("max plan has 40 daily sessions (matches pro, legacy tier)", () => {
+    expect(PLANS.max.dailySessionLimit).toBe(40);
   });
 });
 
 describe("getPlanConfig (legacy)", () => {
   it("returns correct config for known plan", () => {
-    expect(getPlanConfig("pro").dailySessionLimit).toBe(10);
+    expect(getPlanConfig("pro").dailySessionLimit).toBe(40);
   });
 
   it("falls back to free for unknown plan", () => {
@@ -96,8 +97,14 @@ describe("getPlanLimits", () => {
     expect(getPlanLimits("free").monthlyInterviews).toBe(3);
   });
 
-  it("pro plan monthlyInterviews is null (unlimited)", () => {
-    expect(getPlanLimits("pro").monthlyInterviews).toBeNull();
+  it("pro plan monthlyInterviews equals PRO_PLAN_MONTHLY_INTERVIEW_LIMIT", () => {
+    expect(getPlanLimits("pro").monthlyInterviews).toBe(
+      PRO_PLAN_MONTHLY_INTERVIEW_LIMIT
+    );
+  });
+
+  it("pro plan monthlyInterviews is 40", () => {
+    expect(getPlanLimits("pro").monthlyInterviews).toBe(40);
   });
 
   it("free plan dailySessions is a positive number", () => {

--- a/apps/web/lib/plans.ts
+++ b/apps/web/lib/plans.ts
@@ -15,6 +15,11 @@ export interface PlanConfig {
   dailySessionLimit: number;
 }
 
+// Legacy `dailySessionLimit` values are intentionally high — the primary
+// cost gate is now the MONTHLY cap enforced by `tryConsumeInterviewSlot`
+// (see `lib/usage.ts`). Daily numbers here only exist as a soft fair-use
+// safety net against burst abuse (e.g. 40 sessions in 10 minutes) and the
+// dashboard's legacy "Sessions Today" widget.
 export const PLANS: Record<PlanId, PlanConfig> = {
   free: {
     id: "free",
@@ -24,12 +29,12 @@ export const PLANS: Record<PlanId, PlanConfig> = {
   pro: {
     id: "pro",
     name: "Pro",
-    dailySessionLimit: 10,
+    dailySessionLimit: 40,
   },
   max: {
     id: "max",
     name: "Max",
-    dailySessionLimit: 30,
+    dailySessionLimit: 40,
   },
 };
 
@@ -61,19 +66,29 @@ export interface PlanDefinition {
   name: string;
   /** Monthly price in US dollars. 0 = free. */
   priceUsd: number;
-  /** Name of the env var that holds the Stripe price ID for this plan. */
+  /** Effective monthly price if billed annually. 0 = no annual option. */
+  annualMonthlyEquivalentUsd: number;
+  /** Total annual price (what the user is charged once per year). */
+  annualTotalUsd: number;
+  /** Env var that holds the Stripe price ID for the MONTHLY recurring price. */
   stripePriceEnvKey: string;
+  /** Env var that holds the Stripe price ID for the ANNUAL recurring price. */
+  stripePriceEnvKeyAnnual: string;
   limits: PlanLimits;
 }
 
 export const FREE_PLAN_MONTHLY_INTERVIEW_LIMIT = 3;
+export const PRO_PLAN_MONTHLY_INTERVIEW_LIMIT = 40;
 
 export const PLAN_DEFINITIONS: Record<Plan, PlanDefinition> = {
   free: {
     id: "free",
     name: "Free",
     priceUsd: 0,
+    annualMonthlyEquivalentUsd: 0,
+    annualTotalUsd: 0,
     stripePriceEnvKey: "STRIPE_PRICE_FREE",
+    stripePriceEnvKeyAnnual: "STRIPE_PRICE_FREE",
     limits: {
       monthlyInterviews: FREE_PLAN_MONTHLY_INTERVIEW_LIMIT,
       dailySessions: 3,
@@ -82,14 +97,24 @@ export const PLAN_DEFINITIONS: Record<Plan, PlanDefinition> = {
   pro: {
     id: "pro",
     name: "Pro",
-    priceUsd: 19,
-    stripePriceEnvKey: "STRIPE_PRICE_PRO",
+    // Monthly: $15. Annual: $120/year = $10/month effective (33% discount).
+    // Grounded in the cost-per-session analysis — see `dev_logs/pricing-model.md`
+    // (forthcoming). The monthly cap of 40 sessions is the hard ceiling;
+    // there is no per-day cap besides the fair-use number in `PLANS`.
+    priceUsd: 15,
+    annualMonthlyEquivalentUsd: 10,
+    annualTotalUsd: 120,
+    stripePriceEnvKey: "STRIPE_PRO_PRICE_ID",
+    stripePriceEnvKeyAnnual: "STRIPE_PRO_PRICE_ID_ANNUAL",
     limits: {
-      monthlyInterviews: null,
-      dailySessions: 100,
+      monthlyInterviews: PRO_PLAN_MONTHLY_INTERVIEW_LIMIT,
+      dailySessions: 40,
     },
   },
 };
+
+/** Maximum wall-clock duration of a single behavioral interview session. */
+export const BEHAVIORAL_SESSION_MAX_DURATION_SECONDS = 20 * 60; // 20 minutes
 
 /**
  * Returns the PlanLimits for the given Plan.

--- a/apps/web/lib/usage.ts
+++ b/apps/web/lib/usage.ts
@@ -1,13 +1,18 @@
 /**
- * Free-tier interview-usage tracking.
+ * Monthly interview-usage tracking for BOTH free and pro tiers.
  *
- * Free users get FREE_PLAN_MONTHLY_INTERVIEW_LIMIT mock interviews per
- * calendar month. Pro users are unlimited and short-circuit out before
- * any DB read.
+ * - Free users get FREE_PLAN_MONTHLY_INTERVIEW_LIMIT (3) interviews per
+ *   calendar month.
+ * - Pro users get PRO_PLAN_MONTHLY_INTERVIEW_LIMIT (40) interviews per
+ *   calendar month. The monthly cap is the primary cost gate.
+ * - If a plan has `monthlyInterviews: null` in `PLAN_DEFINITIONS`, that
+ *   plan is treated as truly unlimited (short-circuit, no DB read). Not
+ *   currently used by any plan — kept as an escape hatch for a future
+ *   "Enterprise" tier.
  *
  * Usage rows live in `interview_usage(user_id, period_start, count)` with
  * a unique index on `(user_id, period_start)` so the increment is a single
- * indexed UPSERT. Free users' period_start is `date_trunc('month', now())`;
+ * indexed UPSERT. `period_start` is `date_trunc('month', now())` in UTC;
  * old months naturally roll over because the new month produces a new
  * period_start key that doesn't match any existing row.
  */
@@ -15,7 +20,7 @@ import { sql } from "drizzle-orm";
 import { eq, and } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { interviewUsage } from "@/lib/schema";
-import { FREE_PLAN_MONTHLY_INTERVIEW_LIMIT } from "@/lib/plans";
+import { getPlanLimits } from "@/lib/plans";
 import { getCurrentUserPlan } from "@/lib/user-plan";
 
 /**
@@ -58,14 +63,24 @@ export async function getCurrentPeriodUsage(userId: string): Promise<number> {
 
 /**
  * Returns true if the user is allowed to start another interview this period.
- * Pro users always allowed (short-circuit, no DB read).
+ * Applies the user's plan-specific monthly limit; returns true unconditionally
+ * for plans with `monthlyInterviews: null` (truly unlimited, not currently
+ * any tier).
  */
-export async function isWithinFreeLimit(userId: string): Promise<boolean> {
+export async function isWithinMonthlyLimit(userId: string): Promise<boolean> {
   const plan = await getCurrentUserPlan(userId);
-  if (plan === "pro") return true;
+  const limit = getPlanLimits(plan).monthlyInterviews;
+  if (limit === null) return true;
   const used = await getCurrentPeriodUsage(userId);
-  return used < FREE_PLAN_MONTHLY_INTERVIEW_LIMIT;
+  return used < limit;
 }
+
+/**
+ * @deprecated Name is misleading now that Pro users also have a monthly cap.
+ * Kept as an alias for backwards compatibility with any existing callers.
+ * Prefer `isWithinMonthlyLimit`.
+ */
+export const isWithinFreeLimit = isWithinMonthlyLimit;
 
 /**
  * Atomically increments the current period's interview count.
@@ -95,7 +110,8 @@ export async function incrementInterviewUsage(
 /**
  * Read-and-bump used by interview-start endpoints. Returns the new count
  * if the slot was successfully consumed, or `allowed: false` if the user
- * is at the limit. Pro users always allowed (no counter touched).
+ * is at the limit. Applies the user's plan-specific monthly cap from
+ * `PLAN_DEFINITIONS`.
  *
  * **Concurrency-safe** via a single atomic UPSERT with a guarded DO UPDATE:
  *
@@ -107,26 +123,30 @@ export async function incrementInterviewUsage(
  *   RETURNING count;
  *
  * - Brand-new user → INSERT runs, returns count=1.
- * - User at count=2 (limit 3) → conflict, WHERE 2<3 passes, UPDATE to 3,
- *   returns count=3.
- * - User at count=3 → conflict, WHERE 3<3 fails, UPDATE skipped, RETURNING
- *   yields zero rows.
+ * - User at count=39 (pro, limit 40) → conflict, WHERE 39<40 passes, UPDATE
+ *   to 40, returns count=40.
+ * - User at count=40 → conflict, WHERE 40<40 fails, UPDATE skipped,
+ *   RETURNING yields zero rows.
  *
  * Two parallel callers serialize on the row lock taken by the upsert; the
  * second one sees the first's commit and applies the WHERE against the
  * incremented value, so only one can ever cross the threshold.
+ *
+ * If the user's plan has `monthlyInterviews: null` (truly unlimited), the
+ * function short-circuits and returns `{ allowed: true, used: 0, limit: null }`
+ * without touching the counter.
  */
 export async function tryConsumeInterviewSlot(
   userId: string,
   txOrDb: DbOrTx = db
 ): Promise<{ allowed: boolean; used: number; limit: number | null }> {
   const plan = await getCurrentUserPlan(userId);
-  if (plan === "pro") {
+  const limit = getPlanLimits(plan).monthlyInterviews;
+  if (limit === null) {
     return { allowed: true, used: 0, limit: null };
   }
 
   const periodStart = currentFreePeriodStart();
-  const limit = FREE_PLAN_MONTHLY_INTERVIEW_LIMIT;
 
   const rows = await (txOrDb as typeof db)
     .insert(interviewUsage)


### PR DESCRIPTION
## Summary

Replaces the unsustainable **\$10/mo for 10 sessions/day** (= up to 300/month) Pro plan with a sustainable **\$15/mo for 40 sessions/month** model, plus a new **\$120/year** annual option (\$10/mo effective, -33%). Also adds a hard **20-minute wall-clock cap** on behavioral sessions.

Part of issue #81 (pricing investigation).

## Why

Per the pricing research from the earlier session: at ~\$0.12 fully-loaded cost per 10-minute behavioral session (Whisper + question gen + analysis), the old \$10 / 300-sessions-max plan was losing roughly \$26 per power user per month. The new \$15/40 plan yields ~84% blended gross margin with a \$4.80 max-cost ceiling on the heaviest paid users. The 20-minute session cap limits the worst-case cost of any single session.

## Changes

### `lib/plans.ts` (single source of truth)
- `PLAN_DEFINITIONS.pro.priceUsd` 19 → **15**
- `PLAN_DEFINITIONS.pro.limits.monthlyInterviews` null → **40**
- New exports: `PRO_PLAN_MONTHLY_INTERVIEW_LIMIT`, `BEHAVIORAL_SESSION_MAX_DURATION_SECONDS` (= 1200s)
- New pro fields: `annualMonthlyEquivalentUsd: 10`, `annualTotalUsd: 120`, `stripePriceEnvKeyAnnual: "STRIPE_PRO_PRICE_ID_ANNUAL"`
- Legacy `PLANS.pro.dailySessionLimit` raised to 40 (soft fair-use ceiling — monthly cap is primary)

### `lib/usage.ts`
`tryConsumeInterviewSlot` now applies the plan-specific monthly cap to **both** tiers. Pro users at 40/40 get 402 just like free users at 3/3. The existing concurrency-safe atomic UPSERT logic is unchanged.

### `POST /api/billing/checkout`
Accepts optional `{ interval: "month" | "year" }` in the body. Defaults to `"month"`. Annual selects `STRIPE_PRO_PRICE_ID_ANNUAL`; returns 500 with a clear "Annual billing is not configured" message if that env var is missing.

### `/profile` Billing card
Free user now sees **two** upgrade buttons:
- Primary: `Upgrade — $15/month`
- Outline: `Upgrade — $10/month billed annually ($120/year)`

Pro user's Manage-billing button is unchanged. Plan card description reads limits from `PLAN_DEFINITIONS` so the numbers can't drift.

### Behavioral session 20-minute cap
`app/interview/behavioral/session/page.tsx` tracks wall-clock elapsed time from session start. A visible count-down badge (`X:YY left`) appears top-right, turning destructive-red in the last 60 seconds. At 20:00 elapsed, `handleEndSession` auto-fires exactly once.

Client-side enforcement only for v1. When issue #68 (server-side spend caps) ships, it'll be the belt-and-suspenders.

## ⚠️ Follow-up actions for the product owner (NOT in this PR)

1. **Create a \$15/mo recurring price** in Stripe Dashboard → Products → Preploy Pro. Copy the new `price_...` ID.
2. **Create a \$120/year recurring price** on the same Pro product. Copy that `price_...` ID.
3. **Set env vars in Vercel** (Production + Preview scopes):
   - `STRIPE_PRO_PRICE_ID` → the new monthly price ID
   - `STRIPE_PRO_PRICE_ID_ANNUAL` → the new annual price ID
4. **Archive the old \$10 price** in Stripe so no new subscriptions can use it. Existing subscribers (probably zero) are grandfathered on the old price.
5. Redeploy.

## Test plan

- [x] `npx turbo lint typecheck test` — 485 unit tests green
- [x] `npm run test:integration` — 274 integration tests green, including new "pro user 39/40 → 40/40 → 402" progression
- [ ] Manual verification on prod after deploy:
  - Profile page shows both upgrade buttons for a free user
  - Clicking the annual button routes through Stripe Checkout on the annual price
  - A 20-minute behavioral session auto-ends at 20:00 with the timer counting down

🤖 Generated with [Claude Code](https://claude.com/claude-code)