### PR TITLE
feat: delete uploaded resumes from /resume

### DIFF
--- a/apps/web/app/api/resume/[id]/route.integration.test.ts
+++ b/apps/web/app/api/resume/[id]/route.integration.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
+import { NextRequest } from "next/server";
+import {
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../../tests/setup-db";
+import { users, userResumes } from "@/lib/schema";
+
+// Mock auth
+const mockAuth = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+// Point db import to the test database
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return getTestDb();
+  },
+}));
+
+import { DELETE } from "./route";
+
+const TEST_USER = {
+  id: "00000000-0000-0000-0000-000000000011",
+  email: "test-delete-resume@example.com",
+  name: "Delete Test User",
+};
+
+const OTHER_USER = {
+  id: "00000000-0000-0000-0000-000000000012",
+  email: "other-delete-resume@example.com",
+  name: "Other Delete User",
+};
+
+function makeDeleteRequest(id: string) {
+  return new NextRequest(`http://localhost:3000/api/resume/${id}`, {
+    method: "DELETE",
+  });
+}
+
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("API DELETE /api/resume/[id] (integration)", () => {
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values(TEST_USER).onConflictDoNothing();
+    await db.insert(users).values(OTHER_USER).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const db = getTestDb();
+    await db.delete(userResumes);
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  // 117-A — Unauthenticated → 401
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await DELETE(
+      makeDeleteRequest("00000000-0000-0000-0000-000000000099"),
+      makeParams("00000000-0000-0000-0000-000000000099")
+    );
+    expect(res.status).toBe(401);
+  });
+
+  // 117-B — Another user's resume → 404 (no existence leak)
+  it("returns 404 when accessing another user's resume", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const db = getTestDb();
+    const [otherResume] = await db
+      .insert(userResumes)
+      .values({
+        userId: OTHER_USER.id,
+        filename: "other.pdf",
+        content: "other content",
+      })
+      .returning();
+
+    const res = await DELETE(
+      makeDeleteRequest(otherResume.id),
+      makeParams(otherResume.id)
+    );
+    expect(res.status).toBe(404);
+
+    // Confirm the row is still in the database (not deleted)
+    const rows = await db
+      .select()
+      .from(userResumes)
+      .where((await import("drizzle-orm")).eq(userResumes.id, otherResume.id));
+    expect(rows).toHaveLength(1);
+  });
+
+  // 117-C — Nonexistent UUID → 404
+  it("returns 404 for a nonexistent resume UUID", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await DELETE(
+      makeDeleteRequest("00000000-0000-0000-0000-000000009999"),
+      makeParams("00000000-0000-0000-0000-000000009999")
+    );
+    expect(res.status).toBe(404);
+  });
+
+  // 117-D — Malformed UUID → 404 (not 500)
+  it("returns 404 for a malformed UUID (not 500)", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await DELETE(
+      makeDeleteRequest("not-a-valid-uuid"),
+      makeParams("not-a-valid-uuid")
+    );
+    expect(res.status).toBe(404);
+  });
+
+  // 117-E — Happy path → 204 + row gone
+  it("returns 204 and deletes the resume on success", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const db = getTestDb();
+    const [resume] = await db
+      .insert(userResumes)
+      .values({
+        userId: TEST_USER.id,
+        filename: "my-resume.pdf",
+        content: "my resume content",
+      })
+      .returning();
+
+    const res = await DELETE(
+      makeDeleteRequest(resume.id),
+      makeParams(resume.id)
+    );
+    expect(res.status).toBe(204);
+
+    // Verify the row is gone
+    const { eq } = await import("drizzle-orm");
+    const rows = await db
+      .select()
+      .from(userResumes)
+      .where(eq(userResumes.id, resume.id));
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/apps/web/app/api/resume/[id]/route.ts
+++ b/apps/web/app/api/resume/[id]/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { userResumes } from "@/lib/schema";
+import { eq } from "drizzle-orm";
+import { createRequestLogger } from "@/lib/logger";
+
+// DELETE /api/resume/[id] — delete a specific resume owned by the authenticated user
+export async function DELETE(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const { id } = await context.params;
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = session.user.id;
+  const log = createRequestLogger({ route: "DELETE /api/resume/[id]", userId });
+
+  let existing;
+  try {
+    [existing] = await db
+      .select()
+      .from(userResumes)
+      .where(eq(userResumes.id, id));
+  } catch {
+    // Postgres will throw when the id is not a valid UUID — treat as 404
+    return NextResponse.json({ error: "Resume not found" }, { status: 404 });
+  }
+
+  if (!existing) {
+    return NextResponse.json({ error: "Resume not found" }, { status: 404 });
+  }
+
+  // Return 404 (not 403) to avoid leaking existence of another user's resource
+  if (existing.userId !== userId) {
+    return NextResponse.json({ error: "Resume not found" }, { status: 404 });
+  }
+
+  await db.delete(userResumes).where(eq(userResumes.id, id));
+
+  log.info({ resumeId: id }, "Resume deleted");
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/apps/web/app/resume/page.test.tsx
+++ b/apps/web/app/resume/page.test.tsx
@@ -1,0 +1,266 @@
+/**
+ * Component tests for the delete-resume feature on ResumePage.
+ * Covers trace rows 117-F through 117-J.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+// Mock prefillStore with vi.hoisted so the mock is available at module evaluation
+const mockClearResumeReference = vi.hoisted(() => vi.fn());
+const mockSetBehavioralPrefill = vi.hoisted(() => vi.fn());
+
+vi.mock("@/stores/prefillStore", () => ({
+  usePrefillStore: () => ({
+    setBehavioralPrefill: mockSetBehavioralPrefill,
+    clearResumeReference: mockClearResumeReference,
+  }),
+}));
+
+import ResumePage from "./page";
+
+const RESUME_1 = {
+  id: "resume-aaa",
+  filename: "resume_one.pdf",
+  content: "First resume content",
+  createdAt: "2026-01-15T00:00:00Z",
+};
+const RESUME_2 = {
+  id: "resume-bbb",
+  filename: "resume_two.pdf",
+  content: "Second resume content",
+  createdAt: "2026-02-20T00:00:00Z",
+};
+
+function makeFetchMock(overrides?: Record<string, () => Promise<unknown>>) {
+  return vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+    const key = `${init?.method ?? "GET"} ${url}`;
+    if (overrides && key in overrides) {
+      return overrides[key]();
+    }
+    if (url === "/api/resume" && !init?.method) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ resumes: [RESUME_1, RESUME_2] }),
+      });
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) });
+  });
+}
+
+describe("ResumePage — delete feature (117-F through 117-J)", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = makeFetchMock() as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  // 117-F — Click delete → confirm strip appears, no request yet
+  it("shows confirm strip when delete button clicked, without sending any DELETE request", async () => {
+    render(<ResumePage />);
+
+    // Wait for resumes to load
+    await waitFor(() => {
+      expect(screen.getAllByText("resume_one.pdf").length).toBeGreaterThanOrEqual(1);
+    });
+
+    const deleteButtons = screen.getAllByRole("button", { name: /delete resume_one\.pdf/i });
+    expect(deleteButtons.length).toBeGreaterThanOrEqual(1);
+    fireEvent.click(deleteButtons[0]);
+
+    // Confirm strip should be visible
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/Delete this resume\? This can't be undone\./i).length
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    // No DELETE fetch should have been made yet
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+    const deleteCalls = fetchMock.mock.calls.filter(
+      (c) => c[1]?.method === "DELETE"
+    );
+    expect(deleteCalls).toHaveLength(0);
+  });
+
+  // 117-G — Cancel hides confirm strip
+  it("hides confirm strip when Cancel is clicked", async () => {
+    render(<ResumePage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("resume_one.pdf").length).toBeGreaterThanOrEqual(1);
+    });
+
+    const deleteButtons = screen.getAllByRole("button", { name: /delete resume_one\.pdf/i });
+    fireEvent.click(deleteButtons[0]);
+
+    // Confirm strip visible
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/Delete this resume\? This can't be undone\./i).length
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    // Click Cancel
+    const cancelButtons = screen.getAllByRole("button", { name: /cancel/i });
+    fireEvent.click(cancelButtons[0]);
+
+    // Confirm strip hidden
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/Delete this resume\? This can't be undone\./i)
+      ).toBeNull();
+    });
+  });
+
+  // 117-H — Confirm → fetch DELETE + card removed
+  it("sends DELETE request and removes the card when Confirm Delete is clicked", async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (url === "/api/resume" && !init?.method) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ resumes: [RESUME_1, RESUME_2] }),
+        });
+      }
+      if (url === `/api/resume/${RESUME_1.id}` && init?.method === "DELETE") {
+        return Promise.resolve({ status: 204, ok: true, json: async () => ({}) });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<ResumePage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("resume_one.pdf").length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Click the trash icon to open confirm strip
+    const deleteButtons = screen.getAllByRole("button", { name: /delete resume_one\.pdf/i });
+    fireEvent.click(deleteButtons[0]);
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/Delete this resume\? This can't be undone\./i).length
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    // Click the destructive "Delete" button inside the confirm strip
+    const confirmDeleteButtons = screen.getAllByRole("button", { name: /^delete$/i });
+    fireEvent.click(confirmDeleteButtons[0]);
+
+    // DELETE request sent
+    await waitFor(() => {
+      const deleteCalls = fetchMock.mock.calls.filter(
+        (c) =>
+          typeof c[0] === "string" &&
+          c[0].includes(`/api/resume/${RESUME_1.id}`) &&
+          c[1]?.method === "DELETE"
+      );
+      expect(deleteCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Card removed from the list
+    await waitFor(() => {
+      expect(screen.queryByText("resume_one.pdf")).toBeNull();
+    });
+  });
+
+  // 117-I — Deleted selected resume → selectedResumeId falls to next/null
+  it("selects the next resume (or null) when the currently-selected resume is deleted", async () => {
+    // RESUME_1 is first in list and will be auto-selected on load
+    const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (url === "/api/resume" && !init?.method) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ resumes: [RESUME_1, RESUME_2] }),
+        });
+      }
+      if (url === `/api/resume/${RESUME_1.id}` && init?.method === "DELETE") {
+        return Promise.resolve({ status: 204, ok: true, json: async () => ({}) });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<ResumePage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("resume_one.pdf").length).toBeGreaterThanOrEqual(1);
+    });
+
+    // RESUME_1 should be selected (shown with "Selected" badge)
+    expect(screen.getAllByText("Selected").length).toBeGreaterThanOrEqual(1);
+
+    // Delete RESUME_1
+    const deleteButtons = screen.getAllByRole("button", { name: /delete resume_one\.pdf/i });
+    fireEvent.click(deleteButtons[0]);
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/Delete this resume\? This can't be undone\./i).length
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    const confirmDeleteButtons = screen.getAllByRole("button", { name: /^delete$/i });
+    fireEvent.click(confirmDeleteButtons[0]);
+
+    // RESUME_1 gone
+    await waitFor(() => {
+      expect(screen.queryByText("resume_one.pdf")).toBeNull();
+    });
+
+    // RESUME_2 is now selected (still has "Selected" badge)
+    await waitFor(() => {
+      expect(screen.getAllByText("Selected").length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // 117-J — Deleting resume with resume_id in prefillStore → clearResumeReference called
+  it("calls clearResumeReference with the deleted resume id", async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (url === "/api/resume" && !init?.method) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ resumes: [RESUME_1] }),
+        });
+      }
+      if (url === `/api/resume/${RESUME_1.id}` && init?.method === "DELETE") {
+        return Promise.resolve({ status: 204, ok: true, json: async () => ({}) });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<ResumePage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("resume_one.pdf").length).toBeGreaterThanOrEqual(1);
+    });
+
+    const deleteButtons = screen.getAllByRole("button", { name: /delete resume_one\.pdf/i });
+    fireEvent.click(deleteButtons[0]);
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/Delete this resume\? This can't be undone\./i).length
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    const confirmDeleteButtons = screen.getAllByRole("button", { name: /^delete$/i });
+    fireEvent.click(confirmDeleteButtons[0]);
+
+    await waitFor(() => {
+      expect(mockClearResumeReference).toHaveBeenCalledWith(RESUME_1.id);
+    });
+  });
+});

--- a/apps/web/app/resume/page.tsx
+++ b/apps/web/app/resume/page.tsx
@@ -33,7 +33,7 @@ interface GeneratedQuestion {
 
 export default function ResumePage() {
   const router = useRouter();
-  const { setBehavioralPrefill } = usePrefillStore();
+  const { setBehavioralPrefill, clearResumeReference } = usePrefillStore();
   const [resumes, setResumes] = useState<Resume[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isUploading, setIsUploading] = useState(false);
@@ -44,6 +44,11 @@ export default function ResumePage() {
   const [role, setRole] = useState("");
   const [questions, setQuestions] = useState<GeneratedQuestion[]>([]);
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  // Delete state
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const showMessage = useCallback((type: "success" | "error", text: string) => {
@@ -137,6 +142,35 @@ export default function ResumePage() {
     }
   };
 
+  const handleDeleteResume = async (id: string) => {
+    setIsDeleting(true);
+    try {
+      const res = await fetch(`/api/resume/${id}`, { method: "DELETE" });
+      if (res.status === 204) {
+        const updatedResumes = resumes.filter((r) => r.id !== id);
+        setResumes(updatedResumes);
+
+        // If the deleted resume was selected, fall to the next one or null
+        if (selectedResumeId === id) {
+          setSelectedResumeId(updatedResumes.length > 0 ? updatedResumes[0].id : null);
+        }
+
+        // Clear any prefill that referenced this resume
+        clearResumeReference(id);
+
+        setPendingDeleteId(null);
+        showMessage("success", "Resume deleted");
+      } else {
+        const err = await res.json().catch(() => ({}));
+        showMessage("error", (err as { error?: string }).error || "Failed to delete resume");
+      }
+    } catch {
+      showMessage("error", "Failed to delete resume");
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
   const handleGenerateQuestions = async () => {
     if (!selectedResumeId) return;
     setIsGenerating(true);
@@ -182,6 +216,25 @@ export default function ResumePage() {
             <CardContent className="space-y-4 p-6">
               <div className="h-32 w-full animate-pulse rounded bg-muted" />
               <div className="h-5 w-32 animate-pulse rounded bg-muted" />
+              {/* Resume list skeleton rows — mirror post-load layout with delete button */}
+              <div className="space-y-2 pt-2">
+                {[1, 2].map((i) => (
+                  <div
+                    key={i}
+                    className="flex items-center justify-between rounded-md border px-4 py-3"
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="h-4 w-4 animate-pulse rounded bg-muted" />
+                      <div className="space-y-1">
+                        <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+                        <div className="h-3 w-20 animate-pulse rounded bg-muted" />
+                      </div>
+                    </div>
+                    {/* Delete button placeholder */}
+                    <div className="h-7 w-7 animate-pulse rounded bg-muted" />
+                  </div>
+                ))}
+              </div>
             </CardContent>
           </Card>
           <Card>
@@ -295,28 +348,73 @@ export default function ResumePage() {
               ) : (
                 <div className="space-y-2">
                   {resumes.map((resume) => (
-                    <button
-                      key={resume.id}
-                      onClick={() => setSelectedResumeId(resume.id)}
-                      className={`flex w-full items-center justify-between rounded-md border px-4 py-3 text-left transition-colors ${
-                        selectedResumeId === resume.id
-                          ? "border-primary bg-primary/5"
-                          : "hover:bg-accent"
-                      }`}
-                    >
-                      <div className="flex items-center gap-3 min-w-0">
-                        <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
-                        <div className="min-w-0">
-                          <p className="text-sm font-medium truncate">{resume.filename}</p>
-                          <p className="text-xs text-muted-foreground">
-                            {new Date(resume.createdAt).toLocaleDateString()}
-                          </p>
+                    <div key={resume.id} className="space-y-0">
+                      <div
+                        className={`flex w-full items-center justify-between rounded-md border px-4 py-3 transition-colors ${
+                          selectedResumeId === resume.id
+                            ? "border-primary bg-primary/5"
+                            : "hover:bg-accent"
+                        } ${pendingDeleteId === resume.id ? "rounded-b-none border-b-0" : ""}`}
+                      >
+                        <button
+                          onClick={() => setSelectedResumeId(resume.id)}
+                          className="flex items-center gap-3 min-w-0 flex-1 text-left"
+                        >
+                          <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+                          <div className="min-w-0">
+                            <p className="text-sm font-medium truncate">{resume.filename}</p>
+                            <p className="text-xs text-muted-foreground">
+                              {new Date(resume.createdAt).toLocaleDateString()}
+                            </p>
+                          </div>
+                        </button>
+                        <div className="flex items-center gap-2 shrink-0">
+                          {selectedResumeId === resume.id && (
+                            <Badge variant="secondary">Selected</Badge>
+                          )}
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            aria-label={`Delete ${resume.filename}`}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setPendingDeleteId(
+                                pendingDeleteId === resume.id ? null : resume.id
+                              );
+                            }}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
                         </div>
                       </div>
-                      {selectedResumeId === resume.id && (
-                        <Badge variant="secondary" className="shrink-0">Selected</Badge>
+
+                      {/* Inline confirm strip */}
+                      {pendingDeleteId === resume.id && (
+                        <div className="flex items-center justify-between gap-3 rounded-b-md border border-t-0 border-destructive/50 bg-destructive/5 px-4 py-3">
+                          <p className="text-sm text-destructive">
+                            Delete this resume? This can&apos;t be undone.
+                          </p>
+                          <div className="flex gap-2 shrink-0">
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              disabled={isDeleting}
+                              onClick={() => handleDeleteResume(resume.id)}
+                            >
+                              {isDeleting ? "Deleting..." : "Delete"}
+                            </Button>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              disabled={isDeleting}
+                              onClick={() => setPendingDeleteId(null)}
+                            >
+                              Cancel
+                            </Button>
+                          </div>
+                        </div>
                       )}
-                    </button>
+                    </div>
                   ))}
                 </div>
               )}

--- a/apps/web/stores/prefillStore.test.ts
+++ b/apps/web/stores/prefillStore.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { usePrefillStore } from "./prefillStore";
+
+function resetStore() {
+  usePrefillStore.setState({
+    behavioralPrefill: null,
+    technicalPrefill: null,
+  });
+}
+
+describe("usePrefillStore — clearResumeReference", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it("clears resume_id from behavioralPrefill while preserving other fields", () => {
+    usePrefillStore.setState({
+      behavioralPrefill: {
+        company_name: "Acme",
+        expected_questions: ["Q1", "Q2"],
+        resume_id: "resume-abc",
+      },
+    });
+
+    usePrefillStore.getState().clearResumeReference("resume-abc");
+
+    const { behavioralPrefill } = usePrefillStore.getState();
+    expect(behavioralPrefill).not.toBeNull();
+    expect(behavioralPrefill?.resume_id).toBeUndefined();
+    expect(behavioralPrefill?.company_name).toBe("Acme");
+    expect(behavioralPrefill?.expected_questions).toEqual(["Q1", "Q2"]);
+  });
+
+  it("clears resume_id from technicalPrefill while preserving other fields", () => {
+    usePrefillStore.setState({
+      technicalPrefill: {
+        focus_areas: ["algorithms"],
+        additional_instructions: "Focus on DP",
+        resume_id: "resume-abc",
+      },
+    });
+
+    usePrefillStore.getState().clearResumeReference("resume-abc");
+
+    const { technicalPrefill } = usePrefillStore.getState();
+    expect(technicalPrefill).not.toBeNull();
+    expect(technicalPrefill?.resume_id).toBeUndefined();
+    expect(technicalPrefill?.focus_areas).toEqual(["algorithms"]);
+    expect(technicalPrefill?.additional_instructions).toBe("Focus on DP");
+  });
+
+  it("sets prefill to null when resume_id is the only field", () => {
+    usePrefillStore.setState({
+      behavioralPrefill: { resume_id: "resume-only" },
+      technicalPrefill: { resume_id: "resume-only" },
+    });
+
+    usePrefillStore.getState().clearResumeReference("resume-only");
+
+    const { behavioralPrefill, technicalPrefill } = usePrefillStore.getState();
+    expect(behavioralPrefill).toBeNull();
+    expect(technicalPrefill).toBeNull();
+  });
+
+  it("is a no-op when the resumeId does not match any prefill", () => {
+    usePrefillStore.setState({
+      behavioralPrefill: {
+        company_name: "Beta Corp",
+        resume_id: "resume-xyz",
+      },
+      technicalPrefill: {
+        focus_areas: ["system-design"],
+        resume_id: "resume-xyz",
+      },
+    });
+
+    usePrefillStore.getState().clearResumeReference("resume-different");
+
+    const { behavioralPrefill, technicalPrefill } = usePrefillStore.getState();
+    expect(behavioralPrefill?.resume_id).toBe("resume-xyz");
+    expect(technicalPrefill?.resume_id).toBe("resume-xyz");
+  });
+});

--- a/apps/web/stores/prefillStore.ts
+++ b/apps/web/stores/prefillStore.ts
@@ -18,6 +18,12 @@ interface PrefillState {
   setBehavioralPrefill: (data: PrefillState["behavioralPrefill"]) => void;
   setTechnicalPrefill: (data: PrefillState["technicalPrefill"]) => void;
   clearPrefill: () => void;
+  /**
+   * Strip the `resume_id` field from any prefill entry that references the
+   * given resumeId. If the prefill object has no remaining fields after
+   * stripping, it is set to null.
+   */
+  clearResumeReference: (resumeId: string) => void;
 }
 
 export const usePrefillStore = create<PrefillState>((set) => ({
@@ -27,4 +33,29 @@ export const usePrefillStore = create<PrefillState>((set) => ({
   setBehavioralPrefill: (data) => set({ behavioralPrefill: data }),
   setTechnicalPrefill: (data) => set({ technicalPrefill: data }),
   clearPrefill: () => set({ behavioralPrefill: null, technicalPrefill: null }),
+
+  clearResumeReference: (resumeId: string) =>
+    set((state) => {
+      let { behavioralPrefill, technicalPrefill } = state;
+
+      if (behavioralPrefill?.resume_id === resumeId) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { resume_id: _removed, ...rest } = behavioralPrefill;
+        behavioralPrefill =
+          Object.keys(rest).length > 0
+            ? (rest as PrefillState["behavioralPrefill"])
+            : null;
+      }
+
+      if (technicalPrefill?.resume_id === resumeId) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { resume_id: _removed, ...rest } = technicalPrefill;
+        technicalPrefill =
+          Object.keys(rest).length > 0
+            ? (rest as PrefillState["technicalPrefill"])
+            : null;
+      }
+
+      return { behavioralPrefill, technicalPrefill };
+    }),
 }));


### PR DESCRIPTION
## Summary

Adds user-facing delete for uploaded resumes.

- New `DELETE /api/resume/[id]` route: auth-required, 404 (not 403) for another user's resume, 404 for nonexistent/malformed UUID, 204 on success. Integration-tested against the 5 scenarios in the trace table below.
- Inline confirm strip on each resume row in `/resume` (NOT a shadcn Dialog — uses the same pattern as `/profile`'s Danger Zone, no new primitive).
- `usePrefillStore.clearResumeReference(id)` helper strips `resume_id` from `behavioralPrefill` / `technicalPrefill` when the deleted resume was the selected prefill, so a stale id doesn't leak into the next session setup. Sets the prefill to `null` if `resume_id` was the only field, preserves other fields otherwise.
- Skeleton updated to include a trash-icon placeholder so the new Delete button doesn't pop-in.
- No FK constraints from `interview_sessions` to `user_resumes` (verified in `lib/schema.ts`) — historical session configs referencing deleted `resume_id` remain intact per the story's non-goal.
- No schema changes.

Fixes #117

## Test plan

- [x] `stores/prefillStore.test.ts` — 4 unit tests for `clearResumeReference`
- [x] `app/api/resume/[id]/route.integration.test.ts` — 5 integration cases covering 117-A through 117-E (401 unauth, 404 other-user leak-safe, 404 nonexistent, 404 malformed UUID, 204 happy-path with SELECT-after-DELETE)
- [x] `app/resume/page.test.tsx` — 5 component cases covering 117-F through 117-J (confirm strip behavior, cancel, confirm fires DELETE, selection falls to next, `clearResumeReference` called on prefill match)
- [ ] CI: lint + typecheck + unit + integration gauntlet
- [ ] Manual: upload a resume, delete it, confirm toast + card removal

## Trace table

| # | Scenario | Test file |
|---|---|---|
| 117-A | Unauth → 401 | `route.integration.test.ts` |
| 117-B | Other user's resume → 404, row still exists | `route.integration.test.ts` |
| 117-C | Nonexistent UUID → 404 | `route.integration.test.ts` |
| 117-D | Malformed UUID → 404 (not 500) | `route.integration.test.ts` |
| 117-E | Happy path → 204 + row gone | `route.integration.test.ts` |
| 117-F | Click Delete → confirm strip, no fetch yet | `page.test.tsx` |
| 117-G | Cancel hides confirm | `page.test.tsx` |
| 117-H | Confirm → fetch DELETE + card removed | `page.test.tsx` |
| 117-I | Deleted selected → next resume selected | `page.test.tsx` |
| 117-J | Prefill resume_id match → `clearResumeReference` called | `page.test.tsx` |
| 117-K | `clearResumeReference` unit behavior | `prefillStore.test.ts` |

## Non-blocking notes

- This PR was produced via `standup` with worktree-isolated implementers, and went through pre-push diff audit (inline-reviewed by orchestrator) instead of the usual `pr-reviewer` subagent, due to a mid-wave quota exhaustion. Diff is scope-clean: only the 6 files listed in the plan are touched. CI is the final gate before merge.
- No `/profile` resume list exists today; the story's "any resume list on `/profile`" line is treated as a no-op. Adding one would be a separate feature.

## Manual verification

- [ ] Upload a resume via `/resume`; delete it; confirm the row disappears and the toast fires
- [ ] Select a resume as prefill via `/interview/behavioral/setup`, return to `/resume`, delete that resume, restart setup — confirm no stale resume selection remains