### PR TITLE
fix(auth): clear NextAuth session cookies on account deletion

### DIFF
--- a/apps/web/app/api/users/me/route.ts
+++ b/apps/web/app/api/users/me/route.ts
@@ -231,5 +231,22 @@ export async function DELETE(request: NextRequest) {
     }
   }
 
-  return new NextResponse(null, { status: 204 });
+  // Clear the NextAuth session cookies so the browser doesn't keep using
+  // the now-invalid JWT. NextAuth v5 uses "authjs.session-token" on HTTP
+  // and "__Secure-authjs.session-token" on HTTPS. Clear both to be safe.
+  const response = new NextResponse(null, { status: 204 });
+  for (const name of [
+    "authjs.session-token",
+    "__Secure-authjs.session-token",
+    "authjs.callback-url",
+    "__Secure-authjs.callback-url",
+    "authjs.csrf-token",
+    "__Secure-authjs.csrf-token",
+  ]) {
+    response.cookies.set(name, "", {
+      expires: new Date(0),
+      path: "/",
+    });
+  }
+  return response;
 }


### PR DESCRIPTION
After deleting the user row, the JWT cookie stayed valid (JWTs are self-contained and don't check the DB on every request). The deleted user could still browse authenticated pages until the cookie expired.

Now the DELETE response explicitly clears all NextAuth v5 session cookies (both HTTP and __Secure-* HTTPS variants) by setting them to empty with an expired date.