### PR TITLE
feat(plans): archive and delete interview prep plans

### DIFF
--- a/apps/web/app/api/plans/[id]/route.integration.test.ts
+++ b/apps/web/app/api/plans/[id]/route.integration.test.ts
@@ -14,6 +14,7 @@ import {
   getTestDb,
 } from "../../../../tests/setup-db";
 import { users, interviewPlans } from "@/lib/schema";
+import { eq } from "drizzle-orm";
 
 const mockAuth = vi.fn();
 vi.mock("@/lib/auth", () => ({
@@ -26,7 +27,12 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-import { GET, PATCH } from "./route";
+// Mock rate limit to always pass in tests
+vi.mock("@/lib/api-utils", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(null),
+}));
+
+import { GET, PATCH, DELETE } from "./route";
 
 const TEST_USER = {
   id: "00000000-0000-0000-0000-000000000001",
@@ -87,6 +93,15 @@ function makePatchRequest(
   ];
 }
 
+function makeDeleteRequest(id: string): [NextRequest, { params: Promise<{ id: string }> }] {
+  return [
+    new NextRequest(`http://localhost:3000/api/plans/${id}`, {
+      method: "DELETE",
+    }),
+    { params: Promise.resolve({ id }) },
+  ];
+}
+
 describe("API /api/plans/[id] (integration)", () => {
   let planId: string;
 
@@ -98,6 +113,10 @@ describe("API /api/plans/[id] (integration)", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    // Re-apply rate limit mock after clearAllMocks
+    const { checkRateLimit } = await import("@/lib/api-utils");
+    vi.mocked(checkRateLimit).mockResolvedValue(null);
+
     const db = getTestDb();
     await db.delete(interviewPlans);
 
@@ -153,7 +172,7 @@ describe("API /api/plans/[id] (integration)", () => {
     expect(data.planData.days).toHaveLength(3);
   });
 
-  // ---- PATCH tests ----
+  // ---- PATCH day-completion tests ----
 
   it("PATCH returns 401 when unauthenticated", async () => {
     mockAuth.mockResolvedValue(null);
@@ -235,5 +254,102 @@ describe("API /api/plans/[id] (integration)", () => {
     const getRes = await GET(...makeGetRequest(planId));
     const data = await getRes.json();
     expect(data.planData.days[2].completed).toBe(true);
+  });
+
+  // ---- PATCH archive tests ----
+
+  it("PATCH archive: returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await PATCH(...makePatchRequest(planId, { archived: true }));
+    expect(res.status).toBe(401);
+  });
+
+  it("PATCH archive: returns 404 for another user's plan", async () => {
+    mockAuth.mockResolvedValue({ user: { id: OTHER_USER.id } });
+    const res = await PATCH(...makePatchRequest(planId, { archived: true }));
+    expect(res.status).toBe(404);
+  });
+
+  it("PATCH archive: sets archived_at when archived=true", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await PATCH(...makePatchRequest(planId, { archived: true }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.archivedAt).not.toBeNull();
+
+    // Verify in DB
+    const db = getTestDb();
+    const [row] = await db
+      .select()
+      .from(interviewPlans)
+      .where(eq(interviewPlans.id, planId));
+    expect(row.archivedAt).not.toBeNull();
+    expect(row.archivedAt).toBeInstanceOf(Date);
+  });
+
+  it("PATCH archive: clears archived_at when archived=false", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    // First archive
+    await PATCH(...makePatchRequest(planId, { archived: true }));
+
+    // Then unarchive
+    const res = await PATCH(...makePatchRequest(planId, { archived: false }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.archivedAt).toBeNull();
+
+    // Verify in DB
+    const db = getTestDb();
+    const [row] = await db
+      .select()
+      .from(interviewPlans)
+      .where(eq(interviewPlans.id, planId));
+    expect(row.archivedAt).toBeNull();
+  });
+
+  // ---- DELETE tests ----
+
+  it("DELETE returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await DELETE(...makeDeleteRequest(planId));
+    expect(res.status).toBe(401);
+  });
+
+  it("DELETE returns 404 for another user's plan", async () => {
+    mockAuth.mockResolvedValue({ user: { id: OTHER_USER.id } });
+    const res = await DELETE(...makeDeleteRequest(planId));
+    expect(res.status).toBe(404);
+  });
+
+  it("DELETE returns 404 for non-existent plan", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await DELETE(
+      ...makeDeleteRequest("00000000-0000-0000-0000-000000000099")
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("DELETE returns 204 and hard-deletes the plan", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await DELETE(...makeDeleteRequest(planId));
+    expect(res.status).toBe(204);
+
+    // Verify row is gone from DB
+    const db = getTestDb();
+    const rows = await db
+      .select()
+      .from(interviewPlans)
+      .where(eq(interviewPlans.id, planId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("DELETE: subsequent GET returns 404 after deletion", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    await DELETE(...makeDeleteRequest(planId));
+
+    const getRes = await GET(...makeGetRequest(planId));
+    expect(getRes.status).toBe(404);
   });
 });

--- a/apps/web/app/api/plans/[id]/route.ts
+++ b/apps/web/app/api/plans/[id]/route.ts
@@ -4,12 +4,20 @@ import { db } from "@/lib/db";
 import { interviewPlans } from "@/lib/schema";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod/v4";
+import { checkRateLimit } from "@/lib/api-utils";
+import { createRequestLogger } from "@/lib/logger";
 import type { PlanData, PlanDay } from "@/lib/plan-generator";
 
 const markCompletedSchema = z.object({
   day_index: z.number().int().min(0),
   completed: z.boolean(),
 });
+
+// Discriminated union: either day-completion or archive toggle
+const patchPlanSchema = z.union([
+  markCompletedSchema,
+  z.object({ archived: z.boolean() }),
+]);
 
 // GET /api/plans/[id] — get a specific plan
 export async function GET(
@@ -39,7 +47,7 @@ export async function GET(
   return NextResponse.json(plan);
 }
 
-// PATCH /api/plans/[id] — mark a day as completed/uncompleted
+// PATCH /api/plans/[id] — mark a day as completed/uncompleted OR archive/unarchive
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
@@ -50,8 +58,19 @@ export async function PATCH(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const body = await request.json();
-  const parsed = markCompletedSchema.safeParse(body);
+  const rateLimitRes = await checkRateLimit(session.user.id);
+  if (rateLimitRes) return rateLimitRes;
+
+  const log = createRequestLogger({ route: "PATCH /api/plans/[id]", userId: session.user.id });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = patchPlanSchema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json(
       { error: "Invalid request", details: parsed.error.issues },
@@ -59,9 +78,7 @@ export async function PATCH(
     );
   }
 
-  const { day_index, completed } = parsed.data;
-
-  // Fetch the plan first
+  // Fetch the plan first (auth guard — 404 for another user's plan)
   const [plan] = await db
     .select()
     .from(interviewPlans)
@@ -76,6 +93,28 @@ export async function PATCH(
     return NextResponse.json({ error: "Plan not found" }, { status: 404 });
   }
 
+  // Branch: archive toggle
+  if ("archived" in parsed.data) {
+    const { archived } = parsed.data;
+    const archivedAt = archived ? new Date() : null;
+
+    const [updated] = await db
+      .update(interviewPlans)
+      .set({ archivedAt })
+      .where(
+        and(
+          eq(interviewPlans.id, id),
+          eq(interviewPlans.userId, session.user.id)
+        )
+      )
+      .returning();
+
+    log.info({ planId: id, archived }, "Plan archive status updated");
+    return NextResponse.json(updated);
+  }
+
+  // Branch: day completion toggle
+  const { day_index, completed } = parsed.data;
   const planData = plan.planData as PlanData;
   if (!planData.days || day_index >= planData.days.length) {
     return NextResponse.json(
@@ -84,7 +123,6 @@ export async function PATCH(
     );
   }
 
-  // Update the specific day's completed status
   const updatedDays: PlanDay[] = planData.days.map((day, i) =>
     i === day_index ? { ...day, completed } : day
   );
@@ -101,4 +139,48 @@ export async function PATCH(
     .returning();
 
   return NextResponse.json(updated);
+}
+
+// DELETE /api/plans/[id] — hard-delete a plan
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const rateLimitRes = await checkRateLimit(session.user.id);
+  if (rateLimitRes) return rateLimitRes;
+
+  const log = createRequestLogger({ route: "DELETE /api/plans/[id]", userId: session.user.id });
+
+  // Auth guard — 404 for another user's plan (never leak existence)
+  const [plan] = await db
+    .select()
+    .from(interviewPlans)
+    .where(
+      and(
+        eq(interviewPlans.id, id),
+        eq(interviewPlans.userId, session.user.id)
+      )
+    );
+
+  if (!plan) {
+    return NextResponse.json({ error: "Plan not found" }, { status: 404 });
+  }
+
+  await db
+    .delete(interviewPlans)
+    .where(
+      and(
+        eq(interviewPlans.id, id),
+        eq(interviewPlans.userId, session.user.id)
+      )
+    );
+
+  log.info({ planId: id }, "Plan deleted");
+  return new NextResponse(null, { status: 204 });
 }

--- a/apps/web/app/api/plans/route.integration.test.ts
+++ b/apps/web/app/api/plans/route.integration.test.ts
@@ -7,6 +7,7 @@ import {
   beforeEach,
   afterAll,
 } from "vitest";
+import { NextRequest } from "next/server";
 import {
   cleanupTestDb,
   teardownTestDb,
@@ -39,6 +40,11 @@ const OTHER_USER = {
   name: "Other User",
 };
 
+function makeGetRequest(query?: string): NextRequest {
+  const url = `http://localhost:3000/api/plans${query ? `?${query}` : ""}`;
+  return new NextRequest(url);
+}
+
 describe("GET /api/plans (integration)", () => {
   beforeAll(async () => {
     const db = getTestDb();
@@ -59,19 +65,102 @@ describe("GET /api/plans (integration)", () => {
 
   it("returns 401 when unauthenticated", async () => {
     mockAuth.mockResolvedValue(null);
-    const res = await GET();
+    const res = await GET(makeGetRequest());
     expect(res.status).toBe(401);
   });
 
   it("returns empty plans array for user with no plans", async () => {
     mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
-    const res = await GET();
+    const res = await GET(makeGetRequest());
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.plans).toEqual([]);
   });
 
-  it("returns user's plans ordered by createdAt desc", async () => {
+  it("returns only non-archived plans by default", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const db = getTestDb();
+
+    await db.insert(interviewPlans).values([
+      {
+        userId: TEST_USER.id,
+        company: "Google",
+        role: "SWE",
+        interviewDate: new Date("2026-05-01"),
+        planData: { days: [] },
+        archivedAt: null,
+      },
+      {
+        userId: TEST_USER.id,
+        company: "Meta",
+        role: "Frontend",
+        interviewDate: new Date("2026-05-15"),
+        planData: { days: [] },
+        archivedAt: new Date(),
+      },
+    ]);
+
+    const res = await GET(makeGetRequest());
+    const data = await res.json();
+    expect(data.plans).toHaveLength(1);
+    expect(data.plans[0].company).toBe("Google");
+  });
+
+  it("returns only archived plans when ?archived=true", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const db = getTestDb();
+
+    await db.insert(interviewPlans).values([
+      {
+        userId: TEST_USER.id,
+        company: "Google",
+        role: "SWE",
+        interviewDate: new Date("2026-05-01"),
+        planData: { days: [] },
+        archivedAt: null,
+      },
+      {
+        userId: TEST_USER.id,
+        company: "Meta",
+        role: "Frontend",
+        interviewDate: new Date("2026-05-15"),
+        planData: { days: [] },
+        archivedAt: new Date(),
+      },
+    ]);
+
+    const res = await GET(makeGetRequest("archived=true"));
+    const data = await res.json();
+    expect(data.plans).toHaveLength(1);
+    expect(data.plans[0].company).toBe("Meta");
+  });
+
+  it("archived plan does not appear in default list after PATCH archive", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const db = getTestDb();
+
+    const [plan] = await db
+      .insert(interviewPlans)
+      .values({
+        userId: TEST_USER.id,
+        company: "Amazon",
+        role: "SDE",
+        interviewDate: new Date("2026-06-01"),
+        planData: { days: [] },
+        archivedAt: new Date(), // already archived
+      })
+      .returning();
+
+    const defaultRes = await GET(makeGetRequest());
+    const defaultData = await defaultRes.json();
+    expect(defaultData.plans.map((p: { id: string }) => p.id)).not.toContain(plan.id);
+
+    const archivedRes = await GET(makeGetRequest("archived=true"));
+    const archivedData = await archivedRes.json();
+    expect(archivedData.plans.map((p: { id: string }) => p.id)).toContain(plan.id);
+  });
+
+  it("returns user's active plans ordered by createdAt desc", async () => {
     mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
     const db = getTestDb();
 
@@ -92,10 +181,9 @@ describe("GET /api/plans (integration)", () => {
       },
     ]);
 
-    const res = await GET();
+    const res = await GET(makeGetRequest());
     const data = await res.json();
     expect(data.plans).toHaveLength(2);
-    // Should have company and role fields
     expect(data.plans[0].company).toBeDefined();
     expect(data.plans[0].role).toBeDefined();
   });
@@ -112,7 +200,25 @@ describe("GET /api/plans (integration)", () => {
     });
 
     mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
-    const res = await GET();
+    const res = await GET(makeGetRequest());
+    const data = await res.json();
+    expect(data.plans).toEqual([]);
+  });
+
+  it("?archived=true does not return another user's archived plans", async () => {
+    const db = getTestDb();
+
+    await db.insert(interviewPlans).values({
+      userId: OTHER_USER.id,
+      company: "Netflix",
+      role: "Engineer",
+      interviewDate: new Date("2026-05-01"),
+      planData: { days: [] },
+      archivedAt: new Date(),
+    });
+
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await GET(makeGetRequest("archived=true"));
     const data = await res.json();
     expect(data.plans).toEqual([]);
   });

--- a/apps/web/app/api/plans/route.ts
+++ b/apps/web/app/api/plans/route.ts
@@ -1,20 +1,32 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { interviewPlans } from "@/lib/schema";
-import { desc, eq } from "drizzle-orm";
+import { desc, eq, isNotNull, isNull, and } from "drizzle-orm";
 
 // GET /api/plans — list user's interview plans
-export async function GET() {
+// ?archived=true returns only archived plans; default returns only non-archived
+export async function GET(request?: NextRequest) {
   const session = await auth();
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const url = request?.url ? new URL(request.url) : null;
+  const archivedParam = url?.searchParams.get("archived");
+  const showArchived = archivedParam === "true";
+
   const plans = await db
     .select()
     .from(interviewPlans)
-    .where(eq(interviewPlans.userId, session.user.id))
+    .where(
+      and(
+        eq(interviewPlans.userId, session.user.id),
+        showArchived
+          ? isNotNull(interviewPlans.archivedAt)
+          : isNull(interviewPlans.archivedAt)
+      )
+    )
     .orderBy(desc(interviewPlans.createdAt));
 
   return NextResponse.json({ plans });

--- a/apps/web/app/planner/page.tsx
+++ b/apps/web/app/planner/page.tsx
@@ -17,8 +17,10 @@ import {
   MessageSquare,
   Code,
   Plus,
+  ChevronDown,
 } from "lucide-react";
 import type { PlanDay, PlanData } from "@/lib/plan-generator";
+import { PlanCardMenu } from "@/components/planner/PlanCardMenu";
 
 interface Plan {
   id: string;
@@ -27,6 +29,7 @@ interface Plan {
   interviewDate: string;
   planData: PlanData;
   createdAt: string;
+  archivedAt: string | null;
 }
 
 function PlanSkeleton() {
@@ -109,10 +112,12 @@ function DayCard({
 
 export default function PlannerPage() {
   const [plans, setPlans] = useState<Plan[]>([]);
+  const [archivedPlans, setArchivedPlans] = useState<Plan[]>([]);
   const [selectedPlan, setSelectedPlan] = useState<Plan | null>(null);
   const [loading, setLoading] = useState(true);
   const [generating, setGenerating] = useState(false);
   const [showForm, setShowForm] = useState(false);
+  const [archivedOpen, setArchivedOpen] = useState(false);
 
   // Form state
   const [company, setCompany] = useState("");
@@ -121,13 +126,20 @@ export default function PlannerPage() {
 
   const fetchPlans = useCallback(async () => {
     try {
-      const res = await fetch("/api/plans");
-      if (res.ok) {
-        const data = await res.json();
+      const [activeRes, archivedRes] = await Promise.all([
+        fetch("/api/plans"),
+        fetch("/api/plans?archived=true"),
+      ]);
+      if (activeRes.ok) {
+        const data = await activeRes.json();
         setPlans(data.plans);
         if (data.plans.length > 0) {
           setSelectedPlan((prev) => prev ?? data.plans[0]);
         }
+      }
+      if (archivedRes.ok) {
+        const data = await archivedRes.json();
+        setArchivedPlans(data.plans);
       }
     } catch {
       // Silent failure — non-critical
@@ -165,6 +177,48 @@ export default function PlannerPage() {
       // Error handling could be added
     } finally {
       setGenerating(false);
+    }
+  }
+
+  async function handleArchivePlan(planId: string, archived: boolean) {
+    try {
+      const res = await fetch(`/api/plans/${planId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ archived }),
+      });
+      if (res.ok) {
+        const updated: Plan = await res.json();
+        if (archived) {
+          // Move from active to archived
+          setPlans((prev) => prev.filter((p) => p.id !== planId));
+          setArchivedPlans((prev) => [updated, ...prev]);
+          if (selectedPlan?.id === planId) {
+            setSelectedPlan(null);
+          }
+        } else {
+          // Move from archived to active
+          setArchivedPlans((prev) => prev.filter((p) => p.id !== planId));
+          setPlans((prev) => [updated, ...prev]);
+        }
+      }
+    } catch {
+      // Silent failure
+    }
+  }
+
+  async function handleDeletePlan(planId: string) {
+    try {
+      const res = await fetch(`/api/plans/${planId}`, { method: "DELETE" });
+      if (res.status === 204) {
+        setPlans((prev) => prev.filter((p) => p.id !== planId));
+        setArchivedPlans((prev) => prev.filter((p) => p.id !== planId));
+        if (selectedPlan?.id === planId) {
+          setSelectedPlan(null);
+        }
+      }
+    } catch {
+      // Silent failure
     }
   }
 
@@ -301,25 +355,89 @@ export default function PlannerPage() {
               ) : (
                 <div className="space-y-2">
                   {plans.map((plan) => (
-                    <button
+                    <div
                       key={plan.id}
-                      onClick={() => setSelectedPlan(plan)}
-                      className={`w-full text-left rounded-lg border p-3 transition-colors ${
+                      className={`flex items-center gap-1 rounded-lg border transition-colors ${
                         selectedPlan?.id === plan.id
                           ? "border-primary bg-primary/5"
                           : "hover:bg-accent/50"
                       }`}
                     >
-                      <p className="font-medium text-sm">{plan.company}</p>
-                      <p className="text-xs text-muted-foreground">{plan.role}</p>
-                      <p className="text-xs text-muted-foreground">
-                        {new Date(plan.interviewDate).toLocaleDateString()}
-                      </p>
-                    </button>
+                      <button
+                        onClick={() => setSelectedPlan(plan)}
+                        className="flex-1 text-left p-3 min-w-0"
+                      >
+                        <p className="font-medium text-sm truncate">{plan.company}</p>
+                        <p className="text-xs text-muted-foreground truncate">{plan.role}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {new Date(plan.interviewDate).toLocaleDateString()}
+                        </p>
+                      </button>
+                      <div className="pr-1">
+                        <PlanCardMenu
+                          planId={plan.id}
+                          isArchived={false}
+                          onArchive={handleArchivePlan}
+                          onDelete={handleDeletePlan}
+                        />
+                      </div>
+                    </div>
                   ))}
                 </div>
               )}
             </CardContent>
+          </Card>
+
+          {/* Archived plans section */}
+          <Card>
+            <button
+              onClick={() => setArchivedOpen((o) => !o)}
+              className="flex items-center justify-between w-full p-4 text-left"
+              aria-expanded={archivedOpen}
+            >
+              <span className="text-sm font-medium text-muted-foreground">
+                Archived ({loading ? "…" : archivedPlans.length})
+              </span>
+              <ChevronDown
+                className={`h-4 w-4 text-muted-foreground transition-transform ${archivedOpen ? "rotate-180" : ""}`}
+              />
+            </button>
+            {archivedOpen && (
+              <CardContent className="pt-0">
+                {loading ? (
+                  <div className="space-y-2">
+                    <div className="h-12 w-full animate-pulse rounded bg-muted" />
+                  </div>
+                ) : archivedPlans.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No archived plans.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {archivedPlans.map((plan) => (
+                      <div
+                        key={plan.id}
+                        className="flex items-center gap-1 rounded-lg border border-dashed bg-muted/30 transition-colors hover:bg-accent/30"
+                      >
+                        <div className="flex-1 p-3 min-w-0">
+                          <p className="font-medium text-sm truncate text-muted-foreground">{plan.company}</p>
+                          <p className="text-xs text-muted-foreground truncate">{plan.role}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {new Date(plan.interviewDate).toLocaleDateString()}
+                          </p>
+                        </div>
+                        <div className="pr-1">
+                          <PlanCardMenu
+                            planId={plan.id}
+                            isArchived={true}
+                            onArchive={handleArchivePlan}
+                            onDelete={handleDeletePlan}
+                          />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            )}
           </Card>
         </div>
 

--- a/apps/web/components/planner/PlanCardMenu.test.tsx
+++ b/apps/web/components/planner/PlanCardMenu.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { PlanCardMenu } from "./PlanCardMenu";
+
+// Mock next/navigation (not used in this component, but included for safety)
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/planner",
+}));
+
+const PLAN_ID = "00000000-0000-0000-0000-000000000001";
+
+describe("PlanCardMenu", () => {
+  const onArchive = vi.fn().mockResolvedValue(undefined);
+  const onDelete = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the kebab menu trigger button", () => {
+    render(
+      <PlanCardMenu
+        planId={PLAN_ID}
+        isArchived={false}
+        onArchive={onArchive}
+        onDelete={onDelete}
+      />
+    );
+    expect(screen.getByRole("button", { name: /plan options/i })).toBeDefined();
+  });
+
+  it("shows Archive and Delete options when not archived", async () => {
+    render(
+      <PlanCardMenu
+        planId={PLAN_ID}
+        isArchived={false}
+        onArchive={onArchive}
+        onDelete={onDelete}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /plan options/i }));
+    await waitFor(() => {
+      const archiveItems = screen.getAllByText(/archive/i);
+      expect(archiveItems.length).toBeGreaterThan(0);
+    });
+    const deleteItems = screen.getAllByText(/delete/i);
+    expect(deleteItems.length).toBeGreaterThan(0);
+  });
+
+  it("shows Unarchive option when plan is archived", async () => {
+    render(
+      <PlanCardMenu
+        planId={PLAN_ID}
+        isArchived={true}
+        onArchive={onArchive}
+        onDelete={onDelete}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /plan options/i }));
+    await waitFor(() => {
+      const items = screen.getAllByText(/unarchive/i);
+      expect(items.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("calls onArchive with archived=true when Archive is clicked", async () => {
+    render(
+      <PlanCardMenu
+        planId={PLAN_ID}
+        isArchived={false}
+        onArchive={onArchive}
+        onDelete={onDelete}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /plan options/i }));
+    await waitFor(() => {
+      const archiveItems = screen.getAllByText(/^archive$/i);
+      expect(archiveItems.length).toBeGreaterThan(0);
+    });
+    const archiveItem = screen.getAllByText(/^archive$/i)[0];
+    fireEvent.click(archiveItem);
+    await waitFor(() => {
+      expect(onArchive).toHaveBeenCalledWith(PLAN_ID, true);
+    });
+  });
+
+  it("calls onArchive with archived=false (unarchive) when Unarchive is clicked", async () => {
+    render(
+      <PlanCardMenu
+        planId={PLAN_ID}
+        isArchived={true}
+        onArchive={onArchive}
+        onDelete={onDelete}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /plan options/i }));
+    await waitFor(() => {
+      const items = screen.getAllByText(/unarchive/i);
+      expect(items.length).toBeGreaterThan(0);
+    });
+    const unarchiveItem = screen.getAllByText(/unarchive/i)[0];
+    fireEvent.click(unarchiveItem);
+    await waitFor(() => {
+      expect(onArchive).toHaveBeenCalledWith(PLAN_ID, false);
+    });
+  });
+
+  it("opens confirmation dialog when Delete is clicked", async () => {
+    render(
+      <PlanCardMenu
+        planId={PLAN_ID}
+        isArchived={false}
+        onArchive={onArchive}
+        onDelete={onDelete}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /plan options/i }));
+    await waitFor(() => {
+      const deleteItems = screen.getAllByText(/delete/i);
+      expect(deleteItems.length).toBeGreaterThan(0);
+    });
+    const deleteItem = screen.getAllByText(/^delete$/i)[0];
+    fireEvent.click(deleteItem);
+    await waitFor(() => {
+      const dialogTitles = screen.getAllByText(/delete this plan/i);
+      expect(dialogTitles.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("does NOT call onDelete until dialog is confirmed", async () => {
+    render(
+      <PlanCardMenu
+        planId={PLAN_ID}
+        isArchived={false}
+        onArchive={onArchive}
+        onDelete={onDelete}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /plan options/i }));
+    await waitFor(() => {
+      const deleteItems = screen.getAllByText(/^delete$/i);
+      expect(deleteItems.length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByText(/^delete$/i)[0]);
+    // Dialog opened but not confirmed
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it("calls onDelete after confirming in the dialog", async () => {
+    render(
+      <PlanCardMenu
+        planId={PLAN_ID}
+        isArchived={false}
+        onArchive={onArchive}
+        onDelete={onDelete}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /plan options/i }));
+    await waitFor(() => {
+      expect(screen.getAllByText(/^delete$/i).length).toBeGreaterThan(0);
+    });
+    // Click Delete in dropdown to open dialog
+    fireEvent.click(screen.getAllByText(/^delete$/i)[0]);
+    await waitFor(() => {
+      expect(screen.getAllByText(/delete this plan/i).length).toBeGreaterThan(0);
+    });
+    // Click the confirm Delete button in dialog
+    const confirmButtons = screen.getAllByRole("button", { name: /^delete$/i });
+    fireEvent.click(confirmButtons[confirmButtons.length - 1]);
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledWith(PLAN_ID);
+    });
+  });
+});

--- a/apps/web/components/planner/PlanCardMenu.tsx
+++ b/apps/web/components/planner/PlanCardMenu.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { MoreHorizontal, Archive, ArchiveX, Trash2 } from "lucide-react";
+
+interface PlanCardMenuProps {
+  planId: string;
+  isArchived: boolean;
+  onArchive: (planId: string, archived: boolean) => Promise<void>;
+  onDelete: (planId: string) => Promise<void>;
+}
+
+export function PlanCardMenu({
+  planId,
+  isArchived,
+  onArchive,
+  onDelete,
+}: PlanCardMenuProps) {
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [isWorking, setIsWorking] = useState(false);
+
+  async function handleArchive() {
+    setIsWorking(true);
+    try {
+      await onArchive(planId, !isArchived);
+    } finally {
+      setIsWorking(false);
+    }
+  }
+
+  async function handleDeleteConfirm() {
+    setIsWorking(true);
+    try {
+      await onDelete(planId);
+    } finally {
+      setIsWorking(false);
+      setDeleteDialogOpen(false);
+    }
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+          aria-label="Plan options"
+          disabled={isWorking}
+        >
+          <MoreHorizontal className="h-4 w-4" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={handleArchive}>
+            {isArchived ? (
+              <>
+                <ArchiveX className="h-4 w-4 mr-2" />
+                Unarchive
+              </>
+            ) : (
+              <>
+                <Archive className="h-4 w-4 mr-2" />
+                Archive
+              </>
+            )}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => setDeleteDialogOpen(true)}
+            className="text-destructive focus:text-destructive"
+          >
+            <Trash2 className="h-4 w-4 mr-2" />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this plan?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. The plan and all its progress will
+              be permanently deleted.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isWorking}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteConfirm}
+              disabled={isWorking}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/web/components/ui/alert-dialog.tsx
+++ b/apps/web/components/ui/alert-dialog.tsx
@@ -1,0 +1,187 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Popup.Props & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-10 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "font-heading text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <Button
+      data-slot="alert-dialog-action"
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Close.Props &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      className={cn(className)}
+      render={<Button variant={variant} size={size} />}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/apps/web/drizzle/0014_many_mandroid.sql
+++ b/apps/web/drizzle/0014_many_mandroid.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "interview_plans" ADD COLUMN "archived_at" timestamp with time zone;

--- a/apps/web/drizzle/meta/0014_snapshot.json
+++ b/apps/web/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1417 @@
+{
+  "id": "f8a71bb5-f0d6-46c1-9742-5160bb37035d",
+  "prevId": "df4d6e8d-44a6-4d4f-91d6-57cfaacbd2a7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.code_snapshots": {
+      "name": "code_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "code_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_result": {
+          "name": "execution_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "code_snapshots_session_id_interview_sessions_id_fk": {
+          "name": "code_snapshots_session_id_interview_sessions_id_fk",
+          "tableFrom": "code_snapshots",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_questions": {
+      "name": "company_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_questions_user_id_users_id_fk": {
+          "name": "company_questions_user_id_users_id_fk",
+          "tableFrom": "company_questions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deleted_usage": {
+      "name": "deleted_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deleted_usage_hash_month_unique": {
+          "name": "deleted_usage_hash_month_unique",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gaze_samples": {
+      "name": "gaze_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gaze_samples_session_id_interview_sessions_id_fk": {
+          "name": "gaze_samples_session_id_interview_sessions_id_fk",
+          "tableFrom": "gaze_samples",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_plans": {
+      "name": "interview_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interview_date": {
+          "name": "interview_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_data": {
+          "name": "plan_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_plans_user_id_users_id_fk": {
+          "name": "interview_plans_user_id_users_id_fk",
+          "tableFrom": "interview_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_sessions": {
+      "name": "interview_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'configuring'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_star_story_id": {
+          "name": "source_star_story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_sessions_user_id_users_id_fk": {
+          "name": "interview_sessions_user_id_users_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interview_sessions_source_star_story_id_star_stories_id_fk": {
+          "name": "interview_sessions_source_star_story_id_star_stories_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "source_star_story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_usage": {
+      "name": "interview_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "interview_usage_user_period_unique": {
+          "name": "interview_usage_user_period_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interview_usage_user_id_users_id_fk": {
+          "name": "interview_usage_user_id_users_id_fk",
+          "tableFrom": "interview_usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.openai_usage": {
+      "name": "openai_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd_millis": {
+          "name": "cost_usd_millis",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "openai_usage_user_date_model_unique": {
+          "name": "openai_usage_user_date_model_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_feedback": {
+      "name": "session_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_score": {
+          "name": "overall_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strengths": {
+          "name": "strengths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "weaknesses": {
+          "name": "weaknesses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "answer_analyses": {
+          "name": "answer_analyses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "code_quality_score": {
+          "name": "code_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation_quality_score": {
+          "name": "explanation_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeline_analysis": {
+          "name": "timeline_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_consistency_score": {
+          "name": "gaze_consistency_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_distribution": {
+          "name": "gaze_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_coverage": {
+          "name": "gaze_coverage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_timeline": {
+          "name": "gaze_timeline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_feedback_session_id_interview_sessions_id_fk": {
+          "name": "session_feedback_session_id_interview_sessions_id_fk",
+          "tableFrom": "session_feedback",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_templates": {
+      "name": "session_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_templates_user_id_users_id_fk": {
+          "name": "session_templates_user_id_users_id_fk",
+          "tableFrom": "session_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_stories": {
+      "name": "star_stories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_questions": {
+          "name": "expected_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "situation": {
+          "name": "situation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_stories_user_id_users_id_fk": {
+          "name": "star_stories_user_id_users_id_fk",
+          "tableFrom": "star_stories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_story_analyses": {
+      "name": "star_story_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scores": {
+          "name": "scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_story_analyses_story_id_star_stories_id_fk": {
+          "name": "star_story_analyses_story_id_star_stories_id_fk",
+          "tableFrom": "star_story_analyses",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcripts": {
+      "name": "transcripts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcripts_session_id_interview_sessions_id_fk": {
+          "name": "transcripts_session_id_interview_sessions_id_fk",
+          "tableFrom": "transcripts",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_badge_unique": {
+          "name": "user_badge_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "badge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_resumes": {
+      "name": "user_resumes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_resumes_user_id_users_id_fk": {
+          "name": "user_resumes_user_id_users_id_fk",
+          "tableFrom": "user_resumes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "user_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_start": {
+          "name": "plan_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_end": {
+          "name": "plan_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "past_due_at": {
+          "name": "past_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_tracking_enabled": {
+          "name": "gaze_tracking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tour_completed_at": {
+          "name": "tour_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tour_skipped_at": {
+          "name": "tour_skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.code_event_type": {
+      "name": "code_event_type",
+      "schema": "public",
+      "values": [
+        "edit",
+        "run",
+        "submit"
+      ]
+    },
+    "public.interview_type": {
+      "name": "interview_type",
+      "schema": "public",
+      "values": [
+        "behavioral",
+        "technical"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "configuring",
+        "in_progress",
+        "completed",
+        "cancelled",
+        "failed"
+      ]
+    },
+    "public.user_plan": {
+      "name": "user_plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "max"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1776434484200,
       "tag": "0013_same_preak",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1776480540783,
+      "tag": "0014_many_mandroid",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/schema.ts
+++ b/apps/web/lib/schema.ts
@@ -238,6 +238,7 @@ export const interviewPlans = pgTable("interview_plans", {
   role: text("role").notNull(),
   interviewDate: timestamp("interview_date", { withTimezone: true }).notNull(),
   planData: jsonb("plan_data").notNull().default({}),
+  archivedAt: timestamp("archived_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/apps/web/lib/validations.ts
+++ b/apps/web/lib/validations.ts
@@ -100,6 +100,13 @@ export const listStarStoriesQuerySchema = z.object({
 });
 export type ListStarStoriesQuery = z.infer<typeof listStarStoriesQuerySchema>;
 
+// ---- Plan archive PATCH schema ----
+
+export const patchPlanArchiveSchema = z.object({
+  archived: z.boolean(),
+});
+export type PatchPlanArchiveInput = z.infer<typeof patchPlanArchiveSchema>;
+
 // ---- User profile PATCH schema ----
 
 export const patchUserMeSchema = z.object({


### PR DESCRIPTION
## Summary

- **Archive/unarchive** plans (soft-hide, reversible) via `PATCH /api/plans/[id]` with `{ archived: true | false }`
- **Hard-delete** plans via `DELETE /api/plans/[id]` with shadcn `AlertDialog` confirmation
- `GET /api/plans` filters archived by default; `?archived=true` returns archived-only for the collapsed section
- Planner UI: new `PlanCardMenu` (kebab → DropdownMenu), collapsed "Archived" accordion at the bottom with skeleton

Closes #124

## Migration

- `apps/web/drizzle/0014_many_mandroid.sql` — adds nullable `archived_at TIMESTAMP WITH TIME ZONE` to `interview_plans`
- Whole `apps/web/drizzle/` directory staged (SQL + snapshot + `_journal.json` entry) per the bitten-twice rule

## Test plan

Automated (already green):
- [x] Lint + typecheck clean
- [x] 832/832 unit+component tests (includes `PlanCardMenu.test.tsx` covering archive/unarchive/delete dialog)
- [x] 335/335 integration tests (includes `?archived=true` filter, cross-user 404, persistence SELECT, both PATCH branches)
- [x] 21/21 E2E smoke tests

Manual (reviewer, once pulled):
- [ ] On `/planner`, click kebab on a plan → Archive; verify it disappears from the main list
- [ ] Expand Archived section → Unarchive; verify it returns
- [ ] Click kebab → Delete → confirm dialog; verify hard-delete (plan gone even after refresh)
- [ ] Try PATCH/DELETE on another user's plan via \`curl\` — expect 404 (never 403, never 500)

## Notes for reviewer

- Cross-user leak prevention uses \`and(eq(id), eq(userId))\` in the WHERE clause, returning 404 if no row matches (never 403)
- \`checkRateLimit(session.user.id)\` applied to both PATCH and DELETE
- \`DropdownMenuTrigger\` rendered as native button (not \`asChild\`) because this repo uses \`@base-ui/react\` (not Radix); \`aria-label=\"Plan options\"\` and focus-visible styling preserved
- Integration tests mock \`@/lib/api-utils\` to bypass Upstash in CI; mock is scoped to the test file only

🤖 Generated with [Claude Code](https://claude.com/claude-code)