### PR TITLE
fix(auth): properly sign out user after account deletion

### DIFF
--- a/apps/web/app/api/users/me/route.ts
+++ b/apps/web/app/api/users/me/route.ts
@@ -235,6 +235,7 @@ export async function DELETE(request: NextRequest) {
   // the now-invalid JWT. NextAuth v5 uses "authjs.session-token" on HTTP
   // and "__Secure-authjs.session-token" on HTTPS. Clear both to be safe.
   const response = new NextResponse(null, { status: 204 });
+  const isSecure = request.url.startsWith("https");
   for (const name of [
     "authjs.session-token",
     "__Secure-authjs.session-token",
@@ -246,6 +247,7 @@ export async function DELETE(request: NextRequest) {
     response.cookies.set(name, "", {
       expires: new Date(0),
       path: "/",
+      ...(isSecure && { secure: true, sameSite: "lax" as const }),
     });
   }
   return response;

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
+import { signOut } from "next-auth/react";
 import { PLANS, PLAN_DEFINITIONS } from "@/lib/plans";
 import type { PlanId } from "@/lib/plans";
 
@@ -141,7 +142,9 @@ export default function ProfilePage() {
         body: JSON.stringify({ confirmation: deleteConfirmation }),
       });
       if (res.ok || res.status === 204) {
-        window.location.assign("/?deleted=1");
+        // signOut() calls NextAuth's /api/auth/signout which properly
+        // clears the session cookie, then redirects to the homepage.
+        await signOut({ callbackUrl: "/?deleted=1" });
         return;
       }
       const err = await res.json().catch(() => ({}));


### PR DESCRIPTION
## Summary
- **Server**: Added `secure: true` and `sameSite: "lax"` to cookie-clearing headers on HTTPS. `__Secure-` prefixed cookies require the `secure` flag — without it, browsers silently ignore the `Set-Cookie` and the JWT survives deletion.
- **Client**: Replaced `window.location.assign("/?deleted=1")` with NextAuth's `signOut({ callbackUrl: "/?deleted=1" })`, which properly destroys the session via `/api/auth/signout`.

## Test plan
- [x] Lint, typecheck, 499 unit tests pass
- [ ] Delete account on production (HTTPS) and verify user is fully signed out — no stale profile avatar in header, protected routes redirect to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)