### PR TITLE
feat(anti-abuse): carry forward usage on account re-creation

### DIFF
--- a/apps/web/app/api/users/me/route.integration.test.ts
+++ b/apps/web/app/api/users/me/route.integration.test.ts
@@ -13,8 +13,9 @@ import {
   teardownTestDb,
   getTestDb,
 } from "../../../../tests/setup-db";
-import { users } from "@/lib/schema";
-import { eq } from "drizzle-orm";
+import { users, interviewUsage, deletedUsage } from "@/lib/schema";
+import { eq, and } from "drizzle-orm";
+import { hashEmailMonth, currentMonth, currentFreePeriodStart } from "@/lib/usage";
 
 const mockAuth = vi.fn();
 vi.mock("@/lib/auth", () => ({
@@ -27,7 +28,7 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-import { GET, PATCH } from "./route";
+import { GET, PATCH, DELETE } from "./route";
 
 const TEST_USER = {
   id: "00000000-0000-0000-0000-000000000001",
@@ -143,5 +144,84 @@ describe("API /api/users/me (integration)", () => {
     mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
     const res = await PATCH(makePatchRequest({}));
     expect(res.status).toBe(400);
+  });
+
+  // ---- DELETE + anti-abuse carry-forward ----
+
+  const DELETE_USER = {
+    id: "00000000-0000-0000-0000-000000000099",
+    email: "delete-test@example.com",
+    name: "Delete User",
+  };
+
+  function makeDeleteRequest(body: unknown): NextRequest {
+    return new NextRequest("http://localhost:3000/api/users/me", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("DELETE writes a deleted_usage row with correct hash and count (S2)", async () => {
+    const db = getTestDb();
+    // Seed user + usage
+    await db.insert(users).values(DELETE_USER).onConflictDoNothing();
+    const periodStart = currentFreePeriodStart();
+    await db
+      .insert(interviewUsage)
+      .values({ userId: DELETE_USER.id, periodStart, count: 2 })
+      .onConflictDoNothing();
+
+    mockAuth.mockResolvedValue({ user: { id: DELETE_USER.id } });
+    const res = await DELETE(
+      makeDeleteRequest({ confirmation: "DELETE my account and all my data" })
+    );
+    expect(res.status).toBe(204);
+
+    // Verify deleted_usage row exists with correct hash
+    const month = currentMonth();
+    const expectedHash = hashEmailMonth(DELETE_USER.email, month);
+    const [row] = await db
+      .select()
+      .from(deletedUsage)
+      .where(
+        and(
+          eq(deletedUsage.emailHash, expectedHash),
+          eq(deletedUsage.month, month)
+        )
+      );
+    expect(row).toBeDefined();
+    expect(row.usageCount).toBe(2);
+
+    // Clean up
+    await db
+      .delete(deletedUsage)
+      .where(eq(deletedUsage.emailHash, expectedHash));
+  });
+
+  it("DELETE with zero usage does not write a deleted_usage row", async () => {
+    const db = getTestDb();
+    const noUsageUser = {
+      id: "00000000-0000-0000-0000-000000000098",
+      email: "no-usage@example.com",
+      name: "No Usage",
+    };
+    await db.insert(users).values(noUsageUser).onConflictDoNothing();
+
+    mockAuth.mockResolvedValue({ user: { id: noUsageUser.id } });
+    const res = await DELETE(
+      makeDeleteRequest({ confirmation: "DELETE my account and all my data" })
+    );
+    expect(res.status).toBe(204);
+
+    const month = currentMonth();
+    const hash = hashEmailMonth(noUsageUser.email, month);
+    const [row] = await db
+      .select()
+      .from(deletedUsage)
+      .where(
+        and(eq(deletedUsage.emailHash, hash), eq(deletedUsage.month, month))
+      );
+    expect(row).toBeUndefined();
   });
 });

--- a/apps/web/app/api/users/me/route.ts
+++ b/apps/web/app/api/users/me/route.ts
@@ -20,6 +20,7 @@ import {
 } from "@/lib/schema";
 import { eq } from "drizzle-orm";
 import { createRequestLogger } from "@/lib/logger";
+import { getCurrentPeriodUsage, recordDeletedUsage } from "@/lib/usage";
 
 // GET /api/users/me — get current user profile
 export async function GET() {
@@ -159,9 +160,12 @@ export async function DELETE(request: NextRequest) {
 
   const userId = session.user.id;
 
-  // Look up user for Stripe cleanup
+  // Look up user for Stripe cleanup + anti-abuse usage carry-forward
   const [user] = await db
-    .select({ stripeCustomerId: users.stripeCustomerId })
+    .select({
+      email: users.email,
+      stripeCustomerId: users.stripeCustomerId,
+    })
     .from(users)
     .where(eq(users.id, userId));
 
@@ -182,6 +186,13 @@ export async function DELETE(request: NextRequest) {
         // Fallback: delete via subquery might not work in all Drizzle versions.
         // Use cascading FK instead — star_story_analyses CASCADE from star_stories.
       });
+
+      // Anti-abuse: carry forward current month's usage so re-creating the
+      // account with the same email won't reset the free-tier quota.
+      const currentUsage = await getCurrentPeriodUsage(userId);
+      if (user.email) {
+        await recordDeletedUsage(user.email, currentUsage, tx);
+      }
 
       await tx.delete(openaiUsage).where(eq(openaiUsage.userId, userId));
       await tx.delete(sessionTemplates).where(eq(sessionTemplates.userId, userId));

--- a/apps/web/drizzle/0010_puzzling_landau.sql
+++ b/apps/web/drizzle/0010_puzzling_landau.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "deleted_usage" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"email_hash" text NOT NULL,
+	"month" text NOT NULL,
+	"usage_count" integer NOT NULL,
+	"deleted_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "deleted_usage_hash_month_unique" ON "deleted_usage" USING btree ("email_hash","month");

--- a/apps/web/drizzle/meta/0010_snapshot.json
+++ b/apps/web/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1315 @@
+{
+  "id": "bfdd3147-3769-4192-b185-49ab5f141635",
+  "prevId": "41947420-f537-4548-99d2-68c753921188",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.code_snapshots": {
+      "name": "code_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "code_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_result": {
+          "name": "execution_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "code_snapshots_session_id_interview_sessions_id_fk": {
+          "name": "code_snapshots_session_id_interview_sessions_id_fk",
+          "tableFrom": "code_snapshots",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_questions": {
+      "name": "company_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_questions_user_id_users_id_fk": {
+          "name": "company_questions_user_id_users_id_fk",
+          "tableFrom": "company_questions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deleted_usage": {
+      "name": "deleted_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deleted_usage_hash_month_unique": {
+          "name": "deleted_usage_hash_month_unique",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_plans": {
+      "name": "interview_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interview_date": {
+          "name": "interview_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_data": {
+          "name": "plan_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_plans_user_id_users_id_fk": {
+          "name": "interview_plans_user_id_users_id_fk",
+          "tableFrom": "interview_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_sessions": {
+      "name": "interview_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'configuring'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_star_story_id": {
+          "name": "source_star_story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_sessions_user_id_users_id_fk": {
+          "name": "interview_sessions_user_id_users_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interview_sessions_source_star_story_id_star_stories_id_fk": {
+          "name": "interview_sessions_source_star_story_id_star_stories_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "source_star_story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_usage": {
+      "name": "interview_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "interview_usage_user_period_unique": {
+          "name": "interview_usage_user_period_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interview_usage_user_id_users_id_fk": {
+          "name": "interview_usage_user_id_users_id_fk",
+          "tableFrom": "interview_usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.openai_usage": {
+      "name": "openai_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd_millis": {
+          "name": "cost_usd_millis",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "openai_usage_user_date_model_unique": {
+          "name": "openai_usage_user_date_model_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_feedback": {
+      "name": "session_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_score": {
+          "name": "overall_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strengths": {
+          "name": "strengths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "weaknesses": {
+          "name": "weaknesses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "answer_analyses": {
+          "name": "answer_analyses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "code_quality_score": {
+          "name": "code_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation_quality_score": {
+          "name": "explanation_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeline_analysis": {
+          "name": "timeline_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_feedback_session_id_interview_sessions_id_fk": {
+          "name": "session_feedback_session_id_interview_sessions_id_fk",
+          "tableFrom": "session_feedback",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_templates": {
+      "name": "session_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_templates_user_id_users_id_fk": {
+          "name": "session_templates_user_id_users_id_fk",
+          "tableFrom": "session_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_stories": {
+      "name": "star_stories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_questions": {
+          "name": "expected_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "situation": {
+          "name": "situation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_stories_user_id_users_id_fk": {
+          "name": "star_stories_user_id_users_id_fk",
+          "tableFrom": "star_stories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_story_analyses": {
+      "name": "star_story_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scores": {
+          "name": "scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_story_analyses_story_id_star_stories_id_fk": {
+          "name": "star_story_analyses_story_id_star_stories_id_fk",
+          "tableFrom": "star_story_analyses",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcripts": {
+      "name": "transcripts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcripts_session_id_interview_sessions_id_fk": {
+          "name": "transcripts_session_id_interview_sessions_id_fk",
+          "tableFrom": "transcripts",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_badge_unique": {
+          "name": "user_badge_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "badge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_resumes": {
+      "name": "user_resumes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_resumes_user_id_users_id_fk": {
+          "name": "user_resumes_user_id_users_id_fk",
+          "tableFrom": "user_resumes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "user_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_start": {
+          "name": "plan_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_end": {
+          "name": "plan_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "past_due_at": {
+          "name": "past_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.code_event_type": {
+      "name": "code_event_type",
+      "schema": "public",
+      "values": [
+        "edit",
+        "run",
+        "submit"
+      ]
+    },
+    "public.interview_type": {
+      "name": "interview_type",
+      "schema": "public",
+      "values": [
+        "behavioral",
+        "technical"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "configuring",
+        "in_progress",
+        "completed",
+        "cancelled",
+        "failed"
+      ]
+    },
+    "public.user_plan": {
+      "name": "user_plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "max"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1776309497520,
       "tag": "0009_serious_bulldozer",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1776333460014,
+      "tag": "0010_puzzling_landau",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -26,12 +26,21 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     // Fire-and-forget — never block the auth flow on email delivery.
     async createUser({ user }) {
       if (user.email) {
+        // Welcome email — fire-and-forget
         import("@/lib/email/templates").then(({ welcomeEmail }) => {
           const { subject, html } = welcomeEmail(user.name ?? null);
           import("@/lib/email/send").then(({ sendEmail }) => {
             sendEmail({ to: user.email!, subject, html }).catch(() => {});
           });
         });
+
+        // Anti-abuse: if this email was used by a recently-deleted account,
+        // carry forward their monthly usage so re-creation doesn't reset quota.
+        if (user.id) {
+          import("@/lib/usage").then(({ carryForwardUsage }) => {
+            carryForwardUsage(user.email!, user.id!).catch(() => {});
+          });
+        }
       }
     },
   },

--- a/apps/web/lib/schema.ts
+++ b/apps/web/lib/schema.ts
@@ -268,6 +268,30 @@ export const sessionTemplates = pgTable("session_templates", {
     .defaultNow(),
 });
 
+/**
+ * Anti-abuse table: carries forward monthly interview usage when a user
+ * deletes their account so they cannot reset their free-tier quota by
+ * re-creating. Keyed by SHA-256(email + month) — no PII stored.
+ */
+export const deletedUsage = pgTable(
+  "deleted_usage",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    emailHash: text("email_hash").notNull(),
+    month: text("month").notNull(), // YYYY-MM
+    usageCount: integer("usage_count").notNull(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("deleted_usage_hash_month_unique").on(
+      table.emailHash,
+      table.month
+    ),
+  ]
+);
+
 // ---- Relations ----
 
 export const usersRelations = relations(users, ({ many }) => ({

--- a/apps/web/lib/usage.integration.test.ts
+++ b/apps/web/lib/usage.integration.test.ts
@@ -1,0 +1,118 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "vitest";
+import {
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../tests/setup-db";
+import { users, interviewUsage, deletedUsage } from "@/lib/schema";
+import { eq, and } from "drizzle-orm";
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return getTestDb();
+  },
+}));
+
+import {
+  carryForwardUsage,
+  recordDeletedUsage,
+  hashEmailMonth,
+  currentMonth,
+  currentFreePeriodStart,
+} from "./usage";
+
+const TEST_USER = {
+  id: "00000000-0000-0000-0000-000000000050",
+  email: "carry-test@example.com",
+  name: "Carry Test",
+};
+
+describe("usage carry-forward (integration)", () => {
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values(TEST_USER).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    const db = getTestDb();
+    await db.delete(interviewUsage).where(eq(interviewUsage.userId, TEST_USER.id));
+    const month = currentMonth();
+    const hash = hashEmailMonth(TEST_USER.email, month);
+    await db
+      .delete(deletedUsage)
+      .where(and(eq(deletedUsage.emailHash, hash), eq(deletedUsage.month, month)));
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  it("carryForwardUsage seeds interview_usage when matching hash exists (S3)", async () => {
+    const db = getTestDb();
+
+    // Simulate deleted user's usage record
+    await recordDeletedUsage(TEST_USER.email, 3);
+
+    // Carry forward to a new user with same email
+    await carryForwardUsage(TEST_USER.email, TEST_USER.id);
+
+    // Verify interview_usage was seeded
+    const periodStart = currentFreePeriodStart();
+    const [row] = await db
+      .select({ count: interviewUsage.count })
+      .from(interviewUsage)
+      .where(
+        and(
+          eq(interviewUsage.userId, TEST_USER.id),
+          eq(interviewUsage.periodStart, periodStart)
+        )
+      );
+    expect(row).toBeDefined();
+    expect(row.count).toBe(3);
+  });
+
+  it("carryForwardUsage does nothing when no matching hash exists (S4)", async () => {
+    const db = getTestDb();
+
+    // No recordDeletedUsage call — fresh email
+    await carryForwardUsage("brand-new@example.com", TEST_USER.id);
+
+    // Verify no interview_usage row was created
+    const periodStart = currentFreePeriodStart();
+    const [row] = await db
+      .select({ count: interviewUsage.count })
+      .from(interviewUsage)
+      .where(
+        and(
+          eq(interviewUsage.userId, TEST_USER.id),
+          eq(interviewUsage.periodStart, periodStart)
+        )
+      );
+    expect(row).toBeUndefined();
+  });
+
+  it("recordDeletedUsage is idempotent — second call updates the count", async () => {
+    const db = getTestDb();
+    const month = currentMonth();
+    const hash = hashEmailMonth(TEST_USER.email, month);
+
+    await recordDeletedUsage(TEST_USER.email, 2);
+    await recordDeletedUsage(TEST_USER.email, 3);
+
+    const [row] = await db
+      .select({ usageCount: deletedUsage.usageCount })
+      .from(deletedUsage)
+      .where(and(eq(deletedUsage.emailHash, hash), eq(deletedUsage.month, month)));
+    expect(row).toBeDefined();
+    expect(row.usageCount).toBe(3);
+  });
+});

--- a/apps/web/lib/usage.test.ts
+++ b/apps/web/lib/usage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { currentFreePeriodStart } from "./usage";
+import { currentFreePeriodStart, hashEmailMonth, currentMonth } from "./usage";
 
 describe("currentFreePeriodStart", () => {
   it("returns the first day of the current UTC month at midnight", () => {
@@ -42,5 +42,54 @@ describe("currentFreePeriodStart", () => {
 
   it("returns a Date object, not a string", () => {
     expect(currentFreePeriodStart()).toBeInstanceOf(Date);
+  });
+});
+
+describe("hashEmailMonth", () => {
+  it("produces consistent output for the same email+month (S1)", () => {
+    const a = hashEmailMonth("user@example.com", "2026-04");
+    const b = hashEmailMonth("user@example.com", "2026-04");
+    expect(a).toBe(b);
+  });
+
+  it("produces different hashes for different months", () => {
+    const apr = hashEmailMonth("user@example.com", "2026-04");
+    const may = hashEmailMonth("user@example.com", "2026-05");
+    expect(apr).not.toBe(may);
+  });
+
+  it("produces different hashes for different emails", () => {
+    const a = hashEmailMonth("alice@example.com", "2026-04");
+    const b = hashEmailMonth("bob@example.com", "2026-04");
+    expect(a).not.toBe(b);
+  });
+
+  it("normalizes email to lowercase (S5 — no raw PII)", () => {
+    const upper = hashEmailMonth("User@Example.COM", "2026-04");
+    const lower = hashEmailMonth("user@example.com", "2026-04");
+    expect(upper).toBe(lower);
+  });
+
+  it("returns a 64-char hex string (SHA-256)", () => {
+    const hash = hashEmailMonth("test@test.com", "2026-01");
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("does not contain the original email (S5 — no PII)", () => {
+    const hash = hashEmailMonth("user@example.com", "2026-04");
+    expect(hash).not.toContain("user");
+    expect(hash).not.toContain("example");
+  });
+});
+
+describe("currentMonth", () => {
+  it("returns YYYY-MM format", () => {
+    const m = currentMonth(new Date(Date.UTC(2026, 3, 16)));
+    expect(m).toBe("2026-04");
+  });
+
+  it("zero-pads single-digit months", () => {
+    const m = currentMonth(new Date(Date.UTC(2026, 0, 1)));
+    expect(m).toBe("2026-01");
   });
 });

--- a/apps/web/lib/usage.ts
+++ b/apps/web/lib/usage.ts
@@ -16,10 +16,11 @@
  * old months naturally roll over because the new month produces a new
  * period_start key that doesn't match any existing row.
  */
+import { createHash } from "crypto";
 import { sql } from "drizzle-orm";
 import { eq, and } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { interviewUsage } from "@/lib/schema";
+import { interviewUsage, deletedUsage } from "@/lib/schema";
 import { getPlanLimits } from "@/lib/plans";
 import { getCurrentUserPlan } from "@/lib/user-plan";
 
@@ -192,6 +193,80 @@ export async function tryConsumeInterviewSlot(
   }
 
   return { allowed: true, used: newCount, limit };
+}
+
+// ---------------------------------------------------------------------------
+// Anti-abuse: carry forward usage across account deletion / re-creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Deterministic hash of an email + month string. The month isolates each
+ * billing period so a hash from January won't collide with February.
+ * Uses SHA-256 — no raw PII stored.
+ */
+export function hashEmailMonth(email: string, month: string): string {
+  return createHash("sha256")
+    .update(`${email.toLowerCase().trim()}:${month}`)
+    .digest("hex");
+}
+
+/** Returns "YYYY-MM" for the given date (UTC). */
+export function currentMonth(now: Date = new Date()): string {
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, "0");
+  return `${y}-${m}`;
+}
+
+/**
+ * Called inside the account-deletion transaction. Reads the user's current
+ * month usage and persists it as a hashed record so re-creation doesn't
+ * reset the quota.
+ */
+export async function recordDeletedUsage(
+  email: string,
+  usageCount: number,
+  txOrDb: DbOrTx = db
+): Promise<void> {
+  if (usageCount <= 0) return; // nothing to carry forward
+  const month = currentMonth();
+  const emailHash = hashEmailMonth(email, month);
+  await (txOrDb as typeof db)
+    .insert(deletedUsage)
+    .values({ emailHash, month, usageCount })
+    .onConflictDoUpdate({
+      target: [deletedUsage.emailHash, deletedUsage.month],
+      set: { usageCount, deletedAt: new Date() },
+    });
+}
+
+/**
+ * Called from the NextAuth `createUser` event. If the new user's email
+ * matches a deleted-usage record for the current month, seed their
+ * interview_usage so they don't get a free quota reset.
+ */
+export async function carryForwardUsage(
+  email: string,
+  userId: string,
+  txOrDb: DbOrTx = db
+): Promise<void> {
+  const month = currentMonth();
+  const emailHash = hashEmailMonth(email, month);
+  const [row] = await (txOrDb as typeof db)
+    .select({ usageCount: deletedUsage.usageCount })
+    .from(deletedUsage)
+    .where(
+      and(eq(deletedUsage.emailHash, emailHash), eq(deletedUsage.month, month))
+    );
+  if (!row || row.usageCount <= 0) return;
+
+  const periodStart = currentFreePeriodStart();
+  await (txOrDb as typeof db)
+    .insert(interviewUsage)
+    .values({ userId, periodStart, count: row.usageCount })
+    .onConflictDoUpdate({
+      target: [interviewUsage.userId, interviewUsage.periodStart],
+      set: { count: sql`GREATEST(${interviewUsage.count}, ${row.usageCount})` },
+    });
 }
 
 async function getCurrentPeriodUsageWithDb(


### PR DESCRIPTION
## Summary
- Prevents free-tier quota gaming: users can no longer delete + re-create accounts to reset their 3/month limit
- New `deleted_usage` table stores `SHA-256(email + month)` and usage count — **no PII retained**
- `recordDeletedUsage()` runs inside the DELETE transaction before wiping the user
- `carryForwardUsage()` runs in NextAuth's `createUser` event to seed `interview_usage` on re-registration
- Old `deleted_usage` rows (>90 days) can be cleaned up by cron in a follow-up

## Test plan
- [x] Lint: 0 errors (7 pre-existing warnings)
- [x] Typecheck: clean
- [x] Unit tests: 507 passed — includes 8 new tests for `hashEmailMonth`, `currentMonth`
- [x] Integration tests: 285 passed — includes 4 new tests:
  - DELETE writes `deleted_usage` row with correct hash + count (S2)
  - Zero-usage DELETE does not write a row
  - `carryForwardUsage` seeds `interview_usage` when matching hash exists (S3)
  - `carryForwardUsage` does nothing when no match (S4)
  - `recordDeletedUsage` is idempotent
- [ ] Deploy to preview and test: delete account with usage → re-create → verify quota persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)