### PR TITLE
feat(gaze): consistency metric computation and Eye Contact feedback card

### DIFF
--- a/apps/web/app/api/sessions/[id]/feedback/route.integration.test.ts
+++ b/apps/web/app/api/sessions/[id]/feedback/route.integration.test.ts
@@ -21,6 +21,7 @@ import {
   transcripts,
   codeSnapshots,
   sessionFeedback,
+  gazeSamples,
 } from "@/lib/schema";
 import { eq } from "drizzle-orm";
 
@@ -111,6 +112,7 @@ describe("API /api/sessions/[id]/feedback (integration)", () => {
     const db = getTestDb();
     await db.delete(sessionFeedback);
     await db.delete(codeSnapshots);
+    await db.delete(gazeSamples);
     await db.delete(transcripts);
     await db.delete(interviewSessions);
 
@@ -500,5 +502,92 @@ describe("API /api/sessions/[id]/feedback (integration)", () => {
 
     // The retry loop in withOpenAIRetry attempts twice before throwing.
     expect(mockChatCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("POST for behavioral session with gaze samples persists gaze columns", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: BEHAVIORAL_GPT_RESPONSE_RAW } }],
+    });
+
+    // Seed gaze samples for this session (center-looking samples spanning > 50% of a 10s session)
+    const db = getTestDb();
+    const centerSamples = Array.from({ length: 12 }, (_, i) => ({
+      t: i * 500,
+      gaze_x: 0,
+      gaze_y: 0,
+      head_yaw: 0,
+      head_pitch: 0,
+      confidence: 0.9,
+    }));
+    await db.insert(gazeSamples).values({
+      sessionId: behavioralSessionId,
+      samples: centerSamples,
+    });
+
+    // Update session duration so coverage calculation works
+    await db
+      .update(interviewSessions)
+      .set({ durationSeconds: 10 })
+      .where(eq(interviewSessions.id, behavioralSessionId));
+
+    const res = await POST(
+      makePostRequest(behavioralSessionId),
+      makeParams(behavioralSessionId)
+    );
+    expect(res.status).toBe(201);
+
+    // Verify gaze columns were persisted in the DB
+    const [row] = await db
+      .select()
+      .from(sessionFeedback)
+      .where(eq(sessionFeedback.sessionId, behavioralSessionId));
+    expect(row).toBeDefined();
+    expect(row.gazeConsistencyScore).not.toBeNull();
+    expect(row.gazeConsistencyScore).toBe(100); // all center samples → 100
+    expect(row.gazeCoverage).not.toBeNull();
+    expect(row.gazeDistribution).not.toBeNull();
+    expect(row.gazeTimeline).not.toBeNull();
+  });
+
+  it("GET returns gaze fields in response after they are persisted", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    // Seed feedback with gaze columns populated
+    const db = getTestDb();
+    await db.insert(sessionFeedback).values({
+      sessionId: behavioralSessionId,
+      overallScore: 7.5,
+      summary: "Great job",
+      strengths: ["a"],
+      weaknesses: ["b"],
+      answerAnalyses: [],
+      gazeConsistencyScore: 82.5,
+      gazeDistribution: {
+        center_pct: 82.5,
+        up_pct: 5,
+        down_pct: 5,
+        left_pct: 5,
+        right_pct: 2.5,
+        off_screen_pct: 0,
+      },
+      gazeCoverage: 0.88,
+      gazeTimeline: [
+        { bucket_start_s: 0, dominant_zone: "center", center_pct: 90 },
+      ],
+    });
+
+    const res = await GET(
+      makeGetRequest(behavioralSessionId),
+      makeParams(behavioralSessionId)
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.gazeConsistencyScore).toBe(82.5);
+    expect(body.gazeCoverage).toBe(0.88);
+    expect(body.gazeDistribution).not.toBeNull();
+    expect(body.gazeDistribution.center_pct).toBe(82.5);
+    expect(body.gazeTimeline).toHaveLength(1);
   });
 });

--- a/apps/web/app/api/sessions/[id]/feedback/route.ts
+++ b/apps/web/app/api/sessions/[id]/feedback/route.ts
@@ -6,8 +6,16 @@ import {
   transcripts,
   codeSnapshots,
   sessionFeedback,
+  gazeSamples,
 } from "@/lib/schema";
 import { eq, and, asc } from "drizzle-orm";
+import type { GazeSample } from "@/lib/gaze-types";
+import {
+  computeGazeConsistencyScore,
+  computeGazeDistribution,
+  computeCoverage,
+  bucketSamplesForTimeline,
+} from "@/lib/gaze-metrics";
 import { setSentryUser, setSentryContext } from "@/lib/sentry-utils";
 import { isTechnicalFeedbackComplete } from "@/lib/feedback-utils";
 import { createRequestLogger } from "@/lib/logger";
@@ -164,6 +172,42 @@ export async function POST(
     );
   }
 
+  // Compute gaze metrics if samples exist for this session
+  const gazeRows = await db
+    .select()
+    .from(gazeSamples)
+    .where(eq(gazeSamples.sessionId, id));
+
+  let gazeConsistencyScore: number | null = null;
+  let gazeDistribution = null;
+  let gazeCoverage: number | null = null;
+  let gazeTimeline = null;
+
+  if (gazeRows.length > 0) {
+    // Flatten all sample arrays from all gaze rows
+    const allSamples: GazeSample[] = gazeRows.flatMap(
+      (row) => (row.samples as GazeSample[]) ?? []
+    );
+
+    if (allSamples.length > 0) {
+      // Estimate session duration from durationSeconds or from sample span
+      const sessionDurationMs =
+        found.durationSeconds != null && found.durationSeconds > 0
+          ? found.durationSeconds * 1000
+          : allSamples[allSamples.length - 1].t + 1000;
+
+      gazeCoverage = computeCoverage(allSamples, sessionDurationMs);
+      gazeConsistencyScore = computeGazeConsistencyScore(allSamples, sessionDurationMs);
+      gazeDistribution = computeGazeDistribution(allSamples);
+      gazeTimeline = bucketSamplesForTimeline(allSamples);
+
+      log.info(
+        { sessionId: id, sampleCount: allSamples.length, gazeCoverage, gazeConsistencyScore },
+        "gaze metrics computed"
+      );
+    }
+  }
+
   // Save to database
   const [saved] = await db
     .insert(sessionFeedback)
@@ -179,6 +223,10 @@ export async function POST(
         explanationQualityScore: (feedbackData as TechnicalFeedbackResponse).explanation_quality_score,
         timelineAnalysis: (feedbackData as TechnicalFeedbackResponse).timeline_analysis,
       }),
+      gazeConsistencyScore,
+      gazeDistribution,
+      gazeCoverage,
+      gazeTimeline,
     })
     .returning();
 

--- a/apps/web/app/dashboard/sessions/[id]/feedback/page.tsx
+++ b/apps/web/app/dashboard/sessions/[id]/feedback/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { FeedbackDashboard } from "@/components/feedback/FeedbackDashboard";
 import type { TimelineEvent } from "@/components/feedback/TimelineView";
+import type { GazeDistribution, GazeTimelineBucket } from "@/lib/gaze-metrics";
 
 interface FeedbackData {
   overallScore: number;
@@ -20,6 +21,10 @@ interface FeedbackData {
   codeQualityScore?: number;
   explanationQualityScore?: number;
   timelineAnalysis?: TimelineEvent[];
+  gazeConsistencyScore?: number | null;
+  gazeDistribution?: GazeDistribution | null;
+  gazeCoverage?: number | null;
+  gazeTimeline?: GazeTimelineBucket[] | null;
 }
 
 const MAX_POLL_ATTEMPTS = 40; // 40 × 3s = 2 minutes max
@@ -99,6 +104,10 @@ export default function FeedbackPage() {
             undefined,
           timelineAnalysis:
             data.timelineAnalysis ?? data.timeline_analysis ?? undefined,
+          gazeConsistencyScore: data.gazeConsistencyScore ?? undefined,
+          gazeDistribution: data.gazeDistribution ?? undefined,
+          gazeCoverage: data.gazeCoverage ?? undefined,
+          gazeTimeline: data.gazeTimeline ?? undefined,
         });
         setIsLoading(false);
         // Done — no more polling
@@ -154,6 +163,19 @@ export default function FeedbackPage() {
             <div className="h-4 w-4/5 animate-pulse rounded bg-muted" />
             <div className="h-4 w-3/5 animate-pulse rounded bg-muted" />
           </div>
+        </div>
+
+        {/* Gaze card skeleton */}
+        <div className="rounded-lg border p-6 space-y-4">
+          <div className="h-5 w-32 animate-pulse rounded bg-muted" />
+          <div className="flex items-center gap-4">
+            <div className="h-16 w-16 animate-pulse rounded-full bg-muted" />
+            <div className="flex-1 space-y-2">
+              <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-1/2 animate-pulse rounded bg-muted" />
+            </div>
+          </div>
+          <div className="h-6 w-full animate-pulse rounded bg-muted" />
         </div>
 
         {/* Breakdown skeleton */}

--- a/apps/web/components/feedback/FeedbackDashboard.test.tsx
+++ b/apps/web/components/feedback/FeedbackDashboard.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { FeedbackDashboard } from "./FeedbackDashboard";
+import type { GazeDistribution, GazeTimelineBucket } from "@/lib/gaze-metrics";
 
 const BEHAVIORAL_FEEDBACK = {
   overallScore: 7.5,
@@ -120,5 +121,45 @@ describe("FeedbackDashboard", () => {
       <FeedbackDashboard feedback={BEHAVIORAL_FEEDBACK} sessionId="test-id" />
     );
     expect(screen.getAllByText("Export PDF").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("behavioral session with gaze data renders GazePresenceCard", () => {
+    const gazeDistribution: GazeDistribution = {
+      center_pct: 75,
+      up_pct: 5,
+      down_pct: 10,
+      left_pct: 5,
+      right_pct: 5,
+      off_screen_pct: 0,
+    };
+    const gazeTimeline: GazeTimelineBucket[] = [
+      { bucket_start_s: 0, dominant_zone: "center", center_pct: 80 },
+    ];
+    render(
+      <FeedbackDashboard
+        feedback={{
+          ...BEHAVIORAL_FEEDBACK,
+          gazeConsistencyScore: 78,
+          gazeDistribution,
+          gazeCoverage: 0.9,
+          gazeTimeline,
+        }}
+        sessionId="test-id"
+        sessionType="behavioral"
+      />
+    );
+    // GazePresenceCard renders "Eye Contact" as the CardTitle
+    expect(screen.getAllByText("Eye Contact").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("behavioral session without gaze data omits GazePresenceCard", () => {
+    render(
+      <FeedbackDashboard
+        feedback={BEHAVIORAL_FEEDBACK}
+        sessionId="test-id"
+        sessionType="behavioral"
+      />
+    );
+    expect(screen.queryByText("Eye Contact")).toBeNull();
   });
 });

--- a/apps/web/components/feedback/FeedbackDashboard.tsx
+++ b/apps/web/components/feedback/FeedbackDashboard.tsx
@@ -9,6 +9,8 @@ import { StrengthsWeaknesses } from "./StrengthsWeaknesses";
 import { AnswerBreakdown } from "./AnswerBreakdown";
 import { CodeQualityCard } from "./CodeQualityCard";
 import { TimelineView, type TimelineEvent } from "./TimelineView";
+import { GazePresenceCard } from "./GazePresenceCard";
+import type { GazeDistribution, GazeTimelineBucket } from "@/lib/gaze-metrics";
 
 interface AnswerAnalysis {
   question: string;
@@ -27,6 +29,10 @@ interface FeedbackData {
   codeQualityScore?: number;
   explanationQualityScore?: number;
   timelineAnalysis?: TimelineEvent[];
+  gazeConsistencyScore?: number | null;
+  gazeDistribution?: GazeDistribution | null;
+  gazeCoverage?: number | null;
+  gazeTimeline?: GazeTimelineBucket[] | null;
 }
 
 interface FeedbackDashboardProps {
@@ -124,6 +130,17 @@ export function FeedbackDashboard({
         strengths={feedback.strengths}
         weaknesses={feedback.weaknesses}
       />
+
+      {/* Gaze presence card — behavioral only, when gaze tracking was active
+          (gazeCoverage !== null is the reliable signal that the pipeline ran) */}
+      {!isTechnical && feedback.gazeCoverage != null && (
+        <GazePresenceCard
+          gazeConsistencyScore={feedback.gazeConsistencyScore ?? null}
+          gazeDistribution={feedback.gazeDistribution ?? null}
+          gazeCoverage={feedback.gazeCoverage}
+          gazeTimeline={feedback.gazeTimeline ?? null}
+        />
+      )}
 
       {/* Breakdown + Timeline side-by-side for technical, full-width for behavioral */}
       {isTechnical &&

--- a/apps/web/components/feedback/GazePresenceCard.test.tsx
+++ b/apps/web/components/feedback/GazePresenceCard.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { GazePresenceCard } from "./GazePresenceCard";
+import type { GazeDistribution, GazeTimelineBucket } from "@/lib/gaze-metrics";
+
+const FULL_DISTRIBUTION: GazeDistribution = {
+  center_pct: 80,
+  up_pct: 5,
+  down_pct: 5,
+  left_pct: 5,
+  right_pct: 5,
+  off_screen_pct: 0,
+};
+
+const WANDERING_DISTRIBUTION: GazeDistribution = {
+  center_pct: 30,
+  up_pct: 5,
+  down_pct: 35,
+  left_pct: 15,
+  right_pct: 10,
+  off_screen_pct: 5,
+};
+
+const OFF_SCREEN_DISTRIBUTION: GazeDistribution = {
+  center_pct: 40,
+  up_pct: 5,
+  down_pct: 5,
+  left_pct: 5,
+  right_pct: 20,
+  off_screen_pct: 25,
+};
+
+const SAMPLE_TIMELINE: GazeTimelineBucket[] = [
+  { bucket_start_s: 0, dominant_zone: "center", center_pct: 90 },
+  { bucket_start_s: 10, dominant_zone: "left", center_pct: 20 },
+  { bucket_start_s: 20, dominant_zone: "center", center_pct: 85 },
+];
+
+describe("GazePresenceCard", () => {
+  it("renders strong eye contact copy for a high score (85)", () => {
+    render(
+      <GazePresenceCard
+        gazeConsistencyScore={85}
+        gazeDistribution={FULL_DISTRIBUTION}
+        gazeCoverage={0.9}
+        gazeTimeline={SAMPLE_TIMELINE}
+      />
+    );
+    expect(
+      screen.getAllByText(/strong eye contact throughout/i).length
+    ).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/excellent/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders mixed eye contact copy for a mid score (45)", () => {
+    render(
+      <GazePresenceCard
+        gazeConsistencyScore={45}
+        gazeDistribution={WANDERING_DISTRIBUTION}
+        gazeCoverage={0.8}
+        gazeTimeline={SAMPLE_TIMELINE}
+      />
+    );
+    expect(
+      screen.getAllByText(/mixed eye contact/i).length
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders Needs Work copy for a low score (25)", () => {
+    render(
+      <GazePresenceCard
+        gazeConsistencyScore={25}
+        gazeDistribution={WANDERING_DISTRIBUTION}
+        gazeCoverage={0.7}
+        gazeTimeline={SAMPLE_TIMELINE}
+      />
+    );
+    expect(
+      screen.getAllByText(/wandered frequently/i).length
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      screen.getAllByText(/needs work/i).length
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders insufficient data fallback when score is null", () => {
+    render(
+      <GazePresenceCard
+        gazeConsistencyScore={null}
+        gazeDistribution={null}
+        gazeCoverage={null}
+        gazeTimeline={null}
+      />
+    );
+    expect(
+      screen.getAllByText(/couldn't track your gaze/i).length
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders animate-pulse skeleton when isLoading=true", () => {
+    const { container } = render(
+      <GazePresenceCard
+        gazeConsistencyScore={null}
+        gazeDistribution={null}
+        gazeCoverage={null}
+        gazeTimeline={null}
+        isLoading={true}
+      />
+    );
+    const pulseElements = container.querySelectorAll(".animate-pulse");
+    expect(pulseElements.length).toBeGreaterThan(0);
+  });
+
+  it("renders actionable tip when off_screen_pct > 20", () => {
+    render(
+      <GazePresenceCard
+        gazeConsistencyScore={65}
+        gazeDistribution={OFF_SCREEN_DISTRIBUTION}
+        gazeCoverage={0.85}
+        gazeTimeline={SAMPLE_TIMELINE}
+      />
+    );
+    expect(
+      screen.getAllByText(/notes near your camera/i).length
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders timeline strip when gazeTimeline has buckets", () => {
+    const { container } = render(
+      <GazePresenceCard
+        gazeConsistencyScore={75}
+        gazeDistribution={FULL_DISTRIBUTION}
+        gazeCoverage={0.9}
+        gazeTimeline={SAMPLE_TIMELINE}
+      />
+    );
+    expect(
+      screen.getAllByText(/gaze timeline/i).length
+    ).toBeGreaterThanOrEqual(1);
+    // 3 buckets should render as flex children
+    const timelineContainer = container.querySelector(".flex.h-6");
+    expect(timelineContainer).not.toBeNull();
+    expect(timelineContainer!.children.length).toBe(3);
+  });
+});

--- a/apps/web/components/feedback/GazePresenceCard.tsx
+++ b/apps/web/components/feedback/GazePresenceCard.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { getGazeScoreColor } from "@/lib/utils";
+import type { GazeDistribution, GazeTimelineBucket } from "@/lib/gaze-metrics";
+
+interface GazePresenceCardProps {
+  gazeConsistencyScore: number | null;
+  gazeDistribution: GazeDistribution | null;
+  gazeCoverage: number | null;
+  gazeTimeline: GazeTimelineBucket[] | null;
+  isLoading?: boolean;
+}
+
+function zoneColor(zone: string): string {
+  switch (zone) {
+    case "center":
+      return "bg-green-500";
+    case "up":
+      return "bg-blue-500";
+    case "down":
+      return "bg-orange-500";
+    case "left":
+    case "right":
+      return "bg-purple-500";
+    default:
+      return "bg-gray-400";
+  }
+}
+
+function interpretiveCopy(score: number): string {
+  if (score >= 80) return "Strong eye contact throughout";
+  if (score >= 60) return "Good eye contact with some wandering";
+  if (score >= 40) return "Mixed eye contact — try focusing on the camera";
+  return "Your gaze wandered frequently — practice looking at the camera";
+}
+
+function buildTips(dist: GazeDistribution): string[] {
+  const tips: string[] = [];
+
+  if (dist.off_screen_pct > 20) {
+    tips.push("Try placing notes near your camera so you can glance at them without looking away.");
+  }
+  if (dist.down_pct > 30) {
+    tips.push("Try to look up at the camera more often — it projects confidence.");
+  }
+  if (dist.left_pct + dist.right_pct > 30) {
+    tips.push("Keep your eyes facing forward toward the camera to appear more confident.");
+  }
+  if (dist.up_pct > 20) {
+    tips.push("Looking up frequently can signal hesitation — practice your answers to speak more naturally.");
+  }
+
+  if (tips.length === 0) {
+    tips.push("Great work maintaining eye contact! Keep it up in future interviews.");
+  }
+
+  return tips.slice(0, 3);
+}
+
+export function GazePresenceCard({
+  gazeConsistencyScore,
+  gazeDistribution,
+  gazeCoverage,
+  gazeTimeline,
+  isLoading = false,
+}: GazePresenceCardProps) {
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <div className="h-5 w-40 animate-pulse rounded bg-muted" />
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center gap-4">
+            <div className="h-16 w-16 animate-pulse rounded-full bg-muted" />
+            <div className="flex-1 space-y-2">
+              <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-1/2 animate-pulse rounded bg-muted" />
+            </div>
+          </div>
+          <div className="h-6 w-full animate-pulse rounded bg-muted" />
+          <div className="grid grid-cols-6 gap-1">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="h-8 animate-pulse rounded bg-muted" />
+            ))}
+          </div>
+          <div className="space-y-2">
+            <div className="h-3 w-full animate-pulse rounded bg-muted" />
+            <div className="h-3 w-4/5 animate-pulse rounded bg-muted" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Insufficient data fallback
+  if (gazeConsistencyScore === null) {
+    return (
+      <Card className="border-muted">
+        <CardHeader>
+          <CardTitle className="text-base">Eye Contact</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            We couldn&apos;t track your gaze for enough of the session to produce a
+            score. Try improving lighting and camera positioning.
+          </p>
+          {gazeCoverage !== null && gazeCoverage > 0 && (
+            <p className="mt-2 text-xs text-muted-foreground">
+              Coverage: {Math.round(gazeCoverage * 100)}% of session
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const colors = getGazeScoreColor(gazeConsistencyScore);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Eye Contact</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {/* Score badge + interpretive copy */}
+        <div className="flex items-center gap-4">
+          <div
+            className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-full border-2 ${colors.bg} ${colors.border}`}
+          >
+            <span className={`text-xl font-bold ${colors.text}`}>
+              {Math.round(gazeConsistencyScore)}
+            </span>
+          </div>
+          <div>
+            <p className={`font-semibold ${colors.text}`}>{colors.label}</p>
+            <p className="text-sm text-muted-foreground">
+              {interpretiveCopy(gazeConsistencyScore)}
+            </p>
+            {gazeCoverage !== null && (
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                Coverage: {Math.round(gazeCoverage * 100)}% of session
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Timeline strip */}
+        {gazeTimeline && gazeTimeline.length > 0 && (
+          <div>
+            <p className="mb-1.5 text-xs font-medium text-muted-foreground">
+              Gaze Timeline
+            </p>
+            <div className="flex h-6 w-full gap-0.5 overflow-hidden rounded">
+              {gazeTimeline.map((bucket) => (
+                <div
+                  key={bucket.bucket_start_s}
+                  title={`${bucket.bucket_start_s}s–${bucket.bucket_start_s + 10}s: ${bucket.dominant_zone} (${bucket.center_pct}% camera)`}
+                  className={`flex-1 motion-safe:transition-colors ${zoneColor(bucket.dominant_zone)}`}
+                />
+              ))}
+            </div>
+            <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+              <span className="flex items-center gap-1">
+                <span className="inline-block h-2 w-2 rounded-full bg-green-500" />
+                Camera
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="inline-block h-2 w-2 rounded-full bg-blue-500" />
+                Up
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="inline-block h-2 w-2 rounded-full bg-orange-500" />
+                Down
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="inline-block h-2 w-2 rounded-full bg-purple-500" />
+                Side
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="inline-block h-2 w-2 rounded-full bg-gray-400" />
+                Off-screen
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* Distribution row */}
+        {gazeDistribution && (
+          <div>
+            <p className="mb-1.5 text-xs font-medium text-muted-foreground">
+              Gaze Distribution
+            </p>
+            <div className="grid grid-cols-3 gap-2 sm:grid-cols-6">
+              {[
+                { label: "Camera", value: gazeDistribution.center_pct },
+                { label: "Up", value: gazeDistribution.up_pct },
+                { label: "Down", value: gazeDistribution.down_pct },
+                { label: "Left", value: gazeDistribution.left_pct },
+                { label: "Right", value: gazeDistribution.right_pct },
+                { label: "Off-screen", value: gazeDistribution.off_screen_pct },
+              ].map(({ label, value }) => (
+                <div key={label} className="rounded-md border p-2 text-center">
+                  <p className="text-sm font-semibold">{value}%</p>
+                  <p className="text-xs text-muted-foreground">{label}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Actionable tips */}
+        {gazeDistribution && (
+          <div>
+            <p className="mb-1.5 text-xs font-medium text-muted-foreground">
+              Tips to Look More Confident
+            </p>
+            <ul className="space-y-1">
+              {buildTips(gazeDistribution).map((tip, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-muted-foreground">
+                  <span className="mt-0.5 shrink-0 text-primary">•</span>
+                  <span>{tip}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/drizzle/0012_illegal_rocket_raccoon.sql
+++ b/apps/web/drizzle/0012_illegal_rocket_raccoon.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "session_feedback" ADD COLUMN "gaze_consistency_score" real;--> statement-breakpoint
+ALTER TABLE "session_feedback" ADD COLUMN "gaze_distribution" jsonb;--> statement-breakpoint
+ALTER TABLE "session_feedback" ADD COLUMN "gaze_coverage" real;--> statement-breakpoint
+ALTER TABLE "session_feedback" ADD COLUMN "gaze_timeline" jsonb;

--- a/apps/web/drizzle/meta/0012_snapshot.json
+++ b/apps/web/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1399 @@
+{
+  "id": "04c4668d-b2cb-4d2d-9f9e-35d53e751857",
+  "prevId": "237349e9-a997-442e-94df-70b73a203d96",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.code_snapshots": {
+      "name": "code_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "code_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_result": {
+          "name": "execution_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "code_snapshots_session_id_interview_sessions_id_fk": {
+          "name": "code_snapshots_session_id_interview_sessions_id_fk",
+          "tableFrom": "code_snapshots",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_questions": {
+      "name": "company_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_questions_user_id_users_id_fk": {
+          "name": "company_questions_user_id_users_id_fk",
+          "tableFrom": "company_questions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deleted_usage": {
+      "name": "deleted_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deleted_usage_hash_month_unique": {
+          "name": "deleted_usage_hash_month_unique",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gaze_samples": {
+      "name": "gaze_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gaze_samples_session_id_interview_sessions_id_fk": {
+          "name": "gaze_samples_session_id_interview_sessions_id_fk",
+          "tableFrom": "gaze_samples",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_plans": {
+      "name": "interview_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interview_date": {
+          "name": "interview_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_data": {
+          "name": "plan_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_plans_user_id_users_id_fk": {
+          "name": "interview_plans_user_id_users_id_fk",
+          "tableFrom": "interview_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_sessions": {
+      "name": "interview_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'configuring'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_star_story_id": {
+          "name": "source_star_story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_sessions_user_id_users_id_fk": {
+          "name": "interview_sessions_user_id_users_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interview_sessions_source_star_story_id_star_stories_id_fk": {
+          "name": "interview_sessions_source_star_story_id_star_stories_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "source_star_story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_usage": {
+      "name": "interview_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "interview_usage_user_period_unique": {
+          "name": "interview_usage_user_period_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interview_usage_user_id_users_id_fk": {
+          "name": "interview_usage_user_id_users_id_fk",
+          "tableFrom": "interview_usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.openai_usage": {
+      "name": "openai_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd_millis": {
+          "name": "cost_usd_millis",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "openai_usage_user_date_model_unique": {
+          "name": "openai_usage_user_date_model_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_feedback": {
+      "name": "session_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_score": {
+          "name": "overall_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strengths": {
+          "name": "strengths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "weaknesses": {
+          "name": "weaknesses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "answer_analyses": {
+          "name": "answer_analyses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "code_quality_score": {
+          "name": "code_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation_quality_score": {
+          "name": "explanation_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeline_analysis": {
+          "name": "timeline_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_consistency_score": {
+          "name": "gaze_consistency_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_distribution": {
+          "name": "gaze_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_coverage": {
+          "name": "gaze_coverage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_timeline": {
+          "name": "gaze_timeline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_feedback_session_id_interview_sessions_id_fk": {
+          "name": "session_feedback_session_id_interview_sessions_id_fk",
+          "tableFrom": "session_feedback",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_templates": {
+      "name": "session_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_templates_user_id_users_id_fk": {
+          "name": "session_templates_user_id_users_id_fk",
+          "tableFrom": "session_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_stories": {
+      "name": "star_stories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_questions": {
+          "name": "expected_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "situation": {
+          "name": "situation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_stories_user_id_users_id_fk": {
+          "name": "star_stories_user_id_users_id_fk",
+          "tableFrom": "star_stories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_story_analyses": {
+      "name": "star_story_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scores": {
+          "name": "scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_story_analyses_story_id_star_stories_id_fk": {
+          "name": "star_story_analyses_story_id_star_stories_id_fk",
+          "tableFrom": "star_story_analyses",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcripts": {
+      "name": "transcripts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcripts_session_id_interview_sessions_id_fk": {
+          "name": "transcripts_session_id_interview_sessions_id_fk",
+          "tableFrom": "transcripts",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_badge_unique": {
+          "name": "user_badge_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "badge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_resumes": {
+      "name": "user_resumes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_resumes_user_id_users_id_fk": {
+          "name": "user_resumes_user_id_users_id_fk",
+          "tableFrom": "user_resumes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "user_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_start": {
+          "name": "plan_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_end": {
+          "name": "plan_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "past_due_at": {
+          "name": "past_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_tracking_enabled": {
+          "name": "gaze_tracking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.code_event_type": {
+      "name": "code_event_type",
+      "schema": "public",
+      "values": [
+        "edit",
+        "run",
+        "submit"
+      ]
+    },
+    "public.interview_type": {
+      "name": "interview_type",
+      "schema": "public",
+      "values": [
+        "behavioral",
+        "technical"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "configuring",
+        "in_progress",
+        "completed",
+        "cancelled",
+        "failed"
+      ]
+    },
+    "public.user_plan": {
+      "name": "user_plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "max"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1776428463810,
       "tag": "0011_gorgeous_loners",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1776431359834,
+      "tag": "0012_illegal_rocket_raccoon",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/gaze-metrics.test.ts
+++ b/apps/web/lib/gaze-metrics.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "vitest";
+import type { GazeSample } from "./gaze-types";
+import {
+  computeCoverage,
+  computeGazeConsistencyScore,
+  computeGazeDistribution,
+  bucketSamplesForTimeline,
+} from "./gaze-metrics";
+
+function makeSample(overrides?: Partial<GazeSample>): GazeSample {
+  return {
+    t: 0,
+    gaze_x: 0,
+    gaze_y: 0,
+    head_yaw: 0,
+    head_pitch: 0,
+    confidence: 0.9,
+    ...overrides,
+  };
+}
+
+// Samples that classifyGazeZone will classify as "center":
+// gaze_x=0, gaze_y=0, head_yaw=0, head_pitch=0, confidence=0.9
+function makeCenterSample(t: number, confidence = 0.9): GazeSample {
+  return makeSample({ t, gaze_x: 0, gaze_y: 0, head_yaw: 0, head_pitch: 0, confidence });
+}
+
+// Samples that should be classified as "left":
+// head_yaw=-30 > YAW_THRESHOLD(15), combined_x negative
+function makeLeftSample(t: number, confidence = 0.9): GazeSample {
+  return makeSample({ t, gaze_x: -0.5, gaze_y: 0, head_yaw: -30, head_pitch: 0, confidence });
+}
+
+// Samples with low confidence → off-screen
+function makeOffScreenSample(t: number): GazeSample {
+  return makeSample({ t, confidence: 0.1 }); // below CONFIDENCE_THRESHOLD(0.3)
+}
+
+describe("computeCoverage", () => {
+  it("returns 0 for empty samples", () => {
+    expect(computeCoverage([], 10000)).toBe(0);
+  });
+
+  it("returns 0 when sessionDurationMs <= 0", () => {
+    const samples = [makeCenterSample(0), makeCenterSample(5000)];
+    expect(computeCoverage(samples, 0)).toBe(0);
+    expect(computeCoverage(samples, -1)).toBe(0);
+  });
+
+  it("returns 0 for a single sample", () => {
+    expect(computeCoverage([makeCenterSample(0)], 10000)).toBe(0);
+  });
+
+  it("returns ~1.0 when samples span the full session duration", () => {
+    const samples = [makeCenterSample(0), makeCenterSample(10000)];
+    expect(computeCoverage(samples, 10000)).toBeCloseTo(1.0, 5);
+  });
+
+  it("returns ~0.5 when samples span half the session", () => {
+    const samples = [makeCenterSample(0), makeCenterSample(5000)];
+    expect(computeCoverage(samples, 10000)).toBeCloseTo(0.5, 5);
+  });
+
+  it("clamps to 1.0 when span exceeds session duration", () => {
+    const samples = [makeCenterSample(0), makeCenterSample(12000)];
+    expect(computeCoverage(samples, 10000)).toBe(1.0);
+  });
+});
+
+describe("computeGazeConsistencyScore", () => {
+  it("returns null for empty samples", () => {
+    expect(computeGazeConsistencyScore([], 10000)).toBeNull();
+  });
+
+  it("returns null when coverage < 0.5 (suppressed)", () => {
+    // span = 4000ms out of 10000ms = 0.4 coverage
+    const samples = [makeCenterSample(0), makeCenterSample(4000)];
+    expect(computeGazeConsistencyScore(samples, 10000)).toBeNull();
+  });
+
+  it("returns 100 when all samples are center with sufficient coverage", () => {
+    const samples = [makeCenterSample(0), makeCenterSample(5000), makeCenterSample(10000)];
+    const score = computeGazeConsistencyScore(samples, 10000);
+    expect(score).toBe(100);
+  });
+
+  it("returns a low score when all samples are looking left", () => {
+    const samples = [makeLeftSample(0), makeLeftSample(5000), makeLeftSample(10000)];
+    const score = computeGazeConsistencyScore(samples, 10000);
+    expect(score).not.toBeNull();
+    expect(score!).toBe(0);
+  });
+
+  it("returns a mid-range score for an even mix of center and left samples", () => {
+    const samples = [
+      makeCenterSample(0),
+      makeLeftSample(2000),
+      makeCenterSample(4000),
+      makeLeftSample(6000),
+      makeCenterSample(8000),
+      makeLeftSample(10000),
+    ];
+    const score = computeGazeConsistencyScore(samples, 10000);
+    expect(score).not.toBeNull();
+    expect(score!).toBeGreaterThan(0);
+    expect(score!).toBeLessThan(100);
+  });
+
+  it("weights low-confidence samples down", () => {
+    // Two center samples with high confidence, one off-screen with very low confidence
+    const highConfCenter1 = makeCenterSample(0, 0.9);
+    const highConfCenter2 = makeCenterSample(5000, 0.9);
+    const lowConfOff = makeOffScreenSample(10000);
+
+    const samples = [highConfCenter1, highConfCenter2, lowConfOff];
+    const score = computeGazeConsistencyScore(samples, 10000);
+    expect(score).not.toBeNull();
+    // high-confidence center samples should dominate the score
+    expect(score!).toBeGreaterThan(80);
+  });
+
+  it("rounds to 1 decimal place", () => {
+    // 2 center, 1 left — each with equal confidence 0.9
+    const samples = [
+      makeCenterSample(0, 0.9),
+      makeCenterSample(5000, 0.9),
+      makeLeftSample(10000, 0.9),
+    ];
+    const score = computeGazeConsistencyScore(samples, 10000);
+    expect(score).not.toBeNull();
+    // Score = 100 * (0.9+0.9) / (0.9+0.9+0.9) = 100 * 1.8/2.7 = 66.666... → 66.7
+    expect(score).toBe(66.7);
+  });
+});
+
+describe("computeGazeDistribution", () => {
+  it("returns null for empty samples", () => {
+    expect(computeGazeDistribution([])).toBeNull();
+  });
+
+  it("returns 100% center when all samples are center", () => {
+    const samples = [makeCenterSample(0), makeCenterSample(1000), makeCenterSample(2000)];
+    const dist = computeGazeDistribution(samples);
+    expect(dist).not.toBeNull();
+    expect(dist!.center_pct).toBe(100);
+    expect(dist!.up_pct).toBe(0);
+    expect(dist!.down_pct).toBe(0);
+    expect(dist!.left_pct).toBe(0);
+    expect(dist!.right_pct).toBe(0);
+    expect(dist!.off_screen_pct).toBe(0);
+  });
+
+  it("returns expected percentages for a known input mix", () => {
+    const samples = [
+      makeCenterSample(0),
+      makeCenterSample(1000),
+      makeLeftSample(2000),
+      makeLeftSample(3000),
+      makeOffScreenSample(4000),
+    ];
+    const dist = computeGazeDistribution(samples);
+    expect(dist).not.toBeNull();
+    // 2 center / 5 = 40%
+    expect(dist!.center_pct).toBe(40);
+    // 2 left / 5 = 40%
+    expect(dist!.left_pct).toBe(40);
+    // 1 off-screen / 5 = 20%
+    expect(dist!.off_screen_pct).toBe(20);
+  });
+
+  it("all percentages sum to ~100", () => {
+    const samples = [
+      makeCenterSample(0),
+      makeLeftSample(1000),
+      makeOffScreenSample(2000),
+    ];
+    const dist = computeGazeDistribution(samples);
+    expect(dist).not.toBeNull();
+    const sum =
+      dist!.center_pct +
+      dist!.up_pct +
+      dist!.down_pct +
+      dist!.left_pct +
+      dist!.right_pct +
+      dist!.off_screen_pct;
+    expect(sum).toBeCloseTo(100, 0);
+  });
+});
+
+describe("bucketSamplesForTimeline", () => {
+  it("returns empty array for no samples", () => {
+    expect(bucketSamplesForTimeline([])).toEqual([]);
+  });
+
+  it("groups 30s of samples into 3 buckets of 10s each", () => {
+    const samples: GazeSample[] = [];
+    for (let t = 0; t < 30000; t += 1000) {
+      samples.push(makeCenterSample(t));
+    }
+    const buckets = bucketSamplesForTimeline(samples, 10);
+    expect(buckets).toHaveLength(3);
+    expect(buckets[0].bucket_start_s).toBe(0);
+    expect(buckets[1].bucket_start_s).toBe(10);
+    expect(buckets[2].bucket_start_s).toBe(20);
+  });
+
+  it("each bucket has the correct dominant_zone and center_pct", () => {
+    // First 10s: center samples → dominant = center
+    // Next 10s: left samples → dominant = left
+    const samples: GazeSample[] = [
+      ...Array.from({ length: 5 }, (_, i) => makeCenterSample(i * 2000)),
+      ...Array.from({ length: 5 }, (_, i) => makeLeftSample(10000 + i * 2000)),
+    ];
+    const buckets = bucketSamplesForTimeline(samples, 10);
+    expect(buckets[0].dominant_zone).toBe("center");
+    expect(buckets[0].center_pct).toBe(100);
+    expect(buckets[1].dominant_zone).toBe("left");
+    expect(buckets[1].center_pct).toBe(0);
+  });
+
+  it("returns buckets sorted by bucket_start_s ascending", () => {
+    // Insert samples out of order (Map iteration order depends on insertion)
+    const samples: GazeSample[] = [
+      makeCenterSample(20000),
+      makeCenterSample(0),
+      makeCenterSample(10000),
+    ];
+    const buckets = bucketSamplesForTimeline(samples, 10);
+    expect(buckets[0].bucket_start_s).toBeLessThan(buckets[1].bucket_start_s);
+    if (buckets.length > 2) {
+      expect(buckets[1].bucket_start_s).toBeLessThan(buckets[2].bucket_start_s);
+    }
+  });
+});

--- a/apps/web/lib/gaze-metrics.ts
+++ b/apps/web/lib/gaze-metrics.ts
@@ -1,0 +1,180 @@
+import type { GazeSample, GazeZone } from "./gaze-types";
+import { classifyGazeZone } from "./gaze-geometry";
+
+export interface GazeDistribution {
+  center_pct: number;
+  up_pct: number;
+  down_pct: number;
+  left_pct: number;
+  right_pct: number;
+  off_screen_pct: number;
+}
+
+export interface GazeTimelineBucket {
+  bucket_start_s: number;
+  dominant_zone: GazeZone;
+  center_pct: number;
+}
+
+/**
+ * Compute the fraction of the session covered by gaze samples.
+ * Coverage = (last sample t - first sample t) / sessionDurationMs, clamped 0-1.
+ */
+export function computeCoverage(
+  samples: GazeSample[],
+  sessionDurationMs: number
+): number {
+  if (samples.length === 0 || sessionDurationMs <= 0) return 0;
+  if (samples.length === 1) return 0;
+  const span = samples[samples.length - 1].t - samples[0].t;
+  return Math.min(1, Math.max(0, span / sessionDurationMs));
+}
+
+/**
+ * Compute a gaze consistency score (0-100) based on how often the user
+ * maintained camera-forward gaze. Returns null when coverage is below 50%.
+ */
+export function computeGazeConsistencyScore(
+  samples: GazeSample[],
+  sessionDurationMs: number
+): number | null {
+  if (samples.length === 0) return null;
+
+  const coverage = computeCoverage(samples, sessionDurationMs);
+  if (coverage < 0.5) return null;
+
+  let totalWeight = 0;
+  let centerWeight = 0;
+
+  for (const sample of samples) {
+    const zone = classifyGazeZone(
+      sample.gaze_x,
+      sample.gaze_y,
+      sample.head_yaw,
+      sample.head_pitch,
+      sample.confidence
+    );
+    totalWeight += sample.confidence;
+    if (zone === "center") {
+      centerWeight += sample.confidence;
+    }
+  }
+
+  if (totalWeight === 0) return null;
+
+  const score = (100 * centerWeight) / totalWeight;
+  return Math.round(score * 10) / 10;
+}
+
+/**
+ * Compute the distribution of gaze zones as percentages.
+ * Returns null when there are no samples.
+ */
+export function computeGazeDistribution(
+  samples: GazeSample[]
+): GazeDistribution | null {
+  if (samples.length === 0) return null;
+
+  const counts: Record<GazeZone, number> = {
+    center: 0,
+    up: 0,
+    down: 0,
+    left: 0,
+    right: 0,
+    "off-screen": 0,
+  };
+
+  for (const sample of samples) {
+    const zone = classifyGazeZone(
+      sample.gaze_x,
+      sample.gaze_y,
+      sample.head_yaw,
+      sample.head_pitch,
+      sample.confidence
+    );
+    counts[zone]++;
+  }
+
+  const total = samples.length;
+  const pct = (zone: GazeZone) =>
+    Math.round((counts[zone] / total) * 1000) / 10;
+
+  return {
+    center_pct: pct("center"),
+    up_pct: pct("up"),
+    down_pct: pct("down"),
+    left_pct: pct("left"),
+    right_pct: pct("right"),
+    off_screen_pct: pct("off-screen"),
+  };
+}
+
+/**
+ * Group samples into time buckets and summarize each bucket.
+ */
+export function bucketSamplesForTimeline(
+  samples: GazeSample[],
+  bucketSeconds = 10
+): GazeTimelineBucket[] {
+  if (samples.length === 0) return [];
+
+  const bucketMs = bucketSeconds * 1000;
+  const bucketMap = new Map<number, GazeSample[]>();
+
+  for (const sample of samples) {
+    const bucketKey = Math.floor(sample.t / bucketMs);
+    if (!bucketMap.has(bucketKey)) {
+      bucketMap.set(bucketKey, []);
+    }
+    bucketMap.get(bucketKey)!.push(sample);
+  }
+
+  const result: GazeTimelineBucket[] = [];
+
+  for (const [bucketKey, bucketSamples] of bucketMap) {
+    const zoneCounts: Record<GazeZone, number> = {
+      center: 0,
+      up: 0,
+      down: 0,
+      left: 0,
+      right: 0,
+      "off-screen": 0,
+    };
+
+    for (const sample of bucketSamples) {
+      const zone = classifyGazeZone(
+        sample.gaze_x,
+        sample.gaze_y,
+        sample.head_yaw,
+        sample.head_pitch,
+        sample.confidence
+      );
+      zoneCounts[zone]++;
+    }
+
+    let dominantZone: GazeZone = "center";
+    let maxCount = 0;
+    for (const [zone, count] of Object.entries(zoneCounts) as [GazeZone, number][]) {
+      if (count > maxCount) {
+        maxCount = count;
+        dominantZone = zone;
+      }
+    }
+
+    const centerPct =
+      bucketSamples.length > 0
+        ? Math.round((zoneCounts["center"] / bucketSamples.length) * 1000) / 10
+        : 0;
+
+    result.push({
+      bucket_start_s: bucketKey * bucketSeconds,
+      dominant_zone: dominantZone,
+      center_pct: centerPct,
+    });
+  }
+
+  // Sort by bucket start time
+  result.sort((a, b) => a.bucket_start_s - b.bucket_start_s);
+
+  return result;
+}

--- a/apps/web/lib/schema.ts
+++ b/apps/web/lib/schema.ts
@@ -176,6 +176,10 @@ export const sessionFeedback = pgTable("session_feedback", {
   codeQualityScore: real("code_quality_score"),
   explanationQualityScore: real("explanation_quality_score"),
   timelineAnalysis: jsonb("timeline_analysis"),
+  gazeConsistencyScore: real("gaze_consistency_score"),
+  gazeDistribution: jsonb("gaze_distribution"),
+  gazeCoverage: real("gaze_coverage"),
+  gazeTimeline: jsonb("gaze_timeline"),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -11,3 +11,10 @@ export function getScoreColor(score: number) {
   if (score >= 4) return { bg: "bg-yellow-500/10", text: "text-yellow-600 dark:text-yellow-400", border: "border-yellow-500/30", label: "Average" };
   return { bg: "bg-red-500/10", text: "text-red-600 dark:text-red-400", border: "border-red-500/30", label: "Needs Work" };
 }
+
+export function getGazeScoreColor(score: number) {
+  if (score >= 80) return { bg: "bg-blue-500/10", text: "text-blue-600 dark:text-blue-400", border: "border-blue-500/30", label: "Excellent" };
+  if (score >= 60) return { bg: "bg-green-500/10", text: "text-green-600 dark:text-green-400", border: "border-green-500/30", label: "Good" };
+  if (score >= 40) return { bg: "bg-yellow-500/10", text: "text-yellow-600 dark:text-yellow-400", border: "border-yellow-500/30", label: "Average" };
+  return { bg: "bg-red-500/10", text: "text-red-600 dark:text-red-400", border: "border-red-500/30", label: "Needs Work" };
+}


### PR DESCRIPTION
## Summary
- Adds four pure metric functions in `lib/gaze-metrics.ts`: `computeCoverage`,
  `computeGazeConsistencyScore` (confidence-weighted, null when coverage < 50%),
  `computeGazeDistribution`, and `bucketSamplesForTimeline`. Covered by 21 unit tests.
- Extends `session_feedback` with four nullable gaze columns via migration 0012.
- `POST /api/sessions/[id]/feedback` now reads `gaze_samples` rows, computes metrics,
  and persists them alongside the existing score.
- New `GazePresenceCard` component renders an "Eye Contact" section in the behavioral
  feedback report: score badge, gaze timeline strip, distribution grid, and
  self-improvement tips. Handles loading skeleton, null/insufficient-data, and all
  four score tiers (Excellent/Good/Average/Needs Work).
- Card only renders when `gazeCoverage` is non-null — prevents false display for
  sessions where gaze tracking was never active.

## Implements
Closes #134, closes #135

Completes epic #130 (all 6 sub-issues now closed)

## Test plan
- [x] 21 unit tests for `lib/gaze-metrics.ts` (all 4 functions, edge cases, suppression)
- [x] 7 component tests for `GazePresenceCard` (high/mid/low/null scores, skeleton, off-screen tip, timeline)
- [x] 2 component tests for `FeedbackDashboard` (card present/absent based on gaze data)
- [x] 2 integration tests for feedback route (POST persists gaze columns, GET returns them)
- [x] Lint: 0 errors
- [x] Typecheck: pass
- [x] Unit/component tests: 780 passed
- [x] Integration tests: 317 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)