### PR TITLE
feat(email): transactional email via Resend (#73)

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -188,6 +188,7 @@ task definition / secrets manager.
 | `UPSTASH_REDIS_REST_TOKEN` | RUNTIME_ONLY       | Upstash Redis REST token. **Do NOT use deprecated Vercel KV** — go to Upstash directly. |
 | `CRON_SECRET`              | RUNTIME_ONLY       | Bearer token for Vercel Cron endpoints (`/api/admin/cron/*`). Generate with `openssl rand -hex 32`. |
 | `ORPHANED_SESSION_TIMEOUT_HOURS` | RUNTIME_ONLY | How long (hours) before an `in_progress` session is auto-marked `failed` by the cleanup cron (default: `2`). |
+| `RESEND_API_KEY`             | RUNTIME_ONLY       | Resend API key for transactional email (welcome, feedback-ready, upgrade nudge). Create at [resend.com](https://resend.com). Emails silently skipped when unset. |
 
 Server-only secrets (`SUPABASE_DB_URL`, `OPENAI_API_KEY`, `GOOGLE_CLIENT_SECRET`,
 `SENTRY_DSN`) must never be referenced from a file marked `"use client"` and

--- a/apps/web/app/api/sessions/[id]/feedback/route.ts
+++ b/apps/web/app/api/sessions/[id]/feedback/route.ts
@@ -182,6 +182,25 @@ export async function POST(
     })
     .returning();
 
+  // Fire-and-forget: send "feedback ready" email so the user gets pulled
+  // back if they closed the tab after the session ended.
+  const userEmail = session.user?.email;
+  const userName = session.user?.name ?? null;
+  if (userEmail) {
+    import("@/lib/email/templates")
+      .then(({ feedbackReadyEmail }) => {
+        const { subject, html } = feedbackReadyEmail(
+          userName,
+          id,
+          feedbackData.overall_score
+        );
+        return import("@/lib/email/send").then(({ sendEmail }) =>
+          sendEmail({ to: userEmail, subject, html })
+        );
+      })
+      .catch(() => {});
+  }
+
   return NextResponse.json(saved, { status: 201 });
 }
 

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -21,6 +21,20 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   pages: {
     signIn: "/login",
   },
+  events: {
+    // Send a welcome email on first sign-up (not on subsequent sign-ins).
+    // Fire-and-forget — never block the auth flow on email delivery.
+    async createUser({ user }) {
+      if (user.email) {
+        import("@/lib/email/templates").then(({ welcomeEmail }) => {
+          const { subject, html } = welcomeEmail(user.name ?? null);
+          import("@/lib/email/send").then(({ sendEmail }) => {
+            sendEmail({ to: user.email!, subject, html }).catch(() => {});
+          });
+        });
+      }
+    },
+  },
   callbacks: {
     jwt({ token, user }) {
       if (user) {

--- a/apps/web/lib/email/client.ts
+++ b/apps/web/lib/email/client.ts
@@ -1,0 +1,34 @@
+/**
+ * Lazy-init Resend client. Follows the SDK-lazy-init pattern from
+ * apps/web/CLAUDE.md — the client is only constructed on first use so
+ * `next build` doesn't crash when RESEND_API_KEY is missing.
+ *
+ * When the env var is unset, `getResendClient()` returns null and callers
+ * skip sending (with a warn log). This keeps dev + CI working without a
+ * real Resend account.
+ */
+import { Resend } from "resend";
+import { logger } from "@/lib/logger";
+
+let cached: Resend | null | undefined;
+let warnedMissing = false;
+
+export function getResendClient(): Resend | null {
+  if (cached !== undefined) return cached;
+
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    if (!warnedMissing) {
+      warnedMissing = true;
+      logger.warn(
+        "RESEND_API_KEY not set — transactional emails will be skipped. " +
+          "This is fine for local dev but NOT for production."
+      );
+    }
+    cached = null;
+    return null;
+  }
+
+  cached = new Resend(apiKey);
+  return cached;
+}

--- a/apps/web/lib/email/send.ts
+++ b/apps/web/lib/email/send.ts
@@ -1,0 +1,37 @@
+/**
+ * Thin wrapper around Resend's send API. Gracefully no-ops when the
+ * Resend client is unavailable (missing API key).
+ */
+import { getResendClient } from "./client";
+import { logger } from "@/lib/logger";
+
+const FROM_ADDRESS = "Preploy <noreply@preploy.app>";
+
+interface SendEmailOptions {
+  to: string;
+  subject: string;
+  html: string;
+}
+
+/**
+ * Send a transactional email. Fire-and-forget — callers should NOT await
+ * this in the request hot path. Errors are logged but never thrown.
+ */
+export async function sendEmail(opts: SendEmailOptions): Promise<void> {
+  const resend = getResendClient();
+  if (!resend) return; // dev/CI — silently skip
+
+  try {
+    await resend.emails.send({
+      from: FROM_ADDRESS,
+      to: opts.to,
+      subject: opts.subject,
+      html: opts.html,
+    });
+    logger.info({ to: opts.to, subject: opts.subject }, "email sent");
+  } catch (err) {
+    // Log but don't throw — email failure should never break the user's
+    // request flow.
+    logger.error({ err, to: opts.to, subject: opts.subject }, "email send failed");
+  }
+}

--- a/apps/web/lib/email/templates.ts
+++ b/apps/web/lib/email/templates.ts
@@ -1,0 +1,94 @@
+/**
+ * Transactional email templates. Plain HTML strings — no React Email
+ * dependency. Keeps the footprint small and the templates easy to grep.
+ *
+ * Each function returns { subject, html } ready for `sendEmail()`.
+ */
+
+const FOOTER = `
+<hr style="margin: 24px 0; border: none; border-top: 1px solid #e5e7eb;" />
+<p style="font-size: 12px; color: #6b7280;">
+  You're receiving this because you have a Preploy account.<br/>
+  <a href="mailto:preploy.dev@gmail.com" style="color: #6b7280;">Contact support</a>
+</p>
+`;
+
+export function welcomeEmail(name: string | null) {
+  const greeting = name ? `Hi ${name}` : "Welcome";
+  return {
+    subject: "Welcome to Preploy — let's ace your next interview",
+    html: `
+      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 560px; margin: 0 auto; padding: 24px;">
+        <h1 style="font-size: 24px; font-weight: 700;">${greeting}, welcome to Preploy!</h1>
+        <p style="font-size: 16px; color: #374151; line-height: 1.6;">
+          You now have access to AI-powered mock interviews — both behavioral
+          and technical — with scored feedback on every session.
+        </p>
+        <p style="font-size: 16px; color: #374151; line-height: 1.6;">
+          Your free plan includes <strong>3 mock interviews per month</strong>.
+          Start your first one now — it takes about 5 minutes.
+        </p>
+        <a href="https://preploy.vercel.app/dashboard"
+           style="display: inline-block; margin-top: 16px; padding: 12px 24px; background: #0f172a; color: #fff; text-decoration: none; border-radius: 8px; font-weight: 600;">
+          Go to Dashboard
+        </a>
+        ${FOOTER}
+      </div>
+    `,
+  };
+}
+
+export function feedbackReadyEmail(
+  name: string | null,
+  sessionId: string,
+  score: number | null
+) {
+  const greeting = name ? `Hi ${name}` : "Hi there";
+  const scoreText = score !== null ? ` You scored <strong>${score.toFixed(1)}/10</strong>.` : "";
+  return {
+    subject: "Your interview feedback is ready",
+    html: `
+      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 560px; margin: 0 auto; padding: 24px;">
+        <h1 style="font-size: 24px; font-weight: 700;">Feedback ready!</h1>
+        <p style="font-size: 16px; color: #374151; line-height: 1.6;">
+          ${greeting}, your mock interview has been scored.${scoreText}
+        </p>
+        <p style="font-size: 16px; color: #374151; line-height: 1.6;">
+          Review your strengths, areas for improvement, and detailed
+          answer-by-answer analysis:
+        </p>
+        <a href="https://preploy.vercel.app/dashboard/sessions/${sessionId}/feedback"
+           style="display: inline-block; margin-top: 16px; padding: 12px 24px; background: #0f172a; color: #fff; text-decoration: none; border-radius: 8px; font-weight: 600;">
+          View Feedback
+        </a>
+        ${FOOTER}
+      </div>
+    `,
+  };
+}
+
+export function freeTierLimitEmail(name: string | null, used: number, limit: number) {
+  const greeting = name ? `Hi ${name}` : "Hi there";
+  return {
+    subject: `You've used ${used} of ${limit} free interviews this month`,
+    html: `
+      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 560px; margin: 0 auto; padding: 24px;">
+        <h1 style="font-size: 24px; font-weight: 700;">You're making great progress!</h1>
+        <p style="font-size: 16px; color: #374151; line-height: 1.6;">
+          ${greeting}, you've completed <strong>${used} of ${limit}</strong>
+          free mock interviews this month. That's dedication.
+        </p>
+        <p style="font-size: 16px; color: #374151; line-height: 1.6;">
+          Want to keep practicing? Upgrade to Pro for
+          <strong>40 sessions per month</strong> — or save 33% with the
+          annual plan.
+        </p>
+        <a href="https://preploy.vercel.app/profile"
+           style="display: inline-block; margin-top: 16px; padding: 12px 24px; background: #0f172a; color: #fff; text-decoration: none; border-radius: 8px; font-weight: 600;">
+          Upgrade to Pro
+        </a>
+        ${FOOTER}
+      </div>
+    `,
+  };
+}

--- a/apps/web/lib/usage.ts
+++ b/apps/web/lib/usage.ts
@@ -165,7 +165,33 @@ export async function tryConsumeInterviewSlot(
     return { allowed: false, used: current, limit };
   }
 
-  return { allowed: true, used: rows[0].count, limit };
+  const newCount = rows[0].count;
+
+  // Send a nudge email when a free-tier user hits their last free session
+  // (e.g., 3/3). Fire-and-forget — never block session creation on email.
+  // Only for free users, and only on the exact boundary (not every time).
+  if (plan === "free" && newCount === limit) {
+    // Need the user's email — dynamic import to avoid circular deps.
+    import("@/lib/db")
+      .then(({ db: localDb }) =>
+        import("@/lib/schema").then(async ({ users }) => {
+          const { eq } = await import("drizzle-orm");
+          const [user] = await localDb
+            .select({ email: users.email, name: users.name })
+            .from(users)
+            .where(eq(users.id, userId));
+          if (user?.email) {
+            const { freeTierLimitEmail } = await import("@/lib/email/templates");
+            const { sendEmail } = await import("@/lib/email/send");
+            const { subject, html } = freeTierLimitEmail(user.name, newCount, limit);
+            await sendEmail({ to: user.email, subject, html });
+          }
+        })
+      )
+      .catch(() => {});
+  }
+
+  return { allowed: true, used: newCount, limit };
 }
 
 async function getCurrentPeriodUsageWithDb(

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,6 +43,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "recharts": "^3.8.1",
+    "resend": "^6.12.0",
     "shadcn": "^4.2.0",
     "stripe": "^22.0.1",
     "tailwind-merge": "^3.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "recharts": "^3.8.1",
+        "resend": "^6.12.0",
         "shadcn": "^4.2.0",
         "stripe": "^22.0.1",
         "tailwind-merge": "^3.5.0",
@@ -5302,6 +5303,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -9747,6 +9754,12 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -13295,6 +13308,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
@@ -13886,6 +13905,27 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.0.tgz",
+      "integrity": "sha512-CaxEvX1z+/MGbgnhsM/bvmkbnZd1v1sEXELAjBNSDBQNMaB7MgqOyrBgI27CYikEgdaDnBrXghAXYWTBs/h5Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.90.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -14824,6 +14864,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/state-local": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
@@ -15185,6 +15235,16 @@
       "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
       "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
       "license": "ISC"
+    },
+    "node_modules/svix": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
+      "integrity": "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
+      }
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
@@ -16366,6 +16426,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",

--- a/turbo.json
+++ b/turbo.json
@@ -38,7 +38,8 @@
         "OPENAI_PER_USER_DAILY_CAP_USD",
         "OPENAI_GLOBAL_DAILY_CAP_USD",
         "UPSTASH_REDIS_REST_URL",
-        "UPSTASH_REDIS_REST_TOKEN"
+        "UPSTASH_REDIS_REST_TOKEN",
+        "RESEND_API_KEY"
       ]
     },
     "lint": {


### PR DESCRIPTION
## Summary

Three transactional emails via [Resend](https://resend.com), all fire-and-forget:

1. **Welcome** — on first sign-up (NextAuth \`events.createUser\`)
2. **Feedback ready** — after AI analysis saved (\`POST /api/sessions/[id]/feedback\`)
3. **Free-tier limit nudge** — when a free user hits their last session (\`lib/usage.ts\`)

All gracefully skip when \`RESEND_API_KEY\` is unset.

Closes #73.

## Setup

1. Create a [Resend](https://resend.com) account (free: 3K emails/month)
2. Add a verified sending domain or use Resend's test domain
3. Set \`RESEND_API_KEY\` in Vercel env vars (Production + Preview)

## Test plan

- [x] 499 unit + 280 integration tests pass
- [x] Set RESEND_API_KEY → sign up with a new Google account → receive welcome email
- [ ] Complete an interview → receive feedback-ready email with score
- [ ] Use 3rd free interview → receive upgrade-nudge email

🤖 Generated with [Claude Code](https://claude.com/claude-code)