### PR TITLE
feat: /pricing page + regenerate-questions with 5-per-session limit

### DIFF
--- a/apps/web/app/api/problems/generate/route.ts
+++ b/apps/web/app/api/problems/generate/route.ts
@@ -25,6 +25,14 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Optional: previously-shown problems the user wants to exclude. The
+  // prompt will instruct the model not to reuse them or close variants.
+  const excludeQuestions: string[] = Array.isArray(body.excludeQuestions)
+    ? body.excludeQuestions.filter(
+        (q: unknown): q is string => typeof q === "string" && q.length > 0
+      ).slice(0, 20) // cap to prevent prompt stuffing
+    : [];
+
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {
     return NextResponse.json(
@@ -39,18 +47,24 @@ export async function POST(request: NextRequest) {
   // Try up to 2 times (initial + 1 retry)
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
+      // Build the exclusion clause for the system prompt so the model
+      // avoids repeating previously-shown problems.
+      const exclusionClause =
+        excludeQuestions.length > 0
+          ? `\n\nIMPORTANT: The user has already seen the following problems. Do NOT reuse them or generate close variants:\n${excludeQuestions.map((q, i) => `${i + 1}. ${q}`).join("\n")}`
+          : "";
+
       const completion = await openai.chat.completions.create({
         model: "gpt-5.4-mini",
         messages: [
           {
             role: "system",
-            content:
-              "You are a technical interview problem generator. Generate problems in valid JSON only.",
+            content: `You are a technical interview problem generator. Generate problems in valid JSON only.${exclusionClause}`,
           },
           { role: "user", content: prompt },
         ],
         response_format: { type: "json_object" },
-        temperature: 0.7,
+        temperature: 0.8, // slightly higher to increase variety on regeneration
       });
 
       const raw = completion.choices[0]?.message?.content;

--- a/apps/web/app/interview/technical/session/page.tsx
+++ b/apps/web/app/interview/technical/session/page.tsx
@@ -29,6 +29,13 @@ export default function TechnicalSessionPage() {
   const [isProcessing, setIsProcessing] = useState(false);
   const [processingStep, setProcessingStep] = useState("");
 
+  // Regeneration: users can regenerate the question up to 5 times per
+  // session so they don't get stuck on a duplicate or an unfamiliar topic.
+  const MAX_REGENERATIONS = 5;
+  const [regenerationsLeft, setRegenerationsLeft] = useState(MAX_REGENERATIONS);
+  const [isRegenerating, setIsRegenerating] = useState(false);
+  const [previousProblems, setPreviousProblems] = useState<string[]>([]);
+
   const { startRecording, stopRecording, isRecording, audioLevel } =
     useAudioRecorder();
 
@@ -97,6 +104,46 @@ export default function TechnicalSessionPage() {
     init();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId]);
+
+  // Regenerate problem handler — sends all previously-shown problem titles
+  // so the LLM avoids repeats.
+  const handleRegenerate = useCallback(async () => {
+    if (regenerationsLeft <= 0 || isRegenerating) return;
+    setIsRegenerating(true);
+    setProblemError(null);
+
+    // Track the current problem's title for the exclusion list
+    const updatedExclusions = problem?.title
+      ? [...previousProblems, problem.title]
+      : previousProblems;
+    setPreviousProblems(updatedExclusions);
+
+    try {
+      const res = await fetch("/api/problems/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          config: techConfig,
+          excludeQuestions: updatedExclusions,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setProblemError(data.error || "Failed to regenerate problem");
+      } else {
+        const data = await res.json();
+        setProblem(data);
+        setRegenerationsLeft((n) => n - 1);
+      }
+    } catch (err) {
+      setProblemError(
+        err instanceof Error ? err.message : "Failed to regenerate problem"
+      );
+    } finally {
+      setIsRegenerating(false);
+    }
+  }, [regenerationsLeft, isRegenerating, problem, previousProblems, techConfig]);
 
   // End session handler
   const handleEndSession = useCallback(async () => {
@@ -230,7 +277,27 @@ export default function TechnicalSessionPage() {
       </p>
     </div>
   ) : problem ? (
-    <ProblemDescription problem={problem} />
+    <div className="flex h-full flex-col">
+      <div className="flex-1 overflow-y-auto">
+        <ProblemDescription problem={problem} />
+      </div>
+      <div className="border-t px-4 py-3 flex items-center justify-between">
+        <button
+          onClick={handleRegenerate}
+          disabled={regenerationsLeft <= 0 || isRegenerating}
+          className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          title={
+            regenerationsLeft <= 0
+              ? "No regenerations remaining this session"
+              : `Regenerate problem (${regenerationsLeft} left)`
+          }
+        >
+          {isRegenerating
+            ? "Generating..."
+            : `↻ New question (${regenerationsLeft}/${MAX_REGENERATIONS} left)`}
+        </button>
+      </div>
+    </div>
   ) : null;
 
   // Editor panel content

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -1,0 +1,170 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { PLAN_DEFINITIONS } from "@/lib/plans";
+
+export const dynamic = "force-static";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? "https://preploy.app";
+
+export const metadata: Metadata = {
+  title: "Pricing — Preploy",
+  description:
+    "Practice mock interviews with AI feedback. Free tier with 3 sessions per month, or upgrade to Pro for more.",
+  alternates: { canonical: `${BASE_URL}/pricing` },
+  robots: { index: true, follow: true },
+};
+
+const FREE_FEATURES = [
+  "3 mock interviews per month",
+  "Behavioral & technical modes",
+  "Voice-to-voice AI interviewer",
+  "Scored feedback on every session",
+  "STAR story prep with AI analysis",
+];
+
+const PRO_FEATURES = [
+  `${PLAN_DEFINITIONS.pro.limits.monthlyInterviews} mock interviews per month`,
+  "Everything in Free, plus:",
+  "Resume-tailored questions",
+  "Company-specific question generation",
+  "Interview day planner with AI schedule",
+  "Progress tracking & streak badges",
+  "Priority during high-traffic periods",
+];
+
+function PricingCard({
+  name,
+  price,
+  period,
+  description,
+  features,
+  cta,
+  ctaHref,
+  highlight,
+}: {
+  name: string;
+  price: string;
+  period: string;
+  description: string;
+  features: string[];
+  cta: string;
+  ctaHref: string;
+  highlight?: boolean;
+}) {
+  return (
+    <Card
+      className={cn(
+        "flex flex-col",
+        highlight && "border-primary shadow-lg ring-1 ring-primary/20"
+      )}
+    >
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-xl">{name}</CardTitle>
+          {highlight && <Badge>Most popular</Badge>}
+        </div>
+        <div className="mt-2">
+          <span className="text-4xl font-bold">{price}</span>
+          <span className="text-muted-foreground ml-1">{period}</span>
+        </div>
+        <p className="text-sm text-muted-foreground mt-2">{description}</p>
+      </CardHeader>
+      <CardContent className="flex flex-col flex-1">
+        <ul className="space-y-2.5 flex-1 mb-6">
+          {features.map((feature) => (
+            <li key={feature} className="flex items-start gap-2 text-sm">
+              <Check className="h-4 w-4 mt-0.5 shrink-0 text-primary" />
+              <span>{feature}</span>
+            </li>
+          ))}
+        </ul>
+        <Link
+          href={ctaHref}
+          className={cn(
+            buttonVariants({
+              variant: highlight ? "default" : "outline",
+              size: "lg",
+            }),
+            "w-full"
+          )}
+        >
+          {cta}
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function PricingPage() {
+  const pro = PLAN_DEFINITIONS.pro;
+
+  return (
+    <main className="max-w-5xl mx-auto px-4 py-24">
+      <div className="text-center mb-12">
+        <h1 className="text-4xl font-bold tracking-tight mb-3">
+          Simple, honest pricing
+        </h1>
+        <p className="text-lg text-muted-foreground max-w-xl mx-auto">
+          Start practicing for free. Upgrade when you need more sessions —
+          cancel anytime from your profile.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <PricingCard
+          name="Free"
+          price="$0"
+          period="/month"
+          description="Get a feel for AI-powered interview practice."
+          features={FREE_FEATURES}
+          cta="Get started free"
+          ctaHref="/login"
+        />
+
+        <PricingCard
+          name="Pro — Monthly"
+          price={`$${pro.priceUsd}`}
+          period="/month"
+          description={`${pro.limits.monthlyInterviews} sessions per month. Cancel anytime.`}
+          features={PRO_FEATURES}
+          cta="Upgrade to Pro"
+          ctaHref="/profile"
+          highlight
+        />
+
+        <PricingCard
+          name="Pro — Annual"
+          price={`$${pro.annualMonthlyEquivalentUsd}`}
+          period={`/month, billed $${pro.annualTotalUsd}/year`}
+          description="Same as Pro Monthly — save 33% by paying yearly."
+          features={[...PRO_FEATURES, "33% savings vs monthly billing"]}
+          cta="Upgrade — Annual"
+          ctaHref="/profile"
+        />
+      </div>
+
+      <div className="mt-16 text-center space-y-4">
+        <h2 className="text-2xl font-semibold">Questions?</h2>
+        <p className="text-muted-foreground max-w-md mx-auto">
+          Check the{" "}
+          <Link href="/#faq" className="underline hover:text-foreground">
+            FAQ on the landing page
+          </Link>{" "}
+          or email{" "}
+          <a
+            href="mailto:support@preploy.app"
+            className="underline hover:text-foreground"
+          >
+            support@preploy.app
+          </a>
+          .
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/components/landing/LandingFooter.tsx
+++ b/apps/web/components/landing/LandingFooter.tsx
@@ -8,6 +8,9 @@ export function LandingFooter() {
       <div className="max-w-6xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-muted-foreground">
         <p>© {year} Preploy. All rights reserved.</p>
         <nav className="flex items-center gap-6" aria-label="Footer navigation">
+          <Link href="/pricing" className="hover:text-foreground transition-colors">
+            Pricing
+          </Link>
           <Link href="/privacy" className="hover:text-foreground transition-colors">
             Privacy
           </Link>

--- a/apps/web/components/landing/LandingHero.test.tsx
+++ b/apps/web/components/landing/LandingHero.test.tsx
@@ -56,17 +56,15 @@ describe("LandingHero", () => {
     expect(screen.getByText("Start a free mock interview")).toBeTruthy();
   });
 
-  it("secondary CTA scrolls to how-it-works section", () => {
+  it("secondary CTA links to /pricing", () => {
     render(<LandingHero />);
     const secondaryCta = screen.getByTestId("secondary-cta");
-    fireEvent.click(secondaryCta);
-    expect(getElementById).toHaveBeenCalledWith("how-it-works");
-    expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: "smooth" });
+    expect(secondaryCta.getAttribute("href")).toBe("/pricing");
   });
 
   it("secondary CTA has correct text", () => {
     render(<LandingHero />);
-    expect(screen.getByText("See how it works")).toBeTruthy();
+    expect(screen.getByText("See pricing")).toBeTruthy();
   });
 
   it("renders the Preploy logo", () => {

--- a/apps/web/components/landing/LandingHero.tsx
+++ b/apps/web/components/landing/LandingHero.tsx
@@ -41,17 +41,16 @@ export function LandingHero() {
         >
           Start a free mock interview
         </Link>
-        <a
-          href="#how-it-works"
-          onClick={handleScrollToHowItWorks}
+        <Link
+          href="/pricing"
           className={cn(
             buttonVariants({ variant: "outline", size: "lg" }),
             "min-w-48"
           )}
           data-testid="secondary-cta"
         >
-          See how it works
-        </a>
+          See pricing
+        </Link>
       </div>
     </section>
   );


### PR DESCRIPTION
Two new features on the same branch as the pricing model change:

1. Dedicated /pricing page — statically generated, SEO-indexable, three- column card layout (Free / Pro Monthly / Pro Annual). Each card shows the price, session quota, feature list, and a CTA that routes to /login (Free) or /profile (Pro — where the Upgrade buttons live). The landing hero's secondary CTA now links to /pricing instead of scrolling to "How it works". Footer gains a "Pricing" link.

2. "Regenerate question" in technical interview sessions. Users can click "↻ New question (N/5 left)" below the problem description to get a fresh question from the LLM. The button starts at 5 uses and counts down to 0, at which point it disables with a tooltip.

   Backend: POST /api/problems/generate now accepts an optional `excludeQuestions: string[]` body field (capped to 20 entries to prevent prompt stuffing). The model's system prompt gets an explicit "do NOT reuse or generate close variants of these problems" clause with the user's previously-shown titles listed. Temperature bumped from 0.7 to 0.8 for more diversity on regeneration.

   Client: the regeneration counter and previous-problems list are React state — they reset on page reload, which is intentional (the limit is a UX guardrail against excessive LLM calls, not a billing gate).

Tests updated: LandingHero.test.tsx secondary CTA now asserts /pricing link instead of how-it-works scroll.