### PR TITLE
fix(gaze): fetch MediaPipe assets at build time via postinstall

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // MediaPipe WASM JS files (fetched at build time, not source code)
+    "public/mediapipe/**",
   ]),
 ]);
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,8 @@
     "db:push": "drizzle-kit push",
     "test:e2e": "playwright test",
     "test:e2e:smoke": "playwright test --grep @smoke",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "postinstall": "bash scripts/setup-mediapipe.sh"
   },
   "dependencies": {
     "@auth/drizzle-adapter": "^1.11.1",

--- a/apps/web/scripts/setup-mediapipe.sh
+++ b/apps/web/scripts/setup-mediapipe.sh
@@ -14,18 +14,23 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WEB_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-WASM_SRC="$WEB_DIR/node_modules/@mediapipe/tasks-vision/wasm"
 WASM_DEST="$WEB_DIR/public/mediapipe/wasm"
 MODEL_DEST="$WEB_DIR/public/mediapipe/face_landmarker.task"
 MODEL_URL="https://storage.googleapis.com/mediapipe-models/face_landmarker/face_landmarker/float16/1/face_landmarker.task"
 
 echo "Setting up MediaPipe assets..."
 
-# --- WASM files ---
-if [ ! -d "$WASM_SRC" ]; then
-  echo "ERROR: $WASM_SRC not found. Run 'npm install' first." >&2
+# In a monorepo, node_modules may be hoisted to the repo root
+if [ -d "$WEB_DIR/node_modules/@mediapipe/tasks-vision/wasm" ]; then
+  WASM_SRC="$WEB_DIR/node_modules/@mediapipe/tasks-vision/wasm"
+elif [ -d "$WEB_DIR/../../node_modules/@mediapipe/tasks-vision/wasm" ]; then
+  WASM_SRC="$WEB_DIR/../../node_modules/@mediapipe/tasks-vision/wasm"
+else
+  echo "ERROR: @mediapipe/tasks-vision not found in node_modules. Run 'npm install' first." >&2
   exit 1
 fi
+
+# --- WASM files ---
 
 mkdir -p "$WASM_DEST"
 cp -r "$WASM_SRC"/. "$WASM_DEST/"


### PR DESCRIPTION
## Summary
- MediaPipe WASM + model files (~15 MB) are gitignored but were never fetched during
  production builds. Gaze tracking silently failed in deployed environments because
  `public/mediapipe/` was empty.
- Adds `postinstall` script to `package.json` that runs `setup-mediapipe.sh` — this
  fires automatically during `npm install` on Vercel before `next build`.
- Fixes the setup script to find `node_modules` in the hoisted monorepo root.
- Excludes `public/mediapipe/` from ESLint (WASM JS files trigger false positives).

## Test plan
- [x] Lint, typecheck, unit tests — all pass
- [x] `bash scripts/setup-mediapipe.sh` runs successfully and places assets
- [ ] Deploy to Vercel → verify `/mediapipe/face_landmarker.task` returns 200
- [ ] Run a behavioral session with gaze enabled → verify samples appear in `gaze_samples` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)