### PR TITLE
chore(infra): migrate Vercel region from icn1 to syd1

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "regions": ["icn1"],
+  "regions": ["syd1"],
   "crons": [
     {
       "path": "/api/admin/cron/cleanup-sessions",


### PR DESCRIPTION
## Summary

- Switches Vercel functions from `icn1` (Seoul) to `syd1` (Sydney) in `apps/web/vercel.json`
- Pairs with already-completed Supabase Postgres + Upstash Redis moves to `ap-southeast-2` (env vars updated in Vercel dashboard)
- First user base is NZ/AUS — expected TTFB drop from ~200ms+ to ~60–80ms on NZ connections

Refs #152

## Test plan

- [ ] Preview deploy URL loads and region shows `syd1` in response headers (`x-vercel-id`)
- [ ] Sign in with Google works on preview
- [ ] Dashboard renders existing sessions
- [ ] Start a new behavioral session → first question plays
- [ ] Generate feedback on an existing completed session
- [ ] Rapid-fire an API endpoint → 429 after the tier limit (confirms new Upstash Redis is wired)
- [ ] Vercel function logs show no `ECONNREFUSED` / Upstash errors
- [ ] After merge: prod TTFB from NZ dropped meaningfully

## Rollback

Flip `SUPABASE_DB_URL`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN` env vars back to Seoul values and revert this PR. Old Supabase/Upstash resources remain paused for 7 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)