### PR TITLE
fix(prompts): prevent AI interviewer from using candidate's name as its own

### DIFF
--- a/apps/web/lib/prompts.ts
+++ b/apps/web/lib/prompts.ts
@@ -5,9 +5,10 @@ export function buildBehavioralSystemPrompt(
 ): string {
   const sections: string[] = [];
 
-  // Base persona
+  // Base persona — give the interviewer a fixed name so it never
+  // accidentally uses the candidate's name from the resume.
   sections.push(
-    "You are an experienced hiring manager conducting a behavioral interview."
+    "You are Alex, an experienced hiring manager conducting a behavioral interview. Your name is Alex — always introduce yourself as Alex. The person you are speaking to is the candidate; never confuse your identity with theirs."
   );
 
   // Company context
@@ -42,7 +43,7 @@ export function buildBehavioralSystemPrompt(
     );
   } else if (style >= 0.7) {
     sections.push(
-      "Be warm, casual, and conversational. Use the candidate's first name. It's okay to share brief anecdotes or react naturally to their answers."
+      "Be warm, casual, and conversational. It's okay to share brief anecdotes or react naturally to their answers. If you know the candidate's name from their resume, feel free to use it — but never confuse their name with yours."
     );
   } else {
     sections.push(


### PR DESCRIPTION
## Summary
The behavioral interviewer AI sometimes said "Hi, my name is [candidate's name]" when a resume was provided. The prompt told it to "introduce yourself" but never gave it a name, so it grabbed the only name available from the resume context.

**Fix:** The interviewer is now always named "Alex" with explicit identity boundary instructions.

## Changes
- `lib/prompts.ts`: Base persona now says "You are Alex, an experienced hiring manager..." with clear "never confuse your identity with the candidate" instruction
- Casual-style prompt no longer says "use the candidate's first name" without context

## Test plan
- [x] 16 prompt unit tests pass
- [ ] Run a behavioral session with a resume uploaded — verify AI introduces itself as "Alex", not the candidate's name

🤖 Generated with [Claude Code](https://claude.com/claude-code)