### PR TITLE
feat: export STAR stories to PDF from /star page

### DIFF
--- a/apps/web/app/star/page.test.tsx
+++ b/apps/web/app/star/page.test.tsx
@@ -162,4 +162,64 @@ describe("StarPrepPage", () => {
       expect(screen.getAllByText("Practice this question").length).toBeGreaterThanOrEqual(1);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // 119-A: Export PDF visible in story detail view
+  // ---------------------------------------------------------------------------
+  it("shows Export PDF button when a story is selected (119-A)", async () => {
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stories: MOCK_STORIES, pagination: { total: 2, page: 1, limit: 20, totalPages: 1 } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => MOCK_DETAIL,
+      });
+
+    render(<StarPrepPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Led microservices migration").length).toBeGreaterThanOrEqual(1);
+    });
+
+    fireEvent.click(screen.getAllByText("Led microservices migration")[0]);
+
+    await waitFor(() => {
+      // StarPdfExportButton renders "Export PDF" text
+      expect(screen.getAllByText("Export PDF").length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 119-B: Export all visible with >= 1 story
+  // ---------------------------------------------------------------------------
+  it("shows Export all button when at least one story exists (119-B)", async () => {
+    render(<StarPrepPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Led microservices migration").length).toBeGreaterThanOrEqual(1);
+    });
+
+    expect(screen.getAllByText("Export all").length).toBeGreaterThanOrEqual(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 119-C: Export all hidden when zero stories
+  // ---------------------------------------------------------------------------
+  it("hides Export all button when there are no stories (119-C)", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ stories: [], pagination: { total: 0, page: 1, limit: 20, totalPages: 0 } }),
+    });
+
+    render(<StarPrepPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/No stories yet/).length).toBeGreaterThanOrEqual(1);
+    });
+
+    // "Export all" button must not be present
+    expect(screen.queryByText("Export all")).toBeNull();
+  });
 });

--- a/apps/web/app/star/page.tsx
+++ b/apps/web/app/star/page.tsx
@@ -9,6 +9,8 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { getScoreColor } from "@/lib/utils";
+import { StarPdfExportButton } from "@/components/star/StarPdfExportButton";
+import { slugify } from "@/lib/slugify";
 import {
   Star,
   Plus,
@@ -20,6 +22,7 @@ import {
   PlayCircle,
   ChevronDown,
   ChevronUp,
+  Download,
 } from "lucide-react";
 
 interface StarStory {
@@ -179,6 +182,8 @@ export default function StarPrepPage() {
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [analyzing, setAnalyzing] = useState(false);
+  const [exportingAll, setExportingAll] = useState(false);
+  const [exportAllProgress, setExportAllProgress] = useState<{ done: number; total: number } | null>(null);
   const [form, setForm] = useState(EMPTY_FORM);
   const [questionInput, setQuestionInput] = useState("");
 
@@ -345,6 +350,66 @@ export default function StarPrepPage() {
     );
   }
 
+  async function handleExportAll() {
+    if (exportingAll || stories.length === 0) return;
+    setExportingAll(true);
+    setExportAllProgress({ done: 0, total: stories.length });
+    try {
+      // Fetch each story's analyses in chunks of 5 for bounded concurrency
+      const CHUNK = 5;
+      const bundle: Array<{ story: StarStory; analyses: StarAnalysis[] }> = [];
+      for (let i = 0; i < stories.length; i += CHUNK) {
+        const chunk = stories.slice(i, i + CHUNK);
+        const results = await Promise.all(
+          chunk.map(async (s) => {
+            try {
+              const res = await fetch(`/api/star/${s.id}`);
+              if (res.ok) {
+                const data: StoryDetail = await res.json();
+                return { story: s, analyses: data.analyses };
+              }
+            } catch {
+              // Fall back to story-only if detail fetch fails
+            }
+            return { story: s, analyses: [] };
+          })
+        );
+        bundle.push(...results);
+        setExportAllProgress({ done: Math.min(i + CHUNK, stories.length), total: stories.length });
+      }
+
+      const { pdf } = await import("@react-pdf/renderer");
+      const { StarStoriesBundlePDF } = await import("@/components/star/StarStoryPDF");
+
+      const date = new Date().toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      });
+
+      const blob = await pdf(
+        <StarStoriesBundlePDF stories={bundle} date={date} />
+      ).toBlob();
+
+      const today = new Date().toISOString().slice(0, 10);
+      const filename = `star-stories-${slugify(today)}.pdf`;
+
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error("Export all failed:", err);
+    } finally {
+      setExportingAll(false);
+      setExportAllProgress(null);
+    }
+  }
+
   return (
     <div className="flex flex-col gap-6 p-6 max-w-6xl mx-auto">
       <div className="flex items-center justify-between">
@@ -357,10 +422,34 @@ export default function StarPrepPage() {
             Craft and refine behavioral interview stories with AI feedback before your mock session.
           </p>
         </div>
-        <Button onClick={openCreate} disabled={showForm && !editing}>
-          <Plus className="h-4 w-4 mr-2" />
-          New Story
-        </Button>
+        <div className="flex gap-2">
+          {stories.length > 0 && (
+            <Button
+              variant="outline"
+              onClick={handleExportAll}
+              disabled={exportingAll}
+              aria-label="Export all stories as PDF"
+            >
+              {exportingAll ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  {exportAllProgress
+                    ? `Exporting ${exportAllProgress.done} of ${exportAllProgress.total}...`
+                    : "Exporting..."}
+                </>
+              ) : (
+                <>
+                  <Download className="h-4 w-4 mr-2" />
+                  Export all
+                </>
+              )}
+            </Button>
+          )}
+          <Button onClick={openCreate} disabled={showForm && !editing}>
+            <Plus className="h-4 w-4 mr-2" />
+            New Story
+          </Button>
+        </div>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -577,6 +666,10 @@ export default function StarPrepPage() {
                       </p>
                     </div>
                     <div className="flex gap-2 shrink-0">
+                      <StarPdfExportButton
+                        story={selectedDetail.story}
+                        analyses={selectedDetail.analyses}
+                      />
                       <Button
                         size="sm"
                         variant="outline"

--- a/apps/web/components/star/StarPdfExportButton.test.tsx
+++ b/apps/web/components/star/StarPdfExportButton.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { StarStoryForPDF, StarAnalysisForPDF } from "./StarStoryPDF";
+
+// ---------------------------------------------------------------------------
+// Mock @react-pdf/renderer so dynamic import inside the handler works
+// ---------------------------------------------------------------------------
+
+vi.mock("@react-pdf/renderer", () => ({
+  pdf: vi.fn().mockReturnValue({
+    toBlob: vi.fn().mockResolvedValue(new Blob(["pdf"], { type: "application/pdf" })),
+  }),
+  Document: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Page: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Text: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  View: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  StyleSheet: { create: (s: Record<string, unknown>) => s },
+}));
+
+// Mock the StarStoryPDF module so the dynamic import inside the handler resolves
+vi.mock("./StarStoryPDF", () => ({
+  StarStoryPDF: () => <div />,
+  StarStoriesBundlePDF: () => <div />,
+}));
+
+import { StarPdfExportButton } from "./StarPdfExportButton";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STORY: StarStoryForPDF = {
+  id: "s1",
+  title: "Led Microservices Migration",
+  role: "Senior Software Engineer",
+  expectedQuestions: ["Tell me about a technical challenge."],
+  situation: "Monolith was slow.",
+  task: "Design migration.",
+  action: "Split into services.",
+  result: "10× faster deploys.",
+  createdAt: new Date().toISOString(),
+};
+
+const ANALYSES: StarAnalysisForPDF[] = [];
+
+// ---------------------------------------------------------------------------
+// URL / anchor helpers
+// ---------------------------------------------------------------------------
+
+let mockObjectUrl = "blob:http://localhost/fake-url";
+const mockCreateObjectURL = vi.fn(() => mockObjectUrl);
+const mockRevokeObjectURL = vi.fn();
+const mockAnchorClick = vi.fn();
+
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+
+beforeEach(() => {
+  URL.createObjectURL = mockCreateObjectURL;
+  URL.revokeObjectURL = mockRevokeObjectURL;
+
+  // Intercept document.createElement so we can inspect/control anchor behaviour
+  const originalCreateElement = document.createElement.bind(document);
+  vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+    if (tag === "a") {
+      const anchor = originalCreateElement("a");
+      anchor.click = mockAnchorClick;
+      return anchor;
+    }
+    return originalCreateElement(tag);
+  });
+
+  vi.clearAllMocks();
+  // Re-set the mock return value after clearAllMocks
+  URL.createObjectURL = mockCreateObjectURL;
+  URL.revokeObjectURL = mockRevokeObjectURL;
+});
+
+afterEach(() => {
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("StarPdfExportButton", () => {
+  it("renders the Export PDF label and Download icon", () => {
+    render(<StarPdfExportButton story={STORY} analyses={ANALYSES} />);
+    expect(screen.getAllByText("Export PDF").length).toBeGreaterThanOrEqual(1);
+    // Button is enabled when idle
+    const btn = screen.getByRole("button");
+    expect(btn).not.toBeDisabled();
+  });
+
+  it("clicking the button calls pdf() and creates an anchor with correct download filename", async () => {
+    const { pdf } = await import("@react-pdf/renderer");
+    render(<StarPdfExportButton story={STORY} analyses={ANALYSES} />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(pdf).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(mockAnchorClick).toHaveBeenCalled();
+    });
+
+    // Verify the anchor's download attribute — uses slug of the title
+    // document.createElement spy captures the anchor element
+    const createElementSpy = vi.mocked(document.createElement);
+    const anchorCall = createElementSpy.mock.results.find(
+      (r) => r.type === "return" && (r.value as HTMLElement).tagName === "A"
+    );
+    expect(anchorCall).toBeDefined();
+    const anchor = anchorCall!.value as HTMLAnchorElement;
+    // "Led Microservices Migration" → "led-microservices-migration"
+    expect(anchor.download).toBe("star-led-microservices-migration.pdf");
+  });
+
+  it("shows Exporting... spinner and disables button while in-flight", async () => {
+    // Use a deferred promise so the export hangs while we inspect the UI
+    let resolve!: () => void;
+    const deferred = new Promise<void>((res) => { resolve = res; });
+
+    const { pdf } = await import("@react-pdf/renderer");
+    vi.mocked(pdf).mockReturnValueOnce({
+      toBlob: vi.fn().mockReturnValue(deferred.then(() => new Blob(["pdf"]))),
+    });
+
+    render(<StarPdfExportButton story={STORY} analyses={ANALYSES} />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Exporting...").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByRole("button")).toBeDisabled();
+    });
+
+    // Resolve the deferred to clean up
+    resolve();
+    await waitFor(() => {
+      expect(screen.getAllByText("Export PDF").length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("revokes the object URL after the anchor is clicked", async () => {
+    render(<StarPdfExportButton story={STORY} analyses={ANALYSES} />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(mockRevokeObjectURL).toHaveBeenCalledWith(mockObjectUrl);
+    });
+  });
+});

--- a/apps/web/components/star/StarPdfExportButton.test.tsx
+++ b/apps/web/components/star/StarPdfExportButton.test.tsx
@@ -47,7 +47,7 @@ const ANALYSES: StarAnalysisForPDF[] = [];
 // URL / anchor helpers
 // ---------------------------------------------------------------------------
 
-let mockObjectUrl = "blob:http://localhost/fake-url";
+const mockObjectUrl = "blob:http://localhost/fake-url";
 const mockCreateObjectURL = vi.fn(() => mockObjectUrl);
 const mockRevokeObjectURL = vi.fn();
 const mockAnchorClick = vi.fn();
@@ -127,10 +127,10 @@ describe("StarPdfExportButton", () => {
     const deferred = new Promise<void>((res) => { resolve = res; });
 
     const { pdf } = await import("@react-pdf/renderer");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.mocked(pdf).mockReturnValueOnce({
-      toBlob: vi.fn().mockReturnValue(deferred.then(() => new Blob(["pdf"]))),
-    } as any);
+    const blobMock = { toBlob: vi.fn().mockReturnValue(deferred.then(() => new Blob(["pdf"]))) };
+    vi.mocked(pdf).mockReturnValueOnce(
+      blobMock as unknown as ReturnType<typeof pdf>
+    );
 
     render(<StarPdfExportButton story={STORY} analyses={ANALYSES} />);
 

--- a/apps/web/components/star/StarPdfExportButton.test.tsx
+++ b/apps/web/components/star/StarPdfExportButton.test.tsx
@@ -127,9 +127,10 @@ describe("StarPdfExportButton", () => {
     const deferred = new Promise<void>((res) => { resolve = res; });
 
     const { pdf } = await import("@react-pdf/renderer");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(pdf).mockReturnValueOnce({
       toBlob: vi.fn().mockReturnValue(deferred.then(() => new Blob(["pdf"]))),
-    });
+    } as any);
 
     render(<StarPdfExportButton story={STORY} analyses={ANALYSES} />);
 

--- a/apps/web/components/star/StarPdfExportButton.tsx
+++ b/apps/web/components/star/StarPdfExportButton.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Download, Loader2 } from "lucide-react";
+import { slugify } from "@/lib/slugify";
+import type { StarStoryForPDF, StarAnalysisForPDF } from "./StarStoryPDF";
+
+interface StarPdfExportButtonProps {
+  story: StarStoryForPDF;
+  analyses: StarAnalysisForPDF[];
+}
+
+export function StarPdfExportButton({ story, analyses }: StarPdfExportButtonProps) {
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleExport = useCallback(async () => {
+    setIsExporting(true);
+    try {
+      // Dynamic imports keep the ~500 KB PDF library out of the initial bundle
+      const { pdf } = await import("@react-pdf/renderer");
+      const { StarStoryPDF } = await import("./StarStoryPDF");
+
+      const date = new Date().toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      });
+
+      const blob = await pdf(
+        <StarStoryPDF story={story} analyses={analyses} date={date} />
+      ).toBlob();
+
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `star-${slugify(story.title)}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error("PDF export failed:", err);
+    } finally {
+      setIsExporting(false);
+    }
+  }, [story, analyses]);
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleExport}
+      disabled={isExporting}
+    >
+      {isExporting ? (
+        <>
+          <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+          Exporting...
+        </>
+      ) : (
+        <>
+          <Download className="mr-1.5 h-4 w-4" />
+          Export PDF
+        </>
+      )}
+    </Button>
+  );
+}

--- a/apps/web/components/star/StarStoryPDF.test.tsx
+++ b/apps/web/components/star/StarStoryPDF.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+// @react-pdf/renderer does not work in jsdom — mock all exports we use.
+vi.mock("@react-pdf/renderer", () => ({
+  Document: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Page: ({ children }: { children: React.ReactNode }) => <div data-testid="pdf-page">{children}</div>,
+  Text: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  View: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  StyleSheet: {
+    create: (styles: Record<string, unknown>) => styles,
+  },
+}));
+
+import {
+  StarStoryPDF,
+  StarStoriesBundlePDF,
+  type StarStoryForPDF,
+  type StarAnalysisForPDF,
+} from "./StarStoryPDF";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STORY: StarStoryForPDF = {
+  id: "s1",
+  title: "Led microservices migration",
+  role: "Senior Software Engineer",
+  expectedQuestions: ["Tell me about a technical challenge you overcame."],
+  situation: "Our monolith was slow.",
+  task: "Design the migration plan.",
+  action: "Broke it into 8 services.",
+  result: "Deploys went from 2h to 10min.",
+  createdAt: new Date().toISOString(),
+};
+
+const ANALYSIS: StarAnalysisForPDF = {
+  id: "a1",
+  storyId: "s1",
+  scores: {
+    persuasiveness_score: 78,
+    persuasiveness_justification: "Clear narrative arc.",
+    star_alignment_score: 85,
+    star_breakdown: { situation: 80, task: 75, action: 90, result: 88 },
+    role_fit_score: 82,
+    role_fit_justification: "Matches SSE expectations.",
+    question_fit_score: 79,
+    question_fit_justification: "Directly addresses the question.",
+  },
+  suggestions: ["Add quantified impact.", "Mention team size."],
+  model: "gpt-4o",
+  createdAt: new Date().toISOString(),
+};
+
+const STORY_2: StarStoryForPDF = {
+  id: "s2",
+  title: "Handled cross-team conflict",
+  role: "Tech Lead",
+  expectedQuestions: [],
+  situation: "Two teams disagreed.",
+  task: "Mediate the decision.",
+  action: "Ran a structured review.",
+  result: "Reached consensus.",
+  createdAt: new Date().toISOString(),
+};
+
+const STORY_3: StarStoryForPDF = {
+  id: "s3",
+  title: "Shipped zero-downtime deploy",
+  role: "Platform Engineer",
+  expectedQuestions: ["Describe a deployment challenge."],
+  situation: "Legacy deploy caused outages.",
+  task: "Re-architect the pipeline.",
+  action: "Implemented blue-green deploys.",
+  result: "Zero downtime for 6 months.",
+  createdAt: new Date().toISOString(),
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("StarStoryPDF", () => {
+  it("renders without throwing — story only (no analyses)", () => {
+    expect(() => render(<StarStoryPDF story={STORY} analyses={[]} date="April 17, 2026" />)).not.toThrow();
+  });
+
+  it("renders without throwing — story with one analysis", () => {
+    expect(() =>
+      render(<StarStoryPDF story={STORY} analyses={[ANALYSIS]} date="April 17, 2026" />)
+    ).not.toThrow();
+  });
+
+  it("includes story title and STAR section labels in output", () => {
+    const { getAllByText } = render(
+      <StarStoryPDF story={STORY} analyses={[]} date="April 17, 2026" />
+    );
+    // Title appears at least once
+    expect(getAllByText("Led microservices migration").length).toBeGreaterThanOrEqual(1);
+    // STAR labels
+    expect(getAllByText("SITUATION").length).toBeGreaterThanOrEqual(1);
+    expect(getAllByText("ACTION").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows analysis scores when analyses are provided", () => {
+    const { getAllByText } = render(
+      <StarStoryPDF story={STORY} analyses={[ANALYSIS]} date="April 17, 2026" />
+    );
+    expect(getAllByText("Persuasiveness").length).toBeGreaterThanOrEqual(1);
+    expect(getAllByText("STAR Alignment").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("omits Expected Questions section when array is empty", () => {
+    const storyNoQ: StarStoryForPDF = { ...STORY, expectedQuestions: [] };
+    const { queryByText } = render(
+      <StarStoryPDF story={storyNoQ} analyses={[]} date="April 17, 2026" />
+    );
+    expect(queryByText("Expected Questions")).toBeNull();
+  });
+});
+
+describe("StarStoriesBundlePDF", () => {
+  it("renders bundle of 3 stories without throwing", () => {
+    const bundle = [
+      { story: STORY, analyses: [ANALYSIS] },
+      { story: STORY_2, analyses: [] },
+      { story: STORY_3, analyses: [] },
+    ];
+    expect(() =>
+      render(<StarStoriesBundlePDF stories={bundle} date="April 17, 2026" />)
+    ).not.toThrow();
+  });
+
+  it("renders one pdf-page element per story in the bundle", () => {
+    const bundle = [
+      { story: STORY, analyses: [] },
+      { story: STORY_2, analyses: [] },
+      { story: STORY_3, analyses: [] },
+    ];
+    const { getAllByTestId } = render(
+      <StarStoriesBundlePDF stories={bundle} date="April 17, 2026" />
+    );
+    expect(getAllByTestId("pdf-page").length).toBe(3);
+  });
+});

--- a/apps/web/components/star/StarStoryPDF.tsx
+++ b/apps/web/components/star/StarStoryPDF.tsx
@@ -1,0 +1,369 @@
+import {
+  Document,
+  Page,
+  Text,
+  View,
+  StyleSheet,
+} from "@react-pdf/renderer";
+
+// ---------------------------------------------------------------------------
+// Types (mirror the interfaces in apps/web/app/star/page.tsx)
+// ---------------------------------------------------------------------------
+
+export interface StarStoryForPDF {
+  id: string;
+  title: string;
+  role: string;
+  expectedQuestions: string[];
+  situation: string;
+  task: string;
+  action: string;
+  result: string;
+  createdAt: string;
+}
+
+export interface StarAnalysisForPDF {
+  id: string;
+  storyId: string;
+  scores: {
+    persuasiveness_score: number;
+    persuasiveness_justification: string;
+    star_alignment_score: number;
+    star_breakdown: {
+      situation: number;
+      task: number;
+      action: number;
+      result: number;
+    };
+    role_fit_score: number;
+    role_fit_justification: string;
+    question_fit_score: number;
+    question_fit_justification: string;
+  };
+  suggestions: string[];
+  model: string;
+  createdAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Local score-color helper (verbatim from FeedbackPDF.tsx).
+// Scores here are 0–100 so divide by 10 before colour-bucketing.
+// ---------------------------------------------------------------------------
+
+function getScoreColor(score0to100: number): string {
+  const s = score0to100 / 10;
+  if (s >= 9) return "#2563eb";
+  if (s >= 7) return "#16a34a";
+  if (s >= 4) return "#ca8a04";
+  return "#dc2626";
+}
+
+// ---------------------------------------------------------------------------
+// Styles (mirror FeedbackPDF.tsx visual language)
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  page: { padding: 40, fontSize: 10, fontFamily: "Helvetica", color: "#1a1a1a" },
+  header: {
+    marginBottom: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: "#e5e5e5",
+    paddingBottom: 12,
+    backgroundColor: "#f8f9fa",
+    padding: 12,
+    borderRadius: 4,
+  },
+  headerTitle: { fontSize: 16, fontWeight: "bold", marginBottom: 4, color: "#111" },
+  headerSub: { fontSize: 9, color: "#666" },
+  storyTitle: { fontSize: 16, fontWeight: "bold", marginBottom: 4, color: "#111" },
+  section: { marginBottom: 14 },
+  sectionLabel: {
+    fontSize: 9,
+    fontWeight: "bold",
+    color: "#555",
+    textTransform: "uppercase",
+    letterSpacing: 0.8,
+    marginBottom: 2,
+  },
+  sectionBody: { fontSize: 10, lineHeight: 1.6, color: "#333" },
+  divider: { borderBottomWidth: 1, borderBottomColor: "#e5e5e5", marginBottom: 10, marginTop: 4 },
+  questionBullet: { flexDirection: "row", gap: 6, marginBottom: 3 },
+  bulletDot: { color: "#666", fontSize: 10 },
+  bulletText: { flex: 1, fontSize: 10, lineHeight: 1.5, color: "#333" },
+  analysisBlock: {
+    marginTop: 12,
+    borderWidth: 1,
+    borderColor: "#e5e5e5",
+    borderRadius: 6,
+    padding: 12,
+  },
+  analysisTitle: { fontSize: 11, fontWeight: "bold", marginBottom: 8, color: "#111" },
+  scoreRow: { flexDirection: "row", gap: 10, marginBottom: 10 },
+  scoreBox: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: "#e5e5e5",
+    borderRadius: 4,
+    padding: 8,
+    alignItems: "center",
+  },
+  scoreValue: { fontSize: 18, fontWeight: "bold" },
+  scoreLabel: { fontSize: 8, color: "#666", marginTop: 3, textAlign: "center" },
+  breakdownRow: { flexDirection: "row", gap: 10, marginBottom: 10 },
+  breakdownBox: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: "#e5e5e5",
+    borderRadius: 4,
+    padding: 6,
+    alignItems: "center",
+    backgroundColor: "#f8f9fa",
+  },
+  breakdownValue: { fontSize: 14, fontWeight: "bold" },
+  breakdownLabel: { fontSize: 7, color: "#888", marginTop: 2 },
+  justRow: { marginBottom: 8 },
+  justLabel: {
+    fontSize: 8,
+    fontWeight: "bold",
+    color: "#666",
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+    marginBottom: 2,
+  },
+  justText: { fontSize: 9, color: "#444", lineHeight: 1.5 },
+  suggestionItem: { flexDirection: "row", gap: 6, marginBottom: 3 },
+  suggestionNum: { fontSize: 9, color: "#888", width: 14 },
+  suggestionText: { flex: 1, fontSize: 9, color: "#555", lineHeight: 1.5 },
+  footer: {
+    position: "absolute",
+    bottom: 30,
+    left: 40,
+    right: 40,
+    textAlign: "center",
+    fontSize: 8,
+    color: "#aaa",
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Single-story page renderer (reused in both exports)
+// ---------------------------------------------------------------------------
+
+function StarStoryPage({
+  story,
+  analyses,
+  date,
+}: {
+  story: StarStoryForPDF;
+  analyses: StarAnalysisForPDF[];
+  date: string;
+}) {
+  const latestAnalysis = analyses.length > 0 ? analyses[0] : null;
+
+  return (
+    <Page size="A4" style={styles.page}>
+      {/* Header band */}
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Preploy — STAR Story</Text>
+        <Text style={styles.headerSub}>
+          {story.role} | Generated {date}
+        </Text>
+      </View>
+
+      {/* Story title */}
+      <View style={styles.section}>
+        <Text style={styles.storyTitle}>{story.title}</Text>
+      </View>
+
+      {/* Expected Questions */}
+      {story.expectedQuestions.length > 0 && (
+        <View style={styles.section}>
+          <Text style={styles.sectionLabel}>Expected Questions</Text>
+          <View style={styles.divider} />
+          {story.expectedQuestions.map((q, i) => (
+            <View key={i} style={styles.questionBullet}>
+              <Text style={styles.bulletDot}>•</Text>
+              <Text style={styles.bulletText}>{q}</Text>
+            </View>
+          ))}
+        </View>
+      )}
+
+      {/* S/T/A/R blocks */}
+      {(
+        [
+          ["SITUATION", story.situation],
+          ["TASK", story.task],
+          ["ACTION", story.action],
+          ["RESULT", story.result],
+        ] as const
+      ).map(([label, body]) => (
+        <View key={label} style={styles.section}>
+          <Text style={styles.sectionLabel}>{label}</Text>
+          <View style={styles.divider} />
+          <Text style={styles.sectionBody}>{body}</Text>
+        </View>
+      ))}
+
+      {/* Latest Analysis */}
+      {latestAnalysis && (
+        <View style={styles.analysisBlock}>
+          <Text style={styles.analysisTitle}>Latest Analysis</Text>
+
+          {/* Main score boxes */}
+          <View style={styles.scoreRow}>
+            <View style={styles.scoreBox}>
+              <Text
+                style={[
+                  styles.scoreValue,
+                  { color: getScoreColor(latestAnalysis.scores.persuasiveness_score) },
+                ]}
+              >
+                {Math.round(latestAnalysis.scores.persuasiveness_score)}
+              </Text>
+              <Text style={styles.scoreLabel}>Persuasiveness</Text>
+            </View>
+            <View style={styles.scoreBox}>
+              <Text
+                style={[
+                  styles.scoreValue,
+                  { color: getScoreColor(latestAnalysis.scores.star_alignment_score) },
+                ]}
+              >
+                {Math.round(latestAnalysis.scores.star_alignment_score)}
+              </Text>
+              <Text style={styles.scoreLabel}>STAR Alignment</Text>
+            </View>
+            <View style={styles.scoreBox}>
+              <Text
+                style={[
+                  styles.scoreValue,
+                  { color: getScoreColor(latestAnalysis.scores.role_fit_score) },
+                ]}
+              >
+                {Math.round(latestAnalysis.scores.role_fit_score)}
+              </Text>
+              <Text style={styles.scoreLabel}>Role Fit</Text>
+            </View>
+            <View style={styles.scoreBox}>
+              <Text
+                style={[
+                  styles.scoreValue,
+                  { color: getScoreColor(latestAnalysis.scores.question_fit_score) },
+                ]}
+              >
+                {Math.round(latestAnalysis.scores.question_fit_score)}
+              </Text>
+              <Text style={styles.scoreLabel}>Question Fit</Text>
+            </View>
+          </View>
+
+          {/* STAR breakdown sub-row */}
+          <View style={styles.breakdownRow}>
+            {(
+              [
+                ["S", latestAnalysis.scores.star_breakdown.situation],
+                ["T", latestAnalysis.scores.star_breakdown.task],
+                ["A", latestAnalysis.scores.star_breakdown.action],
+                ["R", latestAnalysis.scores.star_breakdown.result],
+              ] as const
+            ).map(([letter, score]) => (
+              <View key={letter} style={styles.breakdownBox}>
+                <Text
+                  style={[
+                    styles.breakdownValue,
+                    { color: getScoreColor(score) },
+                  ]}
+                >
+                  {Math.round(score)}
+                </Text>
+                <Text style={styles.breakdownLabel}>{letter}</Text>
+              </View>
+            ))}
+          </View>
+
+          {/* Justification blocks */}
+          <View style={styles.justRow}>
+            <Text style={styles.justLabel}>Persuasiveness</Text>
+            <Text style={styles.justText}>
+              {latestAnalysis.scores.persuasiveness_justification}
+            </Text>
+          </View>
+          <View style={styles.justRow}>
+            <Text style={styles.justLabel}>Role Fit</Text>
+            <Text style={styles.justText}>
+              {latestAnalysis.scores.role_fit_justification}
+            </Text>
+          </View>
+          <View style={styles.justRow}>
+            <Text style={styles.justLabel}>Question Fit</Text>
+            <Text style={styles.justText}>
+              {latestAnalysis.scores.question_fit_justification}
+            </Text>
+          </View>
+
+          {/* Suggestions */}
+          {latestAnalysis.suggestions.length > 0 && (
+            <View>
+              <Text style={[styles.justLabel, { marginTop: 6, marginBottom: 4 }]}>
+                Suggestions
+              </Text>
+              {latestAnalysis.suggestions.map((s, i) => (
+                <View key={i} style={styles.suggestionItem}>
+                  <Text style={styles.suggestionNum}>{i + 1}.</Text>
+                  <Text style={styles.suggestionText}>{s}</Text>
+                </View>
+              ))}
+            </View>
+          )}
+        </View>
+      )}
+
+      {/* Footer */}
+      <Text style={styles.footer}>Generated by Preploy | {date}</Text>
+    </Page>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Named exports
+// ---------------------------------------------------------------------------
+
+export interface StarStoryPDFProps {
+  story: StarStoryForPDF;
+  analyses: StarAnalysisForPDF[];
+  date: string;
+}
+
+/** Single-story, single-page PDF document. */
+export function StarStoryPDF({ story, analyses, date }: StarStoryPDFProps) {
+  return (
+    <Document>
+      <StarStoryPage story={story} analyses={analyses} date={date} />
+    </Document>
+  );
+}
+
+export interface StarStoriesBundlePDFProps {
+  stories: Array<{ story: StarStoryForPDF; analyses: StarAnalysisForPDF[] }>;
+  date: string;
+}
+
+/** Multi-story PDF — one Page per story inside one Document. */
+export function StarStoriesBundlePDF({
+  stories,
+  date,
+}: StarStoriesBundlePDFProps) {
+  return (
+    <Document>
+      {stories.map(({ story, analyses }) => (
+        <StarStoryPage
+          key={story.id}
+          story={story}
+          analyses={analyses}
+          date={date}
+        />
+      ))}
+    </Document>
+  );
+}

--- a/apps/web/lib/slugify.test.ts
+++ b/apps/web/lib/slugify.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { slugify } from "./slugify";
+
+describe("slugify", () => {
+  it("lowercases and hyphenates a basic title", () => {
+    expect(slugify("Led Microservices Migration")).toBe("led-microservices-migration");
+  });
+
+  it("strips punctuation and collapses runs to a single hyphen", () => {
+    expect(slugify("Hello, World! This is a test...")).toBe("hello-world-this-is-a-test");
+  });
+
+  it("normalises unicode diacritics (é → e, ñ → n, ü → u)", () => {
+    expect(slugify("Café résumé naïve Zürich")).toBe("cafe-resume-naive-zurich");
+  });
+
+  it("returns 'story' for an empty string", () => {
+    expect(slugify("")).toBe("story");
+  });
+
+  it("returns 'story' for a non-string / falsy value", () => {
+    // @ts-expect-error intentional bad input
+    expect(slugify(null)).toBe("story");
+    // @ts-expect-error intentional bad input
+    expect(slugify(undefined)).toBe("story");
+  });
+
+  it("returns 'story' when input contains only special characters", () => {
+    expect(slugify("!!!---???")).toBe("story");
+  });
+
+  it("caps output at 60 characters by default", () => {
+    const long = "word ".repeat(20).trim(); // 99 chars
+    const result = slugify(long);
+    expect(result.length).toBeLessThanOrEqual(60);
+  });
+
+  it("trims at a hyphen boundary when capping length", () => {
+    // 65-char string of alternating word-boundary patterns
+    const input = "alpha beta gamma delta epsilon zeta eta theta iota kappa";
+    const result = slugify(input, 30);
+    expect(result.length).toBeLessThanOrEqual(30);
+    expect(result).not.toMatch(/^-|-$/);
+  });
+
+  it("handles numbers and alphanumeric mixed strings", () => {
+    expect(slugify("Led 3 Teams in Q1 2024")).toBe("led-3-teams-in-q1-2024");
+  });
+});

--- a/apps/web/lib/slugify.ts
+++ b/apps/web/lib/slugify.ts
@@ -1,0 +1,33 @@
+/**
+ * Converts a string to a URL/filename-safe slug.
+ *
+ * - Lowercases the input
+ * - NFKD-normalises and strips diacritics (e.g. "é" → "e")
+ * - Replaces runs of non-alphanumeric characters with a single "-"
+ * - Trims leading/trailing "-"
+ * - Caps at 60 characters (trimming at a "-" boundary when possible)
+ * - Falls back to "story" when the result would be empty
+ */
+export function slugify(input: string, maxLength = 60): string {
+  if (!input || typeof input !== "string") return "story";
+
+  const normalized = input
+    .normalize("NFKD")
+    // Strip combining diacritical marks (U+0300–U+036F)
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (!normalized) return "story";
+
+  if (normalized.length <= maxLength) return normalized;
+
+  // Trim at maxLength, then back up to the nearest "-" boundary
+  let trimmed = normalized.slice(0, maxLength);
+  const lastDash = trimmed.lastIndexOf("-");
+  if (lastDash > 0) {
+    trimmed = trimmed.slice(0, lastDash);
+  }
+  return trimmed.replace(/^-+|-+$/g, "") || "story";
+}


### PR DESCRIPTION
## Summary

Reuses the existing `@react-pdf/renderer` client-side pipeline from Story 33 (feedback PDF export) to add PDF export for STAR stories.

- `components/star/StarStoryPDF.tsx` exports two `@react-pdf/renderer` components: `StarStoryPDF` (single story, single `<Page>`) and `StarStoriesBundlePDF` (array of stories, one `<Page>` per story inside one `<Document>`). Visual language mirrors `FeedbackPDF.tsx` — Helvetica, header band, score boxes, footer. Local `getScoreColor` adjusts for the 0–100 STAR score range (vs. 0–10 feedback scores).
- `components/star/StarPdfExportButton.tsx` is a controlled client component that dynamically imports `@react-pdf/renderer` and `StarStoryPDF` on click, builds a blob, and triggers a download with filename `star-{title-slug}.pdf`. Shows a `Loader2` spinner + "Exporting..." label while in-flight.
- `lib/slugify.ts` is a small 60-char-capped slug helper (lowercase, NFKD diacritic strip, non-alphanumeric → `-`, fall back to `"story"`).
- `/star` page gets:
  - "Export PDF" button in the story detail action row (next to Edit/Delete)
  - "Export all" button in the page header (left of "New Story"), hidden when the user has no stories. Fetches each story's analyses with bounded concurrency (chunks of 5), shows "Exporting N of M..." progress, downloads `star-stories-{YYYY-MM-DD}.pdf` as a single multi-page PDF (no zip → no new dependency).

No server-side PDF route. No new npm dependencies. No schema changes.

Fixes #119

## Design decision recap

**Client-side generation, reusing the existing pipeline** — matches the acceptance criteria's explicit "reuse the existing pipeline" clause and avoids a new dependency (would have needed JSZip for a bundle option). Single multi-page PDF for "Export all" is cleaner UX than a ZIP anyway.

## Test plan

- [x] `lib/slugify.test.ts` — 9 unit cases (basic, punctuation, unicode/diacritics, empty, null/undefined, all-special, length cap, boundary trim, numbers)
- [x] `components/star/StarStoryPDF.test.tsx` — 7 component cases (story-only, story+analysis score-box render, bundle of 3 with per-story pages, empty questions omit section, analysis labels render)
- [x] `components/star/StarPdfExportButton.test.tsx` — 4 component cases (idle render, click → `pdf()` called + correct download filename, deferred-promise spinner + disabled state, `URL.revokeObjectURL` cleanup)
- [x] `app/star/page.test.tsx` — 3 new cases (Export PDF visible in detail, Export all visible with ≥1 story, Export all hidden when empty)
- [ ] CI: lint + typecheck + unit gauntlet
- [ ] Manual cross-browser: open `/star` in Chrome, Firefox, Safari — export one story + "Export all", inspect the rendered PDFs

## Trace table

| # | Scenario | Test file |
|---|---|---|
| 119-A | "Export PDF" on story detail | `app/star/page.test.tsx` |
| 119-B | "Export all" visible with ≥1 story | `app/star/page.test.tsx` |
| 119-C | "Export all" hidden when 0 stories | `app/star/page.test.tsx` |
| 119-D | Click → `@react-pdf/renderer` dynamic import + `pdf().toBlob()` | `StarPdfExportButton.test.tsx` |
| 119-E | PDF renders: story-only, story+analysis, bundle | `StarStoryPDF.test.tsx` |
| 119-F | Filename = `star-{title-slug}.pdf` | `StarPdfExportButton.test.tsx` + `slugify.test.ts` |
| 119-G | Cross-browser smoke | Manual QA before merge |

## Non-blocking notes

- This PR was produced via `standup` with worktree-isolated implementers. Diff audited inline (not via pr-reviewer subagent) due to quota exhaustion recovery. Diff is scope-clean: only the 8 files listed in the plan are touched.
- `@react-pdf/renderer` lazy-import pattern mirrors `FeedbackDashboard.tsx` exactly — bundle impact is limited to the `/star` route.

## Manual verification

- [ ] On `/star`, select a story → click Export PDF → confirm PDF opens/downloads with `star-{slug}.pdf`
- [ ] On `/star` with ≥1 story, click Export all → confirm multi-page `star-stories-YYYY-MM-DD.pdf`
- [ ] Open exported PDFs in Chrome, Firefox, Safari — confirm layout + text rendering
- [ ] Empty state: delete all stories, confirm Export all button disappears