### PR TITLE
fix(interview): correct Realtime API message type and prevent interviewer self-answering

### DIFF
--- a/apps/web/hooks/useRealtimeVoice.ts
+++ b/apps/web/hooks/useRealtimeVoice.ts
@@ -89,7 +89,7 @@ export function useRealtimeVoice(
         item: {
           type: "message",
           role: "system",
-          content: [{ type: "text", text }],
+          content: [{ type: "input_text", text }],
         },
       })
     );

--- a/apps/web/lib/prompts.ts
+++ b/apps/web/lib/prompts.ts
@@ -70,7 +70,7 @@ export function buildBehavioralSystemPrompt(
   // Resume context
   if (config.resume_text?.trim()) {
     sections.push(
-      `The candidate's resume is provided below. Reference their specific experience, projects, and achievements when asking follow-up questions. This makes the interview feel more realistic and personalized.\n\n--- RESUME ---\n${config.resume_text.trim().slice(0, 3000)}\n--- END RESUME ---`
+      `The candidate's resume is provided below for context ONLY. Use it to ask targeted follow-up questions about their experience. CRITICAL: You are the interviewer — NEVER answer questions on the candidate's behalf. NEVER speak as the candidate. NEVER paraphrase or recite the candidate's experience as if you lived it. Your ONLY role is to ask questions and probe deeper. If the candidate gives a vague answer, ask them to elaborate — do NOT fill in details from the resume yourself.\n\n--- RESUME (interviewer reference only) ---\n${config.resume_text.trim().slice(0, 3000)}\n--- END RESUME ---`
     );
   }
 


### PR DESCRIPTION
## Summary
- Fix silence nudge content type from `"text"` to `"input_text"` — the OpenAI Realtime API rejects the former for system messages in `conversation.item.create`, causing random "Invalid value" errors during behavioral interviews
- Strengthen resume injection prompt boundaries to prevent the interviewer from answering its own questions using the candidate's resume content

## Test plan
- [x] Lint, typecheck, 692 unit tests — all pass
- [ ] Manual: start a behavioral session with resume uploaded, wait for silence nudge (~10s) — no API error
- [ ] Manual: verify interviewer asks questions about resume content but never answers them itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)