### PR TITLE
fix(email): use Resend test domain and env-driven base URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,9 @@ git add apps/web/drizzle/   # the whole directory, never individual files
 - Never use `console.log` in server-side code (Next.js API routes). See the
   per-app CLAUDE.md for the structured logger pattern.
 - Never commit secrets or files containing them (`.env`, `credentials.json`).
+- Before pushing to any branch, verify its PR is not already merged or closed
+  (`gh pr list --state merged --head <branch>`). If it is, create a fresh
+  branch from `main` instead.
 
 ## graphify
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -189,6 +189,7 @@ task definition / secrets manager.
 | `CRON_SECRET`              | RUNTIME_ONLY       | Bearer token for Vercel Cron endpoints (`/api/admin/cron/*`). Generate with `openssl rand -hex 32`. |
 | `ORPHANED_SESSION_TIMEOUT_HOURS` | RUNTIME_ONLY | How long (hours) before an `in_progress` session is auto-marked `failed` by the cleanup cron (default: `2`). |
 | `RESEND_API_KEY`             | RUNTIME_ONLY       | Resend API key for transactional email (welcome, feedback-ready, upgrade nudge). Create at [resend.com](https://resend.com). Emails silently skipped when unset. |
+| `RESEND_FROM_ADDRESS`        | RUNTIME_ONLY       | Override the FROM address for transactional emails. Defaults to `Preploy <onboarding@resend.dev>`. Switch to your verified domain (e.g. `Preploy <noreply@preploy.app>`) after DNS verification in Resend. |
 
 Server-only secrets (`SUPABASE_DB_URL`, `OPENAI_API_KEY`, `GOOGLE_CLIENT_SECRET`,
 `SENTRY_DSN`) must never be referenced from a file marked `"use client"` and

--- a/apps/web/lib/email/send.ts
+++ b/apps/web/lib/email/send.ts
@@ -5,7 +5,8 @@
 import { getResendClient } from "./client";
 import { logger } from "@/lib/logger";
 
-const FROM_ADDRESS = "Preploy <noreply@preploy.app>";
+const FROM_ADDRESS =
+  process.env.RESEND_FROM_ADDRESS || "Preploy <onboarding@resend.dev>";
 
 interface SendEmailOptions {
   to: string;

--- a/apps/web/lib/email/templates.ts
+++ b/apps/web/lib/email/templates.ts
@@ -5,6 +5,9 @@
  * Each function returns { subject, html } ready for `sendEmail()`.
  */
 
+const BASE_URL =
+  process.env.NEXT_PUBLIC_BASE_URL || "https://preploy.vercel.app";
+
 const FOOTER = `
 <hr style="margin: 24px 0; border: none; border-top: 1px solid #e5e7eb;" />
 <p style="font-size: 12px; color: #6b7280;">
@@ -28,7 +31,7 @@ export function welcomeEmail(name: string | null) {
           Your free plan includes <strong>3 mock interviews per month</strong>.
           Start your first one now — it takes about 5 minutes.
         </p>
-        <a href="https://preploy.vercel.app/dashboard"
+        <a href="${BASE_URL}/dashboard"
            style="display: inline-block; margin-top: 16px; padding: 12px 24px; background: #0f172a; color: #fff; text-decoration: none; border-radius: 8px; font-weight: 600;">
           Go to Dashboard
         </a>
@@ -57,7 +60,7 @@ export function feedbackReadyEmail(
           Review your strengths, areas for improvement, and detailed
           answer-by-answer analysis:
         </p>
-        <a href="https://preploy.vercel.app/dashboard/sessions/${sessionId}/feedback"
+        <a href="${BASE_URL}/dashboard/sessions/${sessionId}/feedback"
            style="display: inline-block; margin-top: 16px; padding: 12px 24px; background: #0f172a; color: #fff; text-decoration: none; border-radius: 8px; font-weight: 600;">
           View Feedback
         </a>
@@ -83,7 +86,7 @@ export function freeTierLimitEmail(name: string | null, used: number, limit: num
           <strong>40 sessions per month</strong> — or save 33% with the
           annual plan.
         </p>
-        <a href="https://preploy.vercel.app/profile"
+        <a href="${BASE_URL}/profile"
            style="display: inline-block; margin-top: 16px; padding: 12px 24px; background: #0f172a; color: #fff; text-decoration: none; border-radius: 8px; font-weight: 600;">
           Upgrade to Pro
         </a>


### PR DESCRIPTION
## Summary
- Default FROM address changed from `noreply@preploy.app` (unverified domain → bounces) to `onboarding@resend.dev` (Resend's shared test domain → actually delivers).
- Added `RESEND_FROM_ADDRESS` env var to override when you verify a custom domain in Resend.
- Email template URLs now use `NEXT_PUBLIC_BASE_URL` instead of hardcoded `preploy.vercel.app`, so links work across environments.

## Test plan
- [x] Lint, typecheck, 499 unit tests pass
- [ ] Trigger a welcome email (sign up with new account) and verify it arrives from `onboarding@resend.dev`
- [ ] Verify email links point to the correct base URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)