### PR TITLE
chore: pre-public prep — Preploy rename, LICENSE, docs, CI tuning

### DIFF
--- a/.claude/agents/pm-proposer.md
+++ b/.claude/agents/pm-proposer.md
@@ -21,7 +21,7 @@ next. You **do not write code**. You only research and propose.
    Fetch them via:
 
    ```bash
-   gh issue list --repo scy02718/interview-assistant --state open \
+   gh issue list --repo scy02718/preploy --state open \
      --limit 50 --json number,title,labels,body
    ```
 
@@ -29,7 +29,7 @@ next. You **do not write code**. You only research and propose.
    You can fetch a single issue with:
 
    ```bash
-   gh issue view <number> --repo scy02718/interview-assistant --json number,title,labels,body,comments
+   gh issue view <number> --repo scy02718/preploy --json number,title,labels,body,comments
    ```
 
    Rank by label: `priority:high` first, then `priority:medium`, then

--- a/.claude/commands/task.md
+++ b/.claude/commands/task.md
@@ -10,7 +10,7 @@ You are working on task **$ARGUMENTS** from `Tasks.md`.
 1. Open `Tasks.md` and find the entry for `$ARGUMENTS`.
 2. Read the full story description, acceptance criteria, and any sub-tasks.
 3. If the story references a GitHub Issue number, fetch it via
-   `gh issue view <n> --repo scy02718/interview-assistant` for historical context.
+   `gh issue view <n> --repo scy02718/preploy` for historical context.
 4. If `$ARGUMENTS` is empty or ambiguous, list the next 3 unstarted tasks from
    `Tasks.md` and ask the user which one to pick up.
 

--- a/.claude/hooks/precommit-gate.sh
+++ b/.claude/hooks/precommit-gate.sh
@@ -29,10 +29,10 @@ fi
 
 filters=()
 if echo "$changed" | grep -q '^apps/web/'; then
-  filters+=("--filter=@interview-assistant/web")
+  filters+=("--filter=@preploy/web")
 fi
 if echo "$changed" | grep -q '^packages/shared/'; then
-  filters+=("--filter=@interview-assistant/shared")
+  filters+=("--filter=@preploy/shared")
 fi
 
 # If turbo is not installed locally yet (fresh clone), skip silently.

--- a/.claude/skills/github-issues/SKILL.md
+++ b/.claude/skills/github-issues/SKILL.md
@@ -15,7 +15,7 @@ Trigger on any of:
 - "track this in GitHub" / "add this to the backlog"
 - The user describes multi-step work and the repo tracks work in GitHub Issues.
 
-Default target repo for this project: **`scy02718/interview-assistant`** (confirm if unsure).
+Default target repo for this project: **`scy02718/preploy`** (confirm if unsure).
 
 ## Workflow
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   NODE_VERSION: "20"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test
-          POSTGRES_DB: interview_assistant_test
+          POSTGRES_DB: preploy_test
         ports:
           - 5433:5432
         options: >-
@@ -96,7 +96,7 @@ jobs:
       - name: Run integration tests
         working-directory: apps/web
         env:
-          TEST_DATABASE_URL: postgresql://test:test@localhost:5433/interview_assistant_test
+          TEST_DATABASE_URL: postgresql://test:test@localhost:5433/preploy_test
         run: npm run test:integration
 
   e2e:
@@ -110,7 +110,7 @@ jobs:
         env:
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test
-          POSTGRES_DB: interview_assistant_test
+          POSTGRES_DB: preploy_test
         ports:
           - 5433:5432
         options: >-
@@ -155,14 +155,14 @@ jobs:
       - name: Apply database migrations
         working-directory: apps/web
         env:
-          SUPABASE_DB_URL: postgresql://test:test@localhost:5433/interview_assistant_test
+          SUPABASE_DB_URL: postgresql://test:test@localhost:5433/preploy_test
         run: npm run db:migrate
 
       - name: Build Next.js app
         working-directory: apps/web
         env:
-          SUPABASE_DB_URL: postgresql://test:test@localhost:5433/interview_assistant_test
-          TEST_DATABASE_URL: postgresql://test:test@localhost:5433/interview_assistant_test
+          SUPABASE_DB_URL: postgresql://test:test@localhost:5433/preploy_test
+          TEST_DATABASE_URL: postgresql://test:test@localhost:5433/preploy_test
           AUTH_SECRET: dummy-auth-secret-for-ci-only
           AUTH_URL: http://localhost:3000
         run: npm run build
@@ -170,8 +170,8 @@ jobs:
       - name: Run E2E smoke tests
         working-directory: apps/web
         env:
-          TEST_DATABASE_URL: postgresql://test:test@localhost:5433/interview_assistant_test
-          SUPABASE_DB_URL: postgresql://test:test@localhost:5433/interview_assistant_test
+          TEST_DATABASE_URL: postgresql://test:test@localhost:5433/preploy_test
+          SUPABASE_DB_URL: postgresql://test:test@localhost:5433/preploy_test
           AUTH_SECRET: dummy-auth-secret-for-ci-only
           AUTH_URL: http://localhost:3000
           PLAYWRIGHT_BASE_URL: http://localhost:3000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ its acceptance criteria. When the task is complete, update `Tasks.md` to mark
 it done.
 
 When asked about a **new feature idea** or tech debt, check open GitHub Issues
-first (use the GitHub MCP or `gh issue list --repo scy02718/interview-assistant`)
+first (use the GitHub MCP or `gh issue list --repo scy02718/preploy`)
 to see whether it is already filed.
 
 `Backlog.md` is archived at `dev_logs/Backlog-archive.md` — new tech debt and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,29 @@ stays clean, the gate stays consistent across stories, and `pr-reviewer`
 cannot be accidentally skipped because you already "saw" the diff. Manual
 orchestration must still follow the same sequence `/standup` enforces.
 
+### Delegation rule — use cheap subagents for bulk/repetitive work
+
+Running large greps, sweeping docs, auditing many files, or applying the
+same edit across dozens of files directly in the main conversation burns
+tokens fast. **Delegate these to the `Explore` or `general-purpose`
+subagent on a cheaper model:**
+
+- **Haiku** — default for pure discovery: secret scans, ref-usage audits,
+  file-pattern sweeps, staleness checks, "find all X" tasks.
+- **Sonnet** — when the work also requires reasoning or writing quality
+  prose/code: doc rewrites, bulk rename-with-judgment edits, summarizing
+  findings for a human reader.
+- **Opus** — only for the main conversation's own decisions and
+  orchestration, not for grep work.
+
+When to skip delegation: quick targeted lookups (1–2 greps in a known
+file) are faster inline. The rule kicks in for anything touching >5 files,
+sweeping git history, or reading files end-to-end.
+
+Parallelize independent scans in a single message (multiple `Agent` tool
+calls in the same turn). Ask subagents for **structured reports**, not
+raw output — the summary is what comes back to main context.
+
 ## Database schema changes
 
 When modifying `apps/web/lib/schema.ts`, always use versioned migrations:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,33 +46,6 @@ integration suite (it would need Docker and is too slow for a per-turn
 check), so you should still run `cd apps/web && npm run test:integration`
 manually before pushing.
 
-## E2E smoke tests
-
-`apps/web/e2e/` contains Playwright smoke tests for golden paths (landing,
-auth, dashboard, interview setup, profile).  These run against a production
-build — NOT `next dev`.
-
-- Extend only for **new top-level user flows** (golden paths).
-- **Bug repros and edge cases** go in integration tests, not E2E.
-- Tag every test with `@smoke` so CI selects it with `--grep @smoke`.
-- Auth state is pre-minted by `e2e/global.setup.ts` and stored in
-  `e2e/.auth/user.json` (gitignored).
-
-See `apps/web/README.md` → "E2E tests" for local run instructions.
-
-## Skills available in this repo
-
-The skills below live in `.claude/skills/` and trigger automatically when
-relevant. You don't need to invoke them by name.
-
-- **`webapp-testing`** — Playwright browser testing. Use whenever you need to
-  click through the running web app, verify rendered UI, or capture screenshots.
-- **`claude-api`** — Anthropic SDK reference. Use only when a story explicitly
-  asks to add or modify Claude API calls. The web app currently uses OpenAI;
-  do not silently swap providers.
-- **`skill-creator`** — Use only when the user asks to create or improve a
-  project-specific skill.
-
 ## Subagents (the autonomous-loop roles)
 
 The `.claude/agents/` directory holds specialized roles:
@@ -151,12 +124,9 @@ git add apps/web/drizzle/   # the whole directory, never individual files
 
 - Conventional Commits style (`feat:`, `fix:`, `chore:`, `refactor:`, `docs:`).
 - Branch naming: `feature/{story-number}-{short-description}` for feature work.
-- Never use `console.log` in server-side code (Next.js API routes). See the
-  per-app CLAUDE.md for the structured logger pattern.
-- Never commit secrets or files containing them (`.env`, `credentials.json`).
 - Before pushing to any branch, verify its PR is not already merged or closed
   (`gh pr list --state merged --head <branch>`). If it is, create a fresh
-  branch from `main` instead.
+  branch from `main` instead — burned us multiple times.
 
 ## graphify
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2026 scy02718. All rights reserved.
+Copyright (c) 2026 Chan Yoo. All rights reserved.
 
 This source code is made publicly viewable on GitHub for transparency and
 reference purposes only. Viewing the source does not grant any license or

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2026 scy02718. All rights reserved.
+
+This source code is made publicly viewable on GitHub for transparency and
+reference purposes only. Viewing the source does not grant any license or
+right to use, reproduce, modify, distribute, sublicense, or create derivative
+works based on this project, in whole or in part.
+
+No part of this repository — including but not limited to source code,
+documentation, design assets, database schemas, and configuration — may be
+copied, modified, redistributed, or used to build a competing product or
+service without the prior written permission of the copyright holder.
+
+Contributions submitted to this repository (e.g. via pull request) are
+licensed to the copyright holder under the same terms, unless a separate
+written agreement states otherwise.
+
+For licensing inquiries, contact: scy02718@gmail.com
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY
+ARISING FROM THE USE OF THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,143 +1,109 @@
-# Preploy
+# Preploy — Interview Assistant
 
-AI-powered mock interview practice with real-time feedback. Practice behavioral and technical interviews, get scored by AI, and track your improvement over time. Deploy yourself.
+Practice mock interviews with AI. Get scored, track progress, get hired.
 
-**Two interview modes:**
-- **Behavioral** — Voice-to-voice mock interview with real-time AI conversation and STAR-method feedback
-- **Technical** — Split-panel coding session with Monaco editor, problem generation, mic recording for verbal explanations, and code + speech analysis
+## Features
 
-## Project Structure
+- **Behavioral interviews** — Voice-to-voice mock sessions with real-time AI conversation, STAR-method coaching, and scored feedback on structure and delivery
+- **Technical interviews** — Split-panel coding sessions with Monaco editor, problem statements, mic recording for verbal explanations, and AI feedback on correctness and approach
+- **Progress tracking** — Per-session feedback, trend charts, and a coaching hub that breaks down weak areas across behavioral, technical, and communication dimensions
+- **STAR practice** — Standalone STAR-method story builder for structuring behavioral answers
+- **Interview planner** — Session planning and preparation tooling
+- **Resume builder** — Resume editing integrated into the prep workflow
+- **Achievements** — Progress milestones to keep motivation high
+- **Optional gaze tracking** — MediaPipe Face Landmarker measures eye contact and presence during behavioral sessions (opt-in; all processing runs locally in-browser, nothing is sent to a server)
 
-Turborepo monorepo:
+## Tech stack
+
+Next.js 16 (App Router) • React 19 • TypeScript • Drizzle ORM + Supabase Postgres • NextAuth v5 (Google OAuth) • OpenAI • Upstash Redis (rate limiting) • Stripe (billing) • Tailwind v4 + shadcn/ui • Vitest + Playwright • Vercel (Sydney region)
+
+Monorepo managed by [Turborepo](https://turbo.build/):
 
 ```
 apps/
-  web/          Next.js 16 frontend + API routes (Drizzle ORM, Supabase Postgres)
+  web/              Next.js 16 app (frontend + API routes)
 packages/
-  shared/       Shared TypeScript types, constants, and schemas
+  shared/           Shared TypeScript types + constants
 ```
 
-## Prerequisites
-
-- **Node.js 20+** and **npm**
-- **Docker** (for local integration tests)
-- A [Supabase](https://supabase.com) account (free tier works)
-- An [OpenAI](https://platform.openai.com) API key
-- Google OAuth credentials (for login via NextAuth)
-
-## Setup
-
-### 1. Install dependencies
+## Quickstart
 
 ```bash
-npm install
+git clone https://github.com/scy02718/interview-assistant.git
+cd interview-assistant
+npm install                  # also runs scripts/setup-mediapipe.sh via postinstall
+cp apps/web/.env.local.example apps/web/.env.local
+# fill in required env vars (see below)
+npm run dev
 ```
 
-### 2. Configure environment variables
+Open http://localhost:3000.
+
+The `postinstall` script fetches MediaPipe WASM files and the face landmarker model into `apps/web/public/mediapipe/`. If you do not need gaze tracking locally, that step is harmless to skip — the feature is opt-in and the rest of the app works without it.
+
+## Environment variables
+
+**Minimum to boot locally:**
+
+| Variable | Purpose |
+|---|---|
+| `SUPABASE_DB_URL` | Postgres connection string for Drizzle. Use the Supabase Session pooler (port 5432). |
+| `AUTH_SECRET` | NextAuth v5 session signing secret. Generate with `openssl rand -base64 32`. |
+| `AUTH_URL` | Public URL of the app — `http://localhost:3000` for local dev. |
+| `GOOGLE_CLIENT_ID` | Google OAuth client ID (Google Cloud Console → Credentials). |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret. |
+| `OPENAI_API_KEY` | OpenAI API key for question generation, code analysis, and feedback. |
+
+**Optional (needed for billing, rate limiting, email, and error tracking):**
+
+| Variable | Purpose |
+|---|---|
+| `UPSTASH_REDIS_REST_URL` | Upstash Redis URL for rate limiting. Falls back to in-memory limiter when unset (fine for dev, not for prod). |
+| `UPSTASH_REDIS_REST_TOKEN` | Upstash Redis token. |
+| `STRIPE_SECRET_KEY` | Stripe secret key for Pro-plan billing. |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret (from `stripe listen`). |
+| `STRIPE_PRO_PRICE_ID` | Stripe Price ID for the monthly Pro plan. |
+| `STRIPE_PRO_PRICE_ID_ANNUAL` | Stripe Price ID for the annual Pro plan. |
+| `SENTRY_DSN` | Server-side Sentry DSN (leave blank to disable). |
+| `NEXT_PUBLIC_SENTRY_DSN` | Client-side Sentry DSN. |
+| `NEXT_PUBLIC_BASE_URL` | Canonical origin used for sitemap, robots, and OG tags. Defaults to `https://preploy.tech`. |
+| `RESEND_API_KEY` | Resend API key for transactional email. Emails are silently skipped when unset. |
+
+Full env reference (classifications, Docker wiring, Stripe setup): [`apps/web/README.md`](apps/web/README.md#environment-variables).
+
+## Development
+
+Run the full check suite before pushing:
 
 ```bash
-cp .env.example .env
+npx turbo lint typecheck test           # ESLint + tsc + unit/component tests
+cd apps/web && npm run test:integration # Integration tests (requires Docker)
+cd apps/web && npm run test:e2e:smoke   # Playwright E2E smoke suite
 ```
 
-Fill in your `.env` (or copy `apps/web/.env.local.example` → `apps/web/.env.local` for local-only overrides). The full env table with classifications lives in [`apps/web/README.md`](apps/web/README.md#environment-variables) — this is the minimum to get a dev server running:
-
-| Variable | Where to get it |
-|----------|----------------|
-| `SUPABASE_DB_URL` | Supabase dashboard → Settings → Database → Connection string → URI (use the **Session pooler** on port 5432 for local; works for both build-time migrations and runtime queries) |
-| `OPENAI_API_KEY` | [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |
-| `GOOGLE_CLIENT_ID` | [Google Cloud Console](https://console.cloud.google.com/apis/credentials) → OAuth 2.0 Client |
-| `GOOGLE_CLIENT_SECRET` | Same as above |
-| `AUTH_SECRET` | Generate with `openssl rand -base64 32` |
-| `AUTH_URL` | `http://localhost:3000` for local dev; your deployed domain in prod |
-| `AUTH_TRUST_HOST` | `true` — required when running outside Vercel (Docker, Fly.io, self-hosted) so NextAuth accepts the request host. Optional on Vercel. |
-| `NEXT_PUBLIC_BASE_URL` | `http://localhost:3000` for local dev. Used for canonical tags, sitemap, robots.txt, and OG image URLs. |
-| `STRIPE_SECRET_KEY` | Stripe Dashboard → Developers → API keys → Secret key (`sk_test_...` for test mode) |
-| `STRIPE_WEBHOOK_SECRET` | Output of `stripe listen --forward-to localhost:3000/api/billing/webhook` |
-| `STRIPE_PRO_PRICE_ID` | Stripe Dashboard → Products → Preploy Pro → Pricing → ⋯ → Copy ID (starts with `price_`, **not** `prod_`) |
-| `SENTRY_DSN` | [sentry.io](https://sentry.io) → Project Settings → Client Keys (optional — leave blank to disable Sentry) |
-| `NEXT_PUBLIC_SENTRY_DSN` | Same as `SENTRY_DSN` (needed for client-side error capture) |
-
-> Note: there is no longer a `SUPABASE_URL` or `SUPABASE_ANON_KEY` — Drizzle talks directly to Postgres via `SUPABASE_DB_URL`, and we don't use the Supabase client SDK in `apps/web`.
-
-### 3. Run database migrations
+Integration tests and E2E smoke tests require a local Postgres container:
 
 ```bash
-cd apps/web && npm run db:migrate
+docker compose --profile test up -d test-db
 ```
 
-> **For schema changes:** Edit `lib/schema.ts`, then run `npm run db:generate` to create a versioned SQL migration file. Commit the generated file in `drizzle/`. See CLAUDE.md for the full workflow.
+Detailed test docs: [`apps/web/README.md`](apps/web/README.md).
 
-### 4. Start development
-
-```bash
-npm run dev   # starts Next.js on :3000
-```
-
-## CI Pipeline
-
-Every push to `main` and every pull request runs the full CI pipeline via GitHub Actions:
+## Project structure
 
 ```
-lint-typecheck → unit-tests         → build
-               → integration-tests  ↗
+apps/
+  web/              Next.js 16 app (frontend + API routes)
+packages/
+  shared/           Shared TypeScript types + constants
+.github/workflows/  CI pipeline (lint, typecheck, unit, integration, E2E, build)
+dev_logs/           Archived design docs (e.g. parked AWS migration)
 ```
 
-| Job | What it runs |
-|-----|-------------|
-| **lint-typecheck** | ESLint (web) + `tsc --noEmit` |
-| **unit-tests** | Vitest unit/component tests |
-| **integration-tests** | Integration tests against a real Postgres service container |
-| **build** | `next build` production build |
+## Contributing
 
-No real API keys or secrets are needed — the pipeline uses dummy env vars from `.env.ci` and a Postgres container spun up automatically by GitHub Actions.
+This is a solo-maintained project, but bug reports and PRs are welcome. [Open an issue](https://github.com/scy02718/interview-assistant/issues) or fork and submit a PR against `main`.
 
-## Running Tests
+## License
 
-### Unit Tests (no Docker needed)
-
-```bash
-turbo test                           # All unit tests
-
-cd apps/web && npm test              # Web unit tests only
-
-cd apps/web && npm run test:coverage # Web unit tests with coverage
-```
-
-### Integration Tests (requires Docker)
-
-Integration tests run against a real PostgreSQL database in Docker. Only `auth()` is mocked — all database queries are real, matching production behavior exactly.
-
-```bash
-# 1. Start the test database (stays running between test runs)
-docker compose up -d test-db
-
-# 2. Run integration tests
-cd apps/web && npm run test:integration
-
-# 3. When done for the day
-docker compose down
-```
-
-The test database:
-- Postgres 16 on **port 5433** (won't conflict with local Postgres on 5432)
-- Uses **tmpfs** (RAM disk) — fast, no data persists after container stops
-- Schema is **wiped and re-migrated** automatically each test run via `tests/global-setup.ts`
-
-### Where to Put Tests
-
-| Type | Location | Naming |
-|---|---|---|
-| Web unit tests | Next to the source file | `*.test.ts` / `*.test.tsx` |
-| Web integration tests | Next to the route handler | `*.integration.test.ts` |
-| Test DB helpers | `apps/web/tests/` | Shared setup/cleanup utilities |
-
-### Writing New Tests
-
-**Unit tests** — for pure logic (`lib/`, `services/`, `stores/`, utils):
-- Create `myfile.test.ts` next to `myfile.ts`
-- Import from vitest: `import { describe, it, expect } from "vitest"`
-
-**Integration tests** — for API routes that touch the database:
-- Create `route.integration.test.ts` next to `route.ts`
-- Mock `@/lib/auth` for auth simulation, mock `@/lib/db` to point at `getTestDb()` from `tests/setup-db.ts`
-- Use `beforeAll` to seed test users, `beforeEach` to clean data between tests
+See [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ This is a solo-maintained project, but bug reports and PRs are welcome. [Open an
 
 ## License
 
-See [LICENSE](./LICENSE).
+All rights reserved. This source is publicly viewable for reference only — it is not open source and may not be copied, redistributed, or used to build a competing product. See [LICENSE](./LICENSE) for full terms.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Preploy — Interview Assistant
+# Preploy
 
 Practice mock interviews with AI. Get scored, track progress, get hired.
 
@@ -29,8 +29,8 @@ packages/
 ## Quickstart
 
 ```bash
-git clone https://github.com/scy02718/interview-assistant.git
-cd interview-assistant
+git clone https://github.com/scy02718/preploy.git
+cd preploy
 npm install                  # also runs scripts/setup-mediapipe.sh via postinstall
 cp apps/web/.env.local.example apps/web/.env.local
 # fill in required env vars (see below)
@@ -102,7 +102,7 @@ dev_logs/           Archived design docs (e.g. parked AWS migration)
 
 ## Contributing
 
-This is a solo-maintained project, but bug reports and PRs are welcome. [Open an issue](https://github.com/scy02718/interview-assistant/issues) or fork and submit a PR against `main`.
+This is a solo-maintained project, but bug reports and PRs are welcome. [Open an issue](https://github.com/scy02718/preploy/issues) or fork and submit a PR against `main`.
 
 ## License
 

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -5,13 +5,7 @@ covers monorepo-wide rules (Tasks.md workflow, pre-commit checklist).
 
 ## Stack
 
-- Next.js 16 (App Router) + React 19
-- Drizzle ORM + Postgres (`postgres` driver)
-- NextAuth v5 (`@/lib/auth`)
-- Vitest + Testing Library + jsdom for unit/component tests
-- Vitest + real Docker Postgres for integration tests
-- Tailwind v4 + shadcn/ui components
-- Pino structured logging (`@/lib/logger`)
+Next.js 16 (App Router) + React 19 · Drizzle ORM + Postgres (`postgres` driver) · NextAuth v5 (`@/lib/auth`) · Tailwind v4 + shadcn/ui · Vitest (+ jsdom for unit/component, real Docker Postgres for integration) · Pino structured logging (`@/lib/logger`).
 
 ## API routes
 
@@ -87,19 +81,11 @@ twice (PRs #52, #53).
 - [ ] For nested widgets that fetch their own data (e.g., `MonthlyUsageMeter`), the widget owns its own internal skeleton — the parent doesn't need to know about it.
 - [ ] Use `animate-pulse rounded bg-muted` divs sized to match the eventual content. Don't use empty `<Card />` shells without inner placeholders — they look broken.
 
-## Styling
-
-- Tailwind v4 + shadcn/ui (`Card`, `CardHeader`, `CardTitle`, `CardContent`).
-- Dark mode: use `dark:` variants for custom colors.
-- Score colors: `getScoreColor()` from `@/lib/utils`.
-
 ## Tests
 
 ### Unit tests (`lib/*.test.ts`)
 
-- Co-locate next to the source file (e.g., `lib/prompts.test.ts`).
-- Target 80%+ line coverage on `lib/`, `services/`, `stores/`.
-- Cover happy path, edge cases, error cases, boundary values, empty/null inputs.
+Co-locate next to source. Cover happy path + edge/error cases.
 
 ### E2E tests (`e2e/*.spec.ts`)
 
@@ -149,37 +135,7 @@ The only things you may mock:
 - External APIs (OpenAI, Anthropic, etc.)
 - `@/lib/db` — pointed at `getTestDb()` from `tests/setup-db.ts` (this is *redirection*, not mocking)
 
-**Standard template:**
-
-```typescript
-import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
-import { NextRequest } from "next/server";
-import { cleanupTestDb, teardownTestDb, getTestDb } from "../../../../tests/setup-db";
-import { users } from "@/lib/schema";
-
-const mockAuth = vi.fn();
-vi.mock("@/lib/auth", () => ({ auth: () => mockAuth() }));
-vi.mock("@/lib/db", () => ({ get db() { return getTestDb(); } }));
-
-import { GET, POST } from "./route";
-
-const TEST_USER = {
-  id: "00000000-0000-0000-0000-000000000001",
-  email: "test@example.com",
-  name: "Test User",
-};
-
-describe("API /api/your-route (integration)", () => {
-  beforeAll(async () => { /* seed users */ });
-  beforeEach(async () => { vi.clearAllMocks(); /* clean tables */ });
-  afterAll(async () => { await cleanupTestDb(); await teardownTestDb(); });
-
-  it("returns 401 when unauthenticated", async () => { /* ... */ });
-  it("returns 404 for another user's resource", async () => { /* ... */ });
-  it("returns 400 for invalid input", async () => { /* ... */ });
-  it("happy path returns correct data", async () => { /* ... */ });
-});
-```
+For the standard template, copy any existing `app/api/**/*.integration.test.ts` — they all follow the same shape (mock auth + db, seed users in `beforeAll`, clean tables in `beforeEach`, teardown in `afterAll`).
 
 ### Integration test checklist (mandatory for every route change)
 
@@ -196,16 +152,4 @@ When modifying an existing route, **always re-read** its integration test file f
 
 ## Logging
 
-```ts
-import { createRequestLogger } from "@/lib/logger";
-const log = createRequestLogger({ route: "POST /api/example", userId });
-log.info("processing request");
-log.error({ err }, "something failed");
-```
-
-Client-side `console.error` is fine — Pino doesn't run in the browser.
-
-## Skills available in this project
-
-- **`webapp-testing`** — Playwright for browser tests. Use this when asked to "click through", "exercise the UI", or "verify the avatar renders". Prefer this over writing component tests for Three.js or animation-heavy code.
-- **`claude-api`** — reference this only if the story touches Anthropic SDK code. The web app currently uses OpenAI; do not "convert" OpenAI calls to Anthropic without explicit instruction.
+Server-side: use `createRequestLogger({ route, userId })` from `@/lib/logger` — never `console.log`. Client-side `console.error` is fine (Pino doesn't run in the browser).

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,6 +1,6 @@
 > `apps/web` — the Next.js app in the Preploy monorepo. Start with the [root README](../../README.md) for project overview, stack, and setup. This file covers app-level topics: E2E tests, gaze tracking, billing, local Docker.
 
-# @interview-assistant/web
+# @preploy/web
 
 Next.js 16 (App Router) application for Preploy — AI-powered mock interview
 practice. See the root `CLAUDE.md` and `apps/web/CLAUDE.md` for coding

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,3 +1,5 @@
+> `apps/web` — the Next.js app in the Preploy monorepo. Start with the [root README](../../README.md) for project overview, stack, and setup. This file covers app-level topics: E2E tests, gaze tracking, billing, local Docker.
+
 # @interview-assistant/web
 
 Next.js 16 (App Router) application for Preploy — AI-powered mock interview
@@ -63,18 +65,18 @@ to require E2E (tracked as a follow-up task after #41 merges).
 
 The gaze capture pipeline uses MediaPipe Face Landmarker, which requires WASM
 runtime files and a model weight file served from `public/mediapipe/`. These are
-**not** committed to git (they're ~15 MB of binaries). Run the setup script
-after `npm install`:
+**not** committed to git (they're ~15 MB of binaries).
+
+`scripts/setup-mediapipe.sh` runs automatically on `npm install` via the
+`postinstall` hook — you do not need to run it manually. It copies WASM files
+from `node_modules/@mediapipe/tasks-vision/wasm/` and downloads
+`face_landmarker.task` from Google's model storage. The files land in
+`public/mediapipe/` which is gitignored. Re-run the script manually only if you
+delete `public/mediapipe/`:
 
 ```bash
-cd apps/web
 bash scripts/setup-mediapipe.sh
 ```
-
-This copies WASM files from `node_modules/@mediapipe/tasks-vision/wasm/` and
-downloads `face_landmarker.task` from Google's model storage. The files land in
-`public/mediapipe/` which is gitignored. You only need to run this once (or
-after deleting `public/mediapipe/`).
 
 If you don't need gaze tracking locally, you can skip this step — the feature is
 opt-in and the app works without it.

--- a/apps/web/app/coaching/technical/page.tsx
+++ b/apps/web/app/coaching/technical/page.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/coaching/TechnicalFormatCarousel";
 import { usePrefillStore } from "@/stores/prefillStore";
 import { useRouter } from "next/navigation";
-import type { TechnicalInterviewType } from "@interview-assistant/shared";
+import type { TechnicalInterviewType } from "@preploy/shared";
 
 function Section({
   title,

--- a/apps/web/app/interview/behavioral/session/page.tsx
+++ b/apps/web/app/interview/behavioral/session/page.tsx
@@ -7,7 +7,7 @@ import { useRealtimeVoice } from "@/hooks/useRealtimeVoice";
 import { useGazeCapture } from "@/hooks/useGazeCapture";
 import { buildBehavioralSystemPrompt } from "@/lib/prompts";
 import { BEHAVIORAL_SESSION_MAX_DURATION_SECONDS } from "@/lib/plans";
-import type { BehavioralSessionConfig } from "@interview-assistant/shared";
+import type { BehavioralSessionConfig } from "@preploy/shared";
 import { VideoCallLayout } from "@/components/interview/VideoCallLayout";
 import { SessionControls } from "@/components/interview/SessionControls";
 

--- a/apps/web/app/interview/technical/session/page.tsx
+++ b/apps/web/app/interview/technical/session/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { useInterviewStore } from "@/stores/interviewStore";
 import { useAudioRecorder } from "@/hooks/useAudioRecorder";
 import { useCodeSnapshots } from "@/hooks/useCodeSnapshots";
-import type { TechnicalSessionConfig } from "@interview-assistant/shared";
+import type { TechnicalSessionConfig } from "@preploy/shared";
 import { TechnicalSessionLayout } from "@/components/interview/TechnicalSessionLayout";
 import {
   ProblemDescription,

--- a/apps/web/components/coaching/ComingSoon.tsx
+++ b/apps/web/components/coaching/ComingSoon.tsx
@@ -16,7 +16,7 @@ export function ComingSoon({ title, issue }: ComingSoonProps) {
         <p className="text-xs">
           Tracked in{" "}
           <a
-            href={`https://github.com/scy02718/interview-assistant/issues/${issue.replace("#", "")}`}
+            href={`https://github.com/scy02718/preploy/issues/${issue.replace("#", "")}`}
             target="_blank"
             rel="noopener noreferrer"
             className="underline hover:text-foreground"

--- a/apps/web/components/editor/EditorToolbar.tsx
+++ b/apps/web/components/editor/EditorToolbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SUPPORTED_LANGUAGES } from "@interview-assistant/shared";
+import { SUPPORTED_LANGUAGES } from "@preploy/shared";
 import { RotateCcw } from "lucide-react";
 
 interface EditorToolbarProps {

--- a/apps/web/components/interview/BehavioralSetupForm.tsx
+++ b/apps/web/components/interview/BehavioralSetupForm.tsx
@@ -14,7 +14,7 @@ import { TemplateControls } from "./TemplateControls";
 import { ResumeSelector } from "./ResumeSelector";
 import { UpgradePromptDialog } from "@/components/billing/UpgradePromptDialog";
 import { usePrefillStore } from "@/stores/prefillStore";
-import type { BehavioralSessionConfig } from "@interview-assistant/shared";
+import type { BehavioralSessionConfig } from "@preploy/shared";
 
 interface CompanyQuestion {
   question: string;

--- a/apps/web/components/interview/TechnicalSetupForm.tsx
+++ b/apps/web/components/interview/TechnicalSetupForm.tsx
@@ -23,12 +23,12 @@ import { UpgradePromptDialog } from "@/components/billing/UpgradePromptDialog";
 import {
   SUPPORTED_LANGUAGES,
   FOCUS_AREAS_BY_TYPE,
-} from "@interview-assistant/shared";
+} from "@preploy/shared";
 import type {
   TechnicalSessionConfig,
   TechnicalInterviewType,
   Difficulty,
-} from "@interview-assistant/shared";
+} from "@preploy/shared";
 
 /** Prefix used to embed the user's Other topic inside additional_instructions. */
 const OTHER_PREFIX = "Other focus area: ";

--- a/apps/web/e2e/global.setup.ts
+++ b/apps/web/e2e/global.setup.ts
@@ -33,7 +33,7 @@ const AUTH_SECRET =
 const DB_URL =
   process.env.TEST_DATABASE_URL ??
   process.env.SUPABASE_DB_URL ??
-  "postgresql://test:test@localhost:5433/interview_assistant_test";
+  "postgresql://test:test@localhost:5433/preploy_test";
 
 // Cookie name for non-HTTPS origins (NextAuth v5 default)
 const SESSION_COOKIE_NAME = "authjs.session-token";

--- a/apps/web/hooks/useCodeSnapshots.ts
+++ b/apps/web/hooks/useCodeSnapshots.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useCallback, useEffect } from "react";
-import type { CodeEventType } from "@interview-assistant/shared";
+import type { CodeEventType } from "@preploy/shared";
 import { getBoilerplate } from "@/lib/code-templates";
 
 interface CodeSnapshot {

--- a/apps/web/lib/prompts-technical.test.ts
+++ b/apps/web/lib/prompts-technical.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildProblemGenerationPrompt } from "./prompts-technical";
-import type { TechnicalSessionConfig } from "@interview-assistant/shared";
+import type { TechnicalSessionConfig } from "@preploy/shared";
 
 const baseConfig: TechnicalSessionConfig = {
   interview_type: "leetcode",

--- a/apps/web/lib/prompts-technical.ts
+++ b/apps/web/lib/prompts-technical.ts
@@ -1,4 +1,4 @@
-import type { TechnicalSessionConfig } from "@interview-assistant/shared";
+import type { TechnicalSessionConfig } from "@preploy/shared";
 
 const INTERVIEW_TYPE_LABELS: Record<string, string> = {
   leetcode: "LeetCode-style coding problem",

--- a/apps/web/lib/prompts.test.ts
+++ b/apps/web/lib/prompts.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildBehavioralSystemPrompt } from "./prompts";
-import type { BehavioralSessionConfig } from "@interview-assistant/shared";
+import type { BehavioralSessionConfig } from "@preploy/shared";
 
 const DEFAULT_CONFIG: BehavioralSessionConfig = {
   interview_style: 0.5,

--- a/apps/web/lib/prompts.ts
+++ b/apps/web/lib/prompts.ts
@@ -1,4 +1,4 @@
-import type { BehavioralSessionConfig } from "@interview-assistant/shared";
+import type { BehavioralSessionConfig } from "@preploy/shared";
 
 export function buildBehavioralSystemPrompt(
   config: BehavioralSessionConfig

--- a/apps/web/lib/transcription.ts
+++ b/apps/web/lib/transcription.ts
@@ -1,4 +1,4 @@
-import type { TranscriptEntry } from "@interview-assistant/shared";
+import type { TranscriptEntry } from "@preploy/shared";
 
 interface WordTimestamp {
   word: string;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@interview-assistant/web",
+  "name": "@preploy/web",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -23,7 +23,7 @@
   "dependencies": {
     "@auth/drizzle-adapter": "^1.11.1",
     "@base-ui/react": "^1.3.0",
-    "@interview-assistant/shared": "*",
+    "@preploy/shared": "*",
     "@mediapipe/tasks-vision": "^0.10.34",
     "@monaco-editor/react": "^4.7.0",
     "@react-pdf/renderer": "^4.4.1",

--- a/apps/web/stores/interviewStore.ts
+++ b/apps/web/stores/interviewStore.ts
@@ -6,7 +6,7 @@ import type {
   InterviewType,
   SessionStatus,
   TranscriptEntry,
-} from "@interview-assistant/shared";
+} from "@preploy/shared";
 
 /** Set on the store when POST /api/sessions returns 402 free_tier_limit_reached. */
 export interface QuotaError {

--- a/apps/web/stores/prefillStore.ts
+++ b/apps/web/stores/prefillStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { TechnicalInterviewType } from "@interview-assistant/shared";
+import type { TechnicalInterviewType } from "@preploy/shared";
 
 interface PrefillState {
   /** Pre-fill data for behavioral setup */

--- a/apps/web/tests/global-setup.ts
+++ b/apps/web/tests/global-setup.ts
@@ -5,7 +5,7 @@ import path from "path";
 
 const TEST_DB_URL =
   process.env.TEST_DATABASE_URL ??
-  "postgresql://test:test@localhost:5433/interview_assistant_test";
+  "postgresql://test:test@localhost:5433/preploy_test";
 
 export async function setup() {
   const client = postgres(TEST_DB_URL, { prepare: false, max: 1 });

--- a/apps/web/tests/setup-db.ts
+++ b/apps/web/tests/setup-db.ts
@@ -4,7 +4,7 @@ import * as schema from "../lib/schema";
 
 const TEST_DB_URL =
   process.env.TEST_DATABASE_URL ??
-  "postgresql://test:test@localhost:5433/interview_assistant_test";
+  "postgresql://test:test@localhost:5433/preploy_test";
 
 let client: ReturnType<typeof postgres> | null = null;
 

--- a/dev_logs/Backlog-archive.md
+++ b/dev_logs/Backlog-archive.md
@@ -1,4 +1,4 @@
-> **Archived 2026-04-14.** This file is frozen. All items migrated to GitHub Issues — see https://github.com/scy02718/interview-assistant/issues. File new tech debt as issues, not here.
+> **Archived 2026-04-14.** This file is frozen. All items migrated to GitHub Issues — see https://github.com/scy02718/preploy/issues. File new tech debt as issues, not here.
 
 # Backlog
 
@@ -109,7 +109,7 @@ Use the `sessionType` prop (already available) to set the heading:
 
 ### Problem
 
-`npx turbo test --filter=@interview-assistant/web` (and `cd apps/web && npm run test`) reports all 276 test assertions passing but the Vitest process exits with code 1. The cause is uncaught `ReferenceError: window is not defined` exceptions thrown during React 19 async cleanup in jsdom — they surface AFTER every test has already passed, in the teardown phase, so they don't fail any individual test but they break the process exit code.
+`npx turbo test --filter=@preploy/web` (and `cd apps/web && npm run test`) reports all 276 test assertions passing but the Vitest process exits with code 1. The cause is uncaught `ReferenceError: window is not defined` exceptions thrown during React 19 async cleanup in jsdom — they surface AFTER every test has already passed, in the teardown phase, so they don't fail any individual test but they break the process exit code.
 
 Baseline on `main` shows roughly 29 such teardown errors; the PR #1 branch shows 14 (fewer only because fewer files were touched in that test run, not because of any fix). This has been happening for a while and is unrelated to any single story — it's a React 19 + Vitest + jsdom interaction in the component test harness.
 
@@ -127,7 +127,7 @@ Investigate in this order — stop as soon as one works:
 
 ### Acceptance criteria
 
-- `npx turbo test --filter=@interview-assistant/web` exits 0 on a clean `main` checkout.
+- `npx turbo test --filter=@preploy/web` exits 0 on a clean `main` checkout.
 - `.claude/hooks/precommit-gate.sh` passes on any valid web-only change without manual override.
 - No reduction in test count (still 276 assertions, no suppressed tests).
 - Fix is documented in `apps/web/CLAUDE.md` under a short "Known gotchas" section so future contributors don't re-trip this.
@@ -174,7 +174,7 @@ The Python service does NOT touch the database — `SQLAlchemy` is in `pyproject
 1. **Duplicated patterns across languages.** The retry-on-malformed-GPT-response story (PR #2) had to be implemented twice — once per service file — because there's no way to share the helper across languages. Any future resilience / observability / rate-limiting work has the same doubling cost.
 2. **Two test runners, two CI jobs, two dep upgrade flows**, two security audits, two Sentry SDKs, two logging stacks.
 3. **Two CLAUDE.md files** (`apps/web/CLAUDE.md` and `apps/api/CLAUDE.md`) that can drift. The autonomous loop's cognitive overhead doubles when it has to decide which one to read.
-4. **Drift class of bugs.** The `precommit-gate.sh` hook shipped in PR #1 had a bug — it filtered on `interview-assistant-api` but the actual npm workspace name is `@interview-assistant/api`. That bug is only possible because Python and JS use different package naming conventions.
+4. **Drift class of bugs.** The `precommit-gate.sh` hook shipped in PR #1 had a bug — it filtered on `preploy-api` but the actual npm workspace name is `@preploy/api`. That bug is only possible because Python and JS use different package naming conventions.
 5. **Extra hop in the request path.** `browser → Next.js route → fetch → FastAPI → fetch → OpenAI → parse → JSON → fetch response → parse → Next.js response → browser`. That's two JSON round-trips and one extra process boundary for every feedback generation.
 6. **Backlog drift risk.** PR #2 discovered that the retry pattern had been partially implemented in a prior session but the Backlog item was never removed and one of the two services was never mirrored. Single-language, this whole class of drift goes away.
 
@@ -206,7 +206,7 @@ Migration plan (a `/standup` Tech Lead can refine this):
 7. Port the test suite: `apps/api/tests/test_*.py` → `apps/web/app/api/analysis/*.test.ts` + `apps/web/app/api/analysis/*.integration.test.ts`. Use the same sample fixtures and assert byte-equivalent outputs for the pure functions
 8. Delete `apps/api/`, `apps/api/CLAUDE.md`, the Python CI job in `.github/workflows/ci.yml`, and the api service in `docker-compose.yml`
 9. Update `README.md` setup instructions (no more Python venv, no more `pip install -e ".[dev]"`)
-10. Remove `@interview-assistant/api` filter from `.claude/hooks/precommit-gate.sh`
+10. Remove `@preploy/api` filter from `.claude/hooks/precommit-gate.sh`
 11. Shrink the per-app CLAUDE.md scheme to just `apps/web/CLAUDE.md`
 
 ### Validation strategy (byte-equivalent outputs)
@@ -226,7 +226,7 @@ Before deleting `apps/api`, run the existing pytest fixtures (the `VALID_GPT_RES
 - `README.md` setup section no longer mentions Python, venv, or pip
 - All existing Python tests have a TypeScript equivalent asserting the same behavior
 - `apps/api/CLAUDE.md` deleted; `CLAUDE.md` "Monorepo layout" section updated
-- `.claude/hooks/precommit-gate.sh` filter list no longer mentions `@interview-assistant/api`
+- `.claude/hooks/precommit-gate.sh` filter list no longer mentions `@preploy/api`
 - PR includes a before/after diff showing the request path simplification (one fewer process boundary)
 
 ### Out of scope

--- a/dev_logs/Phase1_Tasks.md
+++ b/dev_logs/Phase1_Tasks.md
@@ -1,4 +1,4 @@
-# Interview Assistant - Phase 1: Foundation & Technical Spikes
+# Preploy - Phase 1: Foundation & Technical Spikes
 
 > **Timeline:** Week 1-2
 > **Goal:** Scaffold the project, get auth working, build basic page structure, and prove out the three hardest technical risks — voice conversation, 3D avatar lip-sync, and code execution.

--- a/dev_logs/Phase2_Tasks.md
+++ b/dev_logs/Phase2_Tasks.md
@@ -1,4 +1,4 @@
-# Interview Assistant - Phase 2: Behavioral Interview MVP
+# Preploy - Phase 2: Behavioral Interview MVP
 
 > **Timeline:** Week 3-5
 > **Goal:** Build the full behavioral interview flow from setup → live interview with avatar → AI-generated feedback. Also introduce Zustand state management, input validation, and testing infrastructure.

--- a/dev_logs/Phase3_Tasks.md
+++ b/dev_logs/Phase3_Tasks.md
@@ -1,4 +1,4 @@
-# Interview Assistant — Phase 3: Technical Interview MVP
+# Preploy — Phase 3: Technical Interview MVP
 
 > **Timeline:** Week 6-8
 > **Goal:** Build the full technical interview flow: setup → live coding session with speech capture → AI-generated feedback correlating code with verbal explanations. No code execution — users code in Monaco and explain verbally (Google-style), then AI analyzes code + speech together. Expand test coverage and introduce CI.

--- a/dev_logs/aws-architecture.md
+++ b/dev_logs/aws-architecture.md
@@ -7,7 +7,7 @@
 > that a migration would cost is better spent on landing page, SEO, billing,
 > and remaining feature work.
 >
-> **Revival triggers** — reopen epic [#19](https://github.com/scy02718/interview-assistant/issues/19) when any of the following holds:
+> **Revival triggers** — reopen epic [#19](https://github.com/scy02718/preploy/issues/19) when any of the following holds:
 >
 > - Vercel bandwidth crosses **60 GB** in a single month (60% of the 100 GB Hobby free tier)
 > - Supabase database size crosses **350 MB** (70% of the 500 MB free tier)
@@ -33,8 +33,8 @@
 
 This document is the target architecture for migrating Preploy off Vercel +
 Supabase and onto AWS. It captures the decisions made under the migration
-epic [#19](https://github.com/scy02718/interview-assistant/issues/19) and is
-the deliverable for design sub-issue [#20](https://github.com/scy02718/interview-assistant/issues/20).
+epic [#19](https://github.com/scy02718/preploy/issues/19) and is
+the deliverable for design sub-issue [#20](https://github.com/scy02718/preploy/issues/20).
 It is the contract every downstream sub-issue (#21–#30) would build against;
 if a sub-issue needed to deviate, it would amend this doc first.
 
@@ -311,7 +311,7 @@ and any image tagged `prod`, expire everything else. Scan-on-push enabled.
 **What.** An IAM OIDC identity provider for
 `token.actions.githubusercontent.com` and a `github-actions-deploy` role
 with a trust policy scoped to
-`repo:scy02718/interview-assistant:ref:refs/heads/main`. Permissions: ECR
+`repo:scy02718/preploy:ref:refs/heads/main`. Permissions: ECR
 push to the one repo, ECS `RegisterTaskDefinition` + `UpdateService` +
 `DescribeServices` on the one service, `iam:PassRole` for the task role and
 execution role, CloudWatch log tailing for deploy-time diagnostics.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     environment:
       POSTGRES_USER: test
       POSTGRES_PASSWORD: test
-      POSTGRES_DB: interview_assistant_test
+      POSTGRES_DB: preploy_test
     ports:
       - "5433:5432"
     tmpfs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "interview-assistant",
+  "name": "preploy",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "interview-assistant",
+      "name": "preploy",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -14,14 +14,15 @@
       }
     },
     "apps/web": {
-      "name": "@interview-assistant/web",
+      "name": "@preploy/web",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@auth/drizzle-adapter": "^1.11.1",
         "@base-ui/react": "^1.3.0",
-        "@interview-assistant/shared": "*",
         "@mediapipe/tasks-vision": "^0.10.34",
         "@monaco-editor/react": "^4.7.0",
+        "@preploy/shared": "*",
         "@react-pdf/renderer": "^4.4.1",
         "@sentry/nextjs": "^10.48.0",
         "@upstash/ratelimit": "^2.0.8",
@@ -2969,14 +2970,6 @@
         }
       }
     },
-    "node_modules/@interview-assistant/shared": {
-      "resolved": "packages/shared",
-      "link": true
-    },
-    "node_modules/@interview-assistant/web": {
-      "resolved": "apps/web",
-      "link": true
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -3925,6 +3918,14 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@preploy/shared": {
+      "resolved": "packages/shared",
+      "link": true
+    },
+    "node_modules/@preploy/web": {
+      "resolved": "apps/web",
+      "link": true
     },
     "node_modules/@prisma/instrumentation": {
       "version": "7.6.0",
@@ -13272,7 +13273,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -17322,7 +17322,7 @@
       }
     },
     "packages/shared": {
-      "name": "@interview-assistant/shared",
+      "name": "@preploy/shared",
       "version": "0.1.0",
       "devDependencies": {
         "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "interview-assistant",
+  "name": "preploy",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@interview-assistant/shared",
+  "name": "@preploy/shared",
   "version": "0.1.0",
   "private": true,
   "main": "./src/index.ts",


### PR DESCRIPTION
## Summary

Bundle of changes to prep the repo for public visibility (see #154) AND rename from legacy "Interview Assistant" to the retail name "Preploy".

- **CI concurrency** — cancel stale branch runs, preserve main runs (20-40% Actions minutes savings)
- **README refresh** — cold-reader-friendly rewrite (pitch, features, stack, quickstart, env table, contributing, license); monorepo banner + postinstall clarification in `apps/web/README.md`
- **LICENSE** — proprietary "all rights reserved" (source-available, not open source)
- **Rename to Preploy** — 57 tracked references updated across 3 commits:
  - npm workspaces: `interview-assistant` / `@interview-assistant/*` → `preploy` / `@preploy/*` (package.json + regenerated lockfile + 14 import sites)
  - Test DB: `interview_assistant_test` → `preploy_test` (docker-compose + CI workflow + test setup, atomic across 12 refs)
  - Docs: README, CLAUDE.md, dev_logs, `.claude/` agent/command/skill files

Refs #154

## Pre-public scan status

Security scan (secrets, PII, .gitignore, SDK lazy-init) came back **CLEAN** across all 290 commits. No rotations needed. See #154 comment thread.

## Test plan

- [ ] CI runs green on this PR (lint, typecheck, unit, integration, E2E, build) — especially integration/E2E since the test DB name changed
- [ ] Push a follow-up commit → previous CI run cancelled, new one starts (confirms concurrency works)
- [ ] README renders correctly on GitHub (no broken internal links, code blocks format)
- [ ] No broken imports after `@preploy/shared` rename — covered by CI typecheck

## Manual post-merge steps (for Chan)

1. **Rename repo on GitHub** — Settings → General → top section, rename `interview-assistant` → `preploy`. GitHub auto-redirects old URLs (clone, web, issues, PRs).
2. **Update local remote** — `git remote set-url origin git@github.com:scy02718/preploy.git`
3. **Rename the Vercel project** — Vercel dashboard → Project → Settings → General → Project Name. (Vercel's GitHub integration follows repo renames automatically; only the Vercel project name is separate.)
4. **Rebuild local test DB container if you have one running** — `docker compose down test-db -v && docker compose --profile test up -d test-db` (only needed if you've run it before; new name is `preploy_test`)
5. **Flip repo visibility to Public** — Settings → Danger Zone → Change visibility → Public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)