### PR TITLE
feat(analysis): wire source_star_story_id end-to-end for STAR-to-session drift

### DIFF
--- a/apps/web/app/api/sessions/[id]/feedback/route.ts
+++ b/apps/web/app/api/sessions/[id]/feedback/route.ts
@@ -7,6 +7,7 @@ import {
   codeSnapshots,
   sessionFeedback,
   gazeSamples,
+  starStories,
 } from "@/lib/schema";
 import { eq, and, asc } from "drizzle-orm";
 import type { GazeSample } from "@/lib/gaze-types";
@@ -119,6 +120,26 @@ export async function POST(
       .orderBy(asc(codeSnapshots.timestampMs));
   }
 
+  // For behavioral sessions with a source STAR story, fetch the story for
+  // drift analysis comparison.
+  let preparedStory: { situation: string; task: string; action: string; result: string } | undefined;
+  if (!isTechnical && found.sourceStarStoryId) {
+    const [storyRow] = await db
+      .select({
+        situation: starStories.situation,
+        task: starStories.task,
+        action: starStories.action,
+        result: starStories.result,
+      })
+      .from(starStories)
+      .where(eq(starStories.id, found.sourceStarStoryId));
+
+    if (storyRow) {
+      preparedStory = storyRow;
+      log.info({ sessionId: id, sourceStarStoryId: found.sourceStarStoryId }, "fetched source STAR story for drift analysis");
+    }
+  }
+
   // Call the local TS analysis pipeline directly (no HTTP hop). These are the
   // same functions the thin `/api/analysis/{behavioral,technical}` routes wrap.
   let feedbackData: FeedbackResponse | TechnicalFeedbackResponse;
@@ -149,7 +170,7 @@ export async function POST(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           config: (found.config ?? {}) as any,
         },
-        { log, userId: session.user.id },
+        { log, userId: session.user.id, preparedStory },
       );
     }
   } catch (err) {
@@ -222,6 +243,9 @@ export async function POST(
         codeQualityScore: (feedbackData as TechnicalFeedbackResponse).code_quality_score,
         explanationQualityScore: (feedbackData as TechnicalFeedbackResponse).explanation_quality_score,
         timelineAnalysis: (feedbackData as TechnicalFeedbackResponse).timeline_analysis,
+      }),
+      ...(!isTechnical && {
+        driftAnalysis: (feedbackData as FeedbackResponse).drift_analysis ?? null,
       }),
       gazeConsistencyScore,
       gazeDistribution,

--- a/apps/web/app/api/sessions/route.integration.test.ts
+++ b/apps/web/app/api/sessions/route.integration.test.ts
@@ -643,4 +643,141 @@ describe("API /api/sessions (integration)", () => {
     const data = await res.json();
     expect(data.error).toContain("Invalid session config");
   });
+
+  // ---- 146: source_star_story_id tests ----
+
+  it("POST creates session with valid source_star_story_id and persists it", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const db = getTestDb();
+    const { starStories, interviewSessions } = await import("@/lib/schema");
+    const { eq } = await import("drizzle-orm");
+
+    // Create a star story for the test user
+    const [story] = await db
+      .insert(starStories)
+      .values({
+        userId: TEST_USER.id,
+        title: "Led under pressure",
+        role: "Engineer",
+        expectedQuestions: ["Tell me about a time you led under pressure"],
+        situation: "Our system was down in production.",
+        task: "I needed to coordinate the fix.",
+        action: "I set up a war room and delegated tasks.",
+        result: "We restored service in 2 hours.",
+      })
+      .returning();
+
+    const res = await POST(
+      makePostRequest({
+        type: "behavioral",
+        config: { interview_style: 0.5, difficulty: 0.5 },
+        source_star_story_id: story.id,
+      })
+    );
+
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.id).toBeDefined();
+
+    // Verify persistence
+    const [row] = await db
+      .select()
+      .from(interviewSessions)
+      .where(eq(interviewSessions.id, data.id));
+    expect(row.sourceStarStoryId).toBe(story.id);
+
+    // Cleanup
+    await db.delete(starStories).where(eq(starStories.id, story.id));
+  });
+
+  it("POST returns 400 when source_star_story_id belongs to a different user", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const db = getTestDb();
+    const { starStories, users: usersTable } = await import("@/lib/schema");
+    const { eq } = await import("drizzle-orm");
+
+    // Create a second user and a story belonging to them
+    const OTHER_USER_ID = "00000000-0000-0000-0000-000000000002";
+    await db
+      .insert(usersTable)
+      .values({ id: OTHER_USER_ID, email: "other@example.com", name: "Other" })
+      .onConflictDoNothing();
+
+    const [otherStory] = await db
+      .insert(starStories)
+      .values({
+        userId: OTHER_USER_ID,
+        title: "Other user story",
+        role: "Manager",
+        expectedQuestions: ["Tell me about leadership"],
+        situation: "S",
+        task: "T",
+        action: "A",
+        result: "R",
+      })
+      .returning();
+
+    const res = await POST(
+      makePostRequest({
+        type: "behavioral",
+        source_star_story_id: otherStory.id,
+      })
+    );
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("Invalid source_star_story_id");
+
+    // Cleanup
+    await db.delete(starStories).where(eq(starStories.id, otherStory.id));
+  });
+
+  it("POST returns 400 when source_star_story_id does not exist", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const nonExistentId = "00000000-0000-0000-0000-999999999999";
+    const res = await POST(
+      makePostRequest({
+        type: "behavioral",
+        source_star_story_id: nonExistentId,
+      })
+    );
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("Invalid source_star_story_id");
+  });
+
+  it("POST creates session without source_star_story_id (null preserved)", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const db = getTestDb();
+    const { interviewSessions } = await import("@/lib/schema");
+    const { eq } = await import("drizzle-orm");
+
+    const res = await POST(makePostRequest({ type: "behavioral" }));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+
+    const [row] = await db
+      .select()
+      .from(interviewSessions)
+      .where(eq(interviewSessions.id, data.id));
+    expect(row.sourceStarStoryId).toBeNull();
+  });
+
+  it("POST returns 400 for invalid UUID format in source_star_story_id", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const res = await POST(
+      makePostRequest({
+        type: "behavioral",
+        source_star_story_id: "not-a-uuid",
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
 });

--- a/apps/web/app/api/sessions/route.integration.test.ts
+++ b/apps/web/app/api/sessions/route.integration.test.ts
@@ -20,6 +20,21 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
+// Bypass Upstash-backed rate limiting; it isn't available in the integration
+// test env, and without this mock the test-local rate budget starves later
+// assertions in this file (they return 429 instead of their expected codes).
+// The route contract is: checkRateLimit returns a NextResponse when rate-limited,
+// or null/undefined when allowed — so the passing case returns null.
+vi.mock("@/lib/api-utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-utils")>(
+    "@/lib/api-utils"
+  );
+  return {
+    ...actual,
+    checkRateLimit: vi.fn().mockResolvedValue(null),
+  };
+});
+
 import { GET, POST } from "./route";
 
 const TEST_USER = {
@@ -51,14 +66,22 @@ describe("API /api/sessions (integration)", () => {
   });
 
   beforeEach(async () => {
-    // Clean sessions and usage between tests but keep the user
+    // Clean sessions, usage, and star stories between tests but keep users
     const db = getTestDb();
-    const { interviewSessions, sessionFeedback, transcripts, interviewUsage } =
-      await import("@/lib/schema");
+    const {
+      interviewSessions,
+      sessionFeedback,
+      transcripts,
+      interviewUsage,
+      starStoryAnalyses,
+      starStories,
+    } = await import("@/lib/schema");
     await db.delete(sessionFeedback);
     await db.delete(transcripts);
     await db.delete(interviewSessions);
     await db.delete(interviewUsage);
+    await db.delete(starStoryAnalyses);
+    await db.delete(starStories);
     // Reset plan to free between tests
     const { eq } = await import("drizzle-orm");
     await db
@@ -737,7 +760,10 @@ describe("API /api/sessions (integration)", () => {
   it("POST returns 400 when source_star_story_id does not exist", async () => {
     mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
 
-    const nonExistentId = "00000000-0000-0000-0000-999999999999";
+    // Valid RFC-4122 UUID format (v4) that doesn't exist in the DB.
+    // Strict zod .uuid() requires version + variant bits set correctly,
+    // so all-zeros IDs don't pass the schema validator.
+    const nonExistentId = "11111111-1111-4111-a111-111111111111";
     const res = await POST(
       makePostRequest({
         type: "behavioral",

--- a/apps/web/app/api/sessions/route.ts
+++ b/apps/web/app/api/sessions/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import { interviewSessions, sessionFeedback, users } from "@/lib/schema";
+import { interviewSessions, sessionFeedback, users, starStories } from "@/lib/schema";
 import { and, desc, eq, gte, lte, sql, ne } from "drizzle-orm";
 import { getPlanConfig, FREE_PLAN_MONTHLY_INTERVIEW_LIMIT } from "@/lib/plans";
 import {
@@ -149,7 +149,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const { type, config } = parsed.data;
+  const { type, config, source_star_story_id } = parsed.data;
 
   // Validate config based on interview type
   if (config) {
@@ -168,6 +168,23 @@ export async function POST(request: NextRequest) {
   // (TypeScript loses the `session.user.id` non-null narrowing across the
   // async boundary).
   const userId = session.user.id;
+
+  // Validate source_star_story_id — must exist and belong to the requesting
+  // user. Return 400 (not 404) to avoid leaking the existence of another
+  // user's story.
+  if (source_star_story_id) {
+    const [story] = await db
+      .select({ id: starStories.id, userId: starStories.userId })
+      .from(starStories)
+      .where(eq(starStories.id, source_star_story_id));
+
+    if (!story || story.userId !== userId) {
+      return NextResponse.json(
+        { error: "Invalid source_star_story_id" },
+        { status: 400 }
+      );
+    }
+  }
 
   // Free-tier monthly limit gate. Pro users short-circuit out of the
   // counter entirely; free users at the limit get a 402 with a documented
@@ -199,6 +216,7 @@ export async function POST(request: NextRequest) {
           userId,
           type,
           config: config ?? {},
+          sourceStarStoryId: source_star_story_id ?? null,
         })
         .returning();
       return row;

--- a/apps/web/app/dashboard/sessions/[id]/feedback/page.tsx
+++ b/apps/web/app/dashboard/sessions/[id]/feedback/page.tsx
@@ -6,6 +6,13 @@ import { FeedbackDashboard } from "@/components/feedback/FeedbackDashboard";
 import type { TimelineEvent } from "@/components/feedback/TimelineView";
 import type { GazeDistribution, GazeTimelineBucket } from "@/lib/gaze-metrics";
 
+interface DriftAnalysis {
+  added: string[];
+  omitted: string[];
+  tightened: string[];
+  loosened: string[];
+}
+
 interface FeedbackData {
   overallScore: number;
   summary: string;
@@ -25,6 +32,7 @@ interface FeedbackData {
   gazeDistribution?: GazeDistribution | null;
   gazeCoverage?: number | null;
   gazeTimeline?: GazeTimelineBucket[] | null;
+  driftAnalysis?: DriftAnalysis | null;
 }
 
 const MAX_POLL_ATTEMPTS = 40; // 40 × 3s = 2 minutes max
@@ -108,6 +116,7 @@ export default function FeedbackPage() {
           gazeDistribution: data.gazeDistribution ?? undefined,
           gazeCoverage: data.gazeCoverage ?? undefined,
           gazeTimeline: data.gazeTimeline ?? undefined,
+          driftAnalysis: data.driftAnalysis ?? undefined,
         });
         setIsLoading(false);
         // Done — no more polling

--- a/apps/web/app/star/page.test.tsx
+++ b/apps/web/app/star/page.test.tsx
@@ -210,6 +210,7 @@ describe("StarPrepPage", () => {
 
     expect(mockSetBehavioralPrefill).toHaveBeenCalledWith({
       expected_questions: ["Tell me about a technical challenge"],
+      source_star_story_id: "story-1",
     });
     expect(mockPush).toHaveBeenCalledWith("/interview/behavioral/setup");
   });

--- a/apps/web/app/star/page.tsx
+++ b/apps/web/app/star/page.tsx
@@ -344,14 +344,14 @@ export default function StarPrepPage() {
 
   function handlePractice(story: StarStory) {
     // Pre-fill the behavioral setup form with this story's expected questions
-    // via prefillStore. The setup form consumes the store in its mount effect
-    // and applies the fields via setConfig. URL query params were used here
-    // before but were never read downstream.
+    // and source_star_story_id via prefillStore. The setup form consumes the
+    // store in its mount effect and applies the fields via setConfig.
     const questions = story.expectedQuestions.length
       ? story.expectedQuestions
       : [];
     setBehavioralPrefill({
       expected_questions: questions,
+      source_star_story_id: story.id,
     });
     router.push("/interview/behavioral/setup");
   }

--- a/apps/web/components/feedback/FeedbackDashboard.tsx
+++ b/apps/web/components/feedback/FeedbackDashboard.tsx
@@ -10,6 +10,7 @@ import { AnswerBreakdown } from "./AnswerBreakdown";
 import { CodeQualityCard } from "./CodeQualityCard";
 import { TimelineView, type TimelineEvent } from "./TimelineView";
 import { GazePresenceCard } from "./GazePresenceCard";
+import { PreparedVsSpokenCard, type DriftAnalysis } from "./PreparedVsSpokenCard";
 import type { GazeDistribution, GazeTimelineBucket } from "@/lib/gaze-metrics";
 
 interface AnswerAnalysis {
@@ -33,6 +34,7 @@ interface FeedbackData {
   gazeDistribution?: GazeDistribution | null;
   gazeCoverage?: number | null;
   gazeTimeline?: GazeTimelineBucket[] | null;
+  driftAnalysis?: DriftAnalysis | null;
 }
 
 interface FeedbackDashboardProps {
@@ -140,6 +142,12 @@ export function FeedbackDashboard({
           gazeCoverage={feedback.gazeCoverage}
           gazeTimeline={feedback.gazeTimeline ?? null}
         />
+      )}
+
+      {/* Prepared vs. Spoken drift card — behavioral only, when session was
+          linked to a STAR story (drift_analysis non-null) */}
+      {!isTechnical && feedback.driftAnalysis != null && (
+        <PreparedVsSpokenCard driftAnalysis={feedback.driftAnalysis} />
       )}
 
       {/* Breakdown + Timeline side-by-side for technical, full-width for behavioral */}

--- a/apps/web/components/feedback/PreparedVsSpokenCard.test.tsx
+++ b/apps/web/components/feedback/PreparedVsSpokenCard.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PreparedVsSpokenCard, PreparedVsSpokenCardSkeleton } from "./PreparedVsSpokenCard";
+
+const FULL_DRIFT = {
+  added: ["Mentioned the budget constraints explicitly"],
+  omitted: ["The 3-month timeline detail was dropped"],
+  tightened: ["Condensed the background from 3 sentences to 1"],
+  loosened: ["Vague about the technical solution used"],
+};
+
+const EMPTY_DRIFT = {
+  added: [],
+  omitted: [],
+  tightened: [],
+  loosened: [],
+};
+
+describe("PreparedVsSpokenCard", () => {
+  it("renders all 4 section headings", () => {
+    render(<PreparedVsSpokenCard driftAnalysis={FULL_DRIFT} />);
+    expect(screen.getAllByText(/added/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/omitted/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/tightened/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/loosened/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders bullet items for each section when data is present", () => {
+    render(<PreparedVsSpokenCard driftAnalysis={FULL_DRIFT} />);
+    expect(screen.getByText("Mentioned the budget constraints explicitly")).toBeDefined();
+    expect(screen.getByText("The 3-month timeline detail was dropped")).toBeDefined();
+    expect(screen.getByText("Condensed the background from 3 sentences to 1")).toBeDefined();
+    expect(screen.getByText("Vague about the technical solution used")).toBeDefined();
+  });
+
+  it("renders empty-state labels when arrays are empty", () => {
+    render(<PreparedVsSpokenCard driftAnalysis={EMPTY_DRIFT} />);
+    expect(screen.getByText(/nothing new added/i)).toBeDefined();
+    expect(screen.getByText(/nothing key was left out/i)).toBeDefined();
+    expect(screen.getByText(/no notable tightening/i)).toBeDefined();
+    expect(screen.getByText(/no notable loosening/i)).toBeDefined();
+  });
+
+  it("renders 'Prepared vs. Spoken' card title", () => {
+    render(<PreparedVsSpokenCard driftAnalysis={FULL_DRIFT} />);
+    expect(screen.getAllByText(/prepared vs\. spoken/i).length).toBeGreaterThan(0);
+  });
+
+  it("handles mixed empty and populated sections", () => {
+    const mixedDrift = {
+      added: ["Added detail about stakeholder buy-in"],
+      omitted: [],
+      tightened: [],
+      loosened: ["Less specific about the outcome metrics"],
+    };
+    render(<PreparedVsSpokenCard driftAnalysis={mixedDrift} />);
+    expect(screen.getByText("Added detail about stakeholder buy-in")).toBeDefined();
+    expect(screen.getByText(/nothing key was left out/i)).toBeDefined();
+    expect(screen.getByText(/no notable tightening/i)).toBeDefined();
+    expect(screen.getByText("Less specific about the outcome metrics")).toBeDefined();
+  });
+});
+
+describe("PreparedVsSpokenCardSkeleton", () => {
+  it("renders without crashing", () => {
+    render(<PreparedVsSpokenCardSkeleton />);
+    // Should render 4 skeleton sections matching card shape
+    const pulseElements = document.querySelectorAll(".animate-pulse");
+    expect(pulseElements.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/components/feedback/PreparedVsSpokenCard.tsx
+++ b/apps/web/components/feedback/PreparedVsSpokenCard.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { GitCompareArrows } from "lucide-react";
+
+export interface DriftAnalysis {
+  added: string[];
+  omitted: string[];
+  tightened: string[];
+  loosened: string[];
+}
+
+interface SectionProps {
+  title: string;
+  items: string[];
+  emptyLabel: string;
+}
+
+function DriftSection({ title, items, emptyLabel }: SectionProps) {
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+        {title}
+      </p>
+      {items.length === 0 ? (
+        <p className="text-sm text-muted-foreground italic">{emptyLabel}</p>
+      ) : (
+        <ul className="space-y-1">
+          {items.map((item, i) => (
+            <li key={i} className="flex gap-2 text-sm">
+              <span className="shrink-0 text-muted-foreground">&bull;</span>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+interface PreparedVsSpokenCardProps {
+  driftAnalysis: DriftAnalysis;
+}
+
+export function PreparedVsSpokenCard({ driftAnalysis }: PreparedVsSpokenCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <GitCompareArrows className="h-4 w-4" />
+          Prepared vs. Spoken
+        </CardTitle>
+        <p className="text-sm text-muted-foreground">
+          How your spoken answer evolved from your written STAR story — an opportunity to refine your preparation.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          <DriftSection
+            title="Added"
+            items={driftAnalysis.added}
+            emptyLabel="Nothing new added — your spoken answer stayed close to your preparation."
+          />
+          <DriftSection
+            title="Omitted"
+            items={driftAnalysis.omitted}
+            emptyLabel="Nothing key was left out — great coverage of your prepared story."
+          />
+          <DriftSection
+            title="Tightened"
+            items={driftAnalysis.tightened}
+            emptyLabel="No notable tightening — your level of detail was consistent."
+          />
+          <DriftSection
+            title="Loosened"
+            items={driftAnalysis.loosened}
+            emptyLabel="No notable loosening — your specificity held up well under pressure."
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Skeleton that mirrors the PreparedVsSpokenCard shape.
+ * Render this while the feedback data is loading.
+ */
+export function PreparedVsSpokenCardSkeleton() {
+  return (
+    <div className="rounded-lg border p-6 space-y-4">
+      <div className="space-y-1">
+        <div className="h-5 w-48 animate-pulse rounded bg-muted" />
+        <div className="h-4 w-72 animate-pulse rounded bg-muted" />
+      </div>
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="space-y-2">
+            <div className="h-3 w-20 animate-pulse rounded bg-muted" />
+            <div className="h-4 w-full animate-pulse rounded bg-muted" />
+            <div className="h-4 w-4/5 animate-pulse rounded bg-muted" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/interview/BehavioralSetupForm.tsx
+++ b/apps/web/components/interview/BehavioralSetupForm.tsx
@@ -38,6 +38,7 @@ export function BehavioralSetupForm() {
   const [generateError, setGenerateError] = useState<string | null>(null);
 
   const { behavioralPrefill, clearPrefill } = usePrefillStore();
+  const [sourceStarStoryId, setSourceStarStoryId] = useState<string | undefined>(undefined);
 
   // Fetch user's global gaze tracking preference
   useEffect(() => {
@@ -72,6 +73,9 @@ export function BehavioralSetupForm() {
       }
       if (behavioralPrefill.resume_id) {
         setConfig({ resume_id: behavioralPrefill.resume_id });
+      }
+      if (behavioralPrefill.source_star_story_id) {
+        setSourceStarStoryId(behavioralPrefill.source_star_story_id);
       }
       clearPrefill();
     }
@@ -134,7 +138,9 @@ export function BehavioralSetupForm() {
     setError(null);
     setIsSubmitting(true);
 
-    const sessionId = await createSession();
+    const sessionId = await createSession(
+      sourceStarStoryId ? { source_star_story_id: sourceStarStoryId } : undefined
+    );
     setIsSubmitting(false);
 
     if (sessionId) {

--- a/apps/web/drizzle/0015_common_old_lace.sql
+++ b/apps/web/drizzle/0015_common_old_lace.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "session_feedback" ADD COLUMN "drift_analysis" jsonb;

--- a/apps/web/drizzle/meta/0015_snapshot.json
+++ b/apps/web/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1423 @@
+{
+  "id": "5929f250-3ae5-4da8-864f-1beb20cfb122",
+  "prevId": "f8a71bb5-f0d6-46c1-9742-5160bb37035d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.code_snapshots": {
+      "name": "code_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "code_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_result": {
+          "name": "execution_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "code_snapshots_session_id_interview_sessions_id_fk": {
+          "name": "code_snapshots_session_id_interview_sessions_id_fk",
+          "tableFrom": "code_snapshots",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_questions": {
+      "name": "company_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_questions_user_id_users_id_fk": {
+          "name": "company_questions_user_id_users_id_fk",
+          "tableFrom": "company_questions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deleted_usage": {
+      "name": "deleted_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deleted_usage_hash_month_unique": {
+          "name": "deleted_usage_hash_month_unique",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gaze_samples": {
+      "name": "gaze_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gaze_samples_session_id_interview_sessions_id_fk": {
+          "name": "gaze_samples_session_id_interview_sessions_id_fk",
+          "tableFrom": "gaze_samples",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_plans": {
+      "name": "interview_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interview_date": {
+          "name": "interview_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_data": {
+          "name": "plan_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_plans_user_id_users_id_fk": {
+          "name": "interview_plans_user_id_users_id_fk",
+          "tableFrom": "interview_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_sessions": {
+      "name": "interview_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'configuring'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_star_story_id": {
+          "name": "source_star_story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_sessions_user_id_users_id_fk": {
+          "name": "interview_sessions_user_id_users_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interview_sessions_source_star_story_id_star_stories_id_fk": {
+          "name": "interview_sessions_source_star_story_id_star_stories_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "source_star_story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_usage": {
+      "name": "interview_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "interview_usage_user_period_unique": {
+          "name": "interview_usage_user_period_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interview_usage_user_id_users_id_fk": {
+          "name": "interview_usage_user_id_users_id_fk",
+          "tableFrom": "interview_usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.openai_usage": {
+      "name": "openai_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd_millis": {
+          "name": "cost_usd_millis",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "openai_usage_user_date_model_unique": {
+          "name": "openai_usage_user_date_model_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_feedback": {
+      "name": "session_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_score": {
+          "name": "overall_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strengths": {
+          "name": "strengths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "weaknesses": {
+          "name": "weaknesses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "answer_analyses": {
+          "name": "answer_analyses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "code_quality_score": {
+          "name": "code_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation_quality_score": {
+          "name": "explanation_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeline_analysis": {
+          "name": "timeline_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_consistency_score": {
+          "name": "gaze_consistency_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_distribution": {
+          "name": "gaze_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_coverage": {
+          "name": "gaze_coverage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_timeline": {
+          "name": "gaze_timeline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drift_analysis": {
+          "name": "drift_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_feedback_session_id_interview_sessions_id_fk": {
+          "name": "session_feedback_session_id_interview_sessions_id_fk",
+          "tableFrom": "session_feedback",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_templates": {
+      "name": "session_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_templates_user_id_users_id_fk": {
+          "name": "session_templates_user_id_users_id_fk",
+          "tableFrom": "session_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_stories": {
+      "name": "star_stories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_questions": {
+          "name": "expected_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "situation": {
+          "name": "situation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_stories_user_id_users_id_fk": {
+          "name": "star_stories_user_id_users_id_fk",
+          "tableFrom": "star_stories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_story_analyses": {
+      "name": "star_story_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scores": {
+          "name": "scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_story_analyses_story_id_star_stories_id_fk": {
+          "name": "star_story_analyses_story_id_star_stories_id_fk",
+          "tableFrom": "star_story_analyses",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcripts": {
+      "name": "transcripts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcripts_session_id_interview_sessions_id_fk": {
+          "name": "transcripts_session_id_interview_sessions_id_fk",
+          "tableFrom": "transcripts",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_badge_unique": {
+          "name": "user_badge_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "badge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_resumes": {
+      "name": "user_resumes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_resumes_user_id_users_id_fk": {
+          "name": "user_resumes_user_id_users_id_fk",
+          "tableFrom": "user_resumes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "user_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_start": {
+          "name": "plan_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_end": {
+          "name": "plan_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "past_due_at": {
+          "name": "past_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_tracking_enabled": {
+          "name": "gaze_tracking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tour_completed_at": {
+          "name": "tour_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tour_skipped_at": {
+          "name": "tour_skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.code_event_type": {
+      "name": "code_event_type",
+      "schema": "public",
+      "values": [
+        "edit",
+        "run",
+        "submit"
+      ]
+    },
+    "public.interview_type": {
+      "name": "interview_type",
+      "schema": "public",
+      "values": [
+        "behavioral",
+        "technical"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "configuring",
+        "in_progress",
+        "completed",
+        "cancelled",
+        "failed"
+      ]
+    },
+    "public.user_plan": {
+      "name": "user_plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "max"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1776480540783,
       "tag": "0014_many_mandroid",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1776490265188,
+      "tag": "0015_common_old_lace",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/analysis-behavioral.ts
+++ b/apps/web/lib/analysis-behavioral.ts
@@ -14,6 +14,7 @@ import OpenAI from "openai";
 import {
   buildBehavioralPrompt,
   BEHAVIORAL_SYSTEM_PROMPT,
+  type PreparedStarStory,
 } from "@/lib/analysis-prompts";
 import {
   FeedbackRequest,
@@ -25,12 +26,18 @@ import { OpenAIRetryError, withOpenAIRetry } from "@/lib/openai-retry";
 export interface RunBehavioralAnalysisOptions {
   log: pino.Logger;
   userId?: string;
+  /** Optional prepared STAR story for drift analysis */
+  preparedStory?: PreparedStarStory;
 }
 
 /**
  * Run behavioral analysis against OpenAI with retry + Zod validation.
  * Expects an already-Zod-parsed `FeedbackRequest` — does NOT re-validate input.
  * Throws `OpenAIRetryError` on retry exhaustion; propagates other errors as-is.
+ *
+ * When `opts.preparedStory` is provided the prompt includes the candidate's
+ * written STAR story and drift-analysis instructions; the returned
+ * `FeedbackResponse` will contain a `drift_analysis` field.
  */
 export async function runBehavioralAnalysis(
   input: FeedbackRequest,
@@ -38,7 +45,7 @@ export async function runBehavioralAnalysis(
 ): Promise<FeedbackResponse> {
   const { log } = opts;
   const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-  const prompt = buildBehavioralPrompt(input.transcript, input.config);
+  const prompt = buildBehavioralPrompt(input.transcript, input.config, opts.preparedStory);
 
   return withOpenAIRetry(
     () =>

--- a/apps/web/lib/analysis-prompts.test.ts
+++ b/apps/web/lib/analysis-prompts.test.ts
@@ -6,6 +6,7 @@ import {
   buildTechnicalPrompt,
   type BehavioralPromptConfig,
   type TechnicalPromptConfig,
+  type PreparedStarStory,
 } from "./analysis-prompts";
 import type {
   CodeSnapshotInput,
@@ -124,6 +125,70 @@ describe("buildBehavioralPrompt", () => {
     );
     const actual = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, SAMPLE_CONFIG);
     expect(actual).toBe(expected);
+  });
+
+  it("without preparedStory is byte-identical to baseline (no drift section)", () => {
+    const withoutStory = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, SAMPLE_CONFIG);
+    const alsoWithoutStory = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, SAMPLE_CONFIG, undefined);
+    expect(withoutStory).toBe(alsoWithoutStory);
+  });
+});
+
+// ---- buildBehavioralPrompt with preparedStory (drift analysis) ----
+
+const SAMPLE_STAR_STORY: PreparedStarStory = {
+  situation: "Our production system experienced a critical outage.",
+  task: "I needed to coordinate the on-call engineers to restore service.",
+  action: "I set up a war room, assigned roles, and led the post-mortem.",
+  result: "We restored service in 2 hours and reduced future incidents by 40%.",
+};
+
+describe("buildBehavioralPrompt with preparedStory", () => {
+  it("includes PREPARED STAR STORY markers when preparedStory provided", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, SAMPLE_CONFIG, SAMPLE_STAR_STORY);
+    expect(prompt).toContain("--- PREPARED STAR STORY ---");
+    expect(prompt).toContain("--- END PREPARED STAR STORY ---");
+  });
+
+  it("includes all four STAR sections from the story", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, SAMPLE_CONFIG, SAMPLE_STAR_STORY);
+    expect(prompt).toContain("Situation: Our production system");
+    expect(prompt).toContain("Task: I needed to coordinate");
+    expect(prompt).toContain("Action: I set up a war room");
+    expect(prompt).toContain("Result: We restored service");
+  });
+
+  it("includes drift_analysis instruction in prompt", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, SAMPLE_CONFIG, SAMPLE_STAR_STORY);
+    expect(prompt).toContain("drift_analysis");
+  });
+
+  it("includes guardrail: Return empty arrays when drift is minimal — no forcing 3 bullets", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, SAMPLE_CONFIG, SAMPLE_STAR_STORY);
+    expect(prompt).toContain("Return empty arrays when drift is minimal — no forcing 3 bullets");
+  });
+
+  it("includes guardrail: Only flag drift that's meaningful for answer quality (not tiny paraphrasing)", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, SAMPLE_CONFIG, SAMPLE_STAR_STORY);
+    expect(prompt).toContain("Only flag drift that's meaningful for answer quality (not tiny paraphrasing)");
+  });
+
+  it("includes guardrail: Do not invent drift that isn't there", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, SAMPLE_CONFIG, SAMPLE_STAR_STORY);
+    expect(prompt).toContain("Do not invent drift that isn't there");
+  });
+
+  it("still includes TRANSCRIPT section after STAR story section", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, SAMPLE_CONFIG, SAMPLE_STAR_STORY);
+    const starEndIdx = prompt.indexOf("--- END PREPARED STAR STORY ---");
+    const transcriptIdx = prompt.indexOf("--- TRANSCRIPT ---");
+    expect(starEndIdx).toBeLessThan(transcriptIdx);
+  });
+
+  it("prompt without story does NOT contain PREPARED STAR STORY section", () => {
+    const prompt = buildBehavioralPrompt(SAMPLE_TRANSCRIPT, SAMPLE_CONFIG);
+    expect(prompt).not.toContain("--- PREPARED STAR STORY ---");
+    expect(prompt).not.toContain("drift_analysis");
   });
 });
 

--- a/apps/web/lib/analysis-prompts.ts
+++ b/apps/web/lib/analysis-prompts.ts
@@ -107,6 +107,13 @@ Respond ONLY with valid JSON matching this exact structure:
 
 // ---- Behavioral prompt config ----
 
+export interface PreparedStarStory {
+  situation: string;
+  task: string;
+  action: string;
+  result: string;
+}
+
 export interface BehavioralPromptConfig {
   company_name?: string | null;
   job_description?: string | null;
@@ -120,10 +127,17 @@ export interface BehavioralPromptConfig {
  * from `_build_analysis_prompt` in feedback_generator.py — every `parts.append`
  * here corresponds to a Python `parts.append`, and the final `parts.join("\n")`
  * mirrors Python's `"\n".join(parts)`.
+ *
+ * When `preparedStory` is provided the prompt includes the candidate's
+ * written STAR story and drift-analysis instructions; the JSON schema gains a
+ * `drift_analysis` field. When `preparedStory` is absent the prompt is
+ * byte-identical to the version without drift support (snapshot-tested in
+ * analysis-prompts.test.ts).
  */
 export function buildBehavioralPrompt(
   transcript: TranscriptEntryInput[],
   config: BehavioralPromptConfig,
+  preparedStory?: PreparedStarStory,
 ): string {
   const parts: string[] = [];
 
@@ -144,6 +158,29 @@ export function buildBehavioralPrompt(
     parts.push("Interview level: Senior/Staff");
   } else {
     parts.push("Interview level: Mid-level");
+  }
+
+  // Prepared STAR story for drift analysis
+  if (preparedStory) {
+    parts.push("\n--- PREPARED STAR STORY ---\n");
+    parts.push(`Situation: ${preparedStory.situation}`);
+    parts.push(`Task: ${preparedStory.task}`);
+    parts.push(`Action: ${preparedStory.action}`);
+    parts.push(`Result: ${preparedStory.result}`);
+    parts.push("\n--- END PREPARED STAR STORY ---");
+    parts.push(
+      "\nCompare the candidate's spoken answer to the prepared STAR story above and return a drift_analysis field in your JSON response."
+    );
+    parts.push(
+      "drift_analysis must have four string arrays: added (details mentioned in the spoken answer not in the prepared story), omitted (meaningful details from the prepared story missing from the spoken answer), tightened (details that became more concise or focused), loosened (details that became vaguer or less specific)."
+    );
+    parts.push(
+      "Return empty arrays when drift is minimal — no forcing 3 bullets."
+    );
+    parts.push(
+      "Only flag drift that's meaningful for answer quality (not tiny paraphrasing)."
+    );
+    parts.push("Do not invent drift that isn't there.");
   }
 
   parts.push("\n--- TRANSCRIPT ---\n");

--- a/apps/web/lib/analysis-schemas.test.ts
+++ b/apps/web/lib/analysis-schemas.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   answerAnalysisSchema,
+  driftAnalysisSchema,
   feedbackRequestSchema,
   feedbackResponseSchema,
   technicalFeedbackRequestSchema,
@@ -76,6 +77,76 @@ describe("feedbackResponseSchema", () => {
     const { summary: _omit, ...without } = VALID_FEEDBACK_RESPONSE;
     void _omit;
     expect(feedbackResponseSchema.safeParse(without).success).toBe(false);
+  });
+
+  it("accepts drift_analysis when present with all four arrays", () => {
+    const result = feedbackResponseSchema.safeParse({
+      ...VALID_FEEDBACK_RESPONSE,
+      drift_analysis: {
+        added: ["mentioned budget"],
+        omitted: ["dropped timeline"],
+        tightened: ["concise background"],
+        loosened: [],
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.drift_analysis?.added).toHaveLength(1);
+    }
+  });
+
+  it("accepts drift_analysis as null", () => {
+    const result = feedbackResponseSchema.safeParse({
+      ...VALID_FEEDBACK_RESPONSE,
+      drift_analysis: null,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.drift_analysis).toBeNull();
+    }
+  });
+
+  it("accepts response without drift_analysis field (optional)", () => {
+    const result = feedbackResponseSchema.safeParse(VALID_FEEDBACK_RESPONSE);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.drift_analysis).toBeUndefined();
+    }
+  });
+});
+
+describe("driftAnalysisSchema", () => {
+  it("accepts valid drift with all four arrays", () => {
+    const result = driftAnalysisSchema.safeParse({
+      added: ["a"],
+      omitted: ["b"],
+      tightened: ["c"],
+      loosened: ["d"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts empty arrays for all sections", () => {
+    const result = driftAnalysisSchema.safeParse({
+      added: [],
+      omitted: [],
+      tightened: [],
+      loosened: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts null (no drift data)", () => {
+    const result = driftAnalysisSchema.safeParse(null);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBeNull();
+    }
+  });
+
+  it("rejects object missing required keys", () => {
+    const result = driftAnalysisSchema.safeParse({ added: [], omitted: [] });
+    expect(result.success).toBe(false);
   });
 });
 

--- a/apps/web/lib/analysis-schemas.ts
+++ b/apps/web/lib/analysis-schemas.ts
@@ -51,12 +51,21 @@ export const answerAnalysisSchema = z.object({
 });
 export type AnswerAnalysis = z.infer<typeof answerAnalysisSchema>;
 
+export const driftAnalysisSchema = z.object({
+  added: z.array(z.string()),
+  omitted: z.array(z.string()),
+  tightened: z.array(z.string()),
+  loosened: z.array(z.string()),
+}).nullable();
+export type DriftAnalysis = z.infer<typeof driftAnalysisSchema>;
+
 export const feedbackResponseSchema = z.object({
   overall_score: z.number().min(0).max(10),
   summary: z.string(),
   strengths: z.array(z.string()),
   weaknesses: z.array(z.string()),
   answer_analyses: z.array(answerAnalysisSchema),
+  drift_analysis: driftAnalysisSchema.optional(),
 });
 export type FeedbackResponse = z.infer<typeof feedbackResponseSchema>;
 

--- a/apps/web/lib/schema.ts
+++ b/apps/web/lib/schema.ts
@@ -182,6 +182,7 @@ export const sessionFeedback = pgTable("session_feedback", {
   gazeDistribution: jsonb("gaze_distribution"),
   gazeCoverage: real("gaze_coverage"),
   gazeTimeline: jsonb("gaze_timeline"),
+  driftAnalysis: jsonb("drift_analysis"),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/apps/web/lib/validations.ts
+++ b/apps/web/lib/validations.ts
@@ -36,6 +36,7 @@ export const problemSchema = z.object({
 export const createSessionSchema = z.object({
   type: z.enum(["behavioral", "technical"]),
   config: z.record(z.string(), z.unknown()).optional(),
+  source_star_story_id: z.string().uuid().optional(),
 });
 
 // ---- Timeline correlator schemas ----

--- a/apps/web/stores/interviewStore.ts
+++ b/apps/web/stores/interviewStore.ts
@@ -36,7 +36,7 @@ interface InterviewState {
   // Actions
   setType: (type: InterviewType) => void;
   setConfig: (partial: Partial<SessionConfig>) => void;
-  createSession: () => Promise<string | null>;
+  createSession: (extraFields?: { source_star_story_id?: string }) => Promise<string | null>;
   clearQuotaError: () => void;
   startSession: () => Promise<void>;
   endSession: () => Promise<void>;
@@ -79,7 +79,7 @@ export const useInterviewStore = create<InterviewState>((set, get) => ({
       config: { ...state.config, ...partial } as SessionConfig,
     })),
 
-  createSession: async () => {
+  createSession: async (extraFields?: { source_star_story_id?: string }) => {
     const { config, type } = get();
     const sessionType = type ?? "behavioral";
     set({ error: null, quotaError: null });
@@ -88,7 +88,7 @@ export const useInterviewStore = create<InterviewState>((set, get) => ({
       const res = await fetch("/api/sessions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ type: sessionType, config }),
+        body: JSON.stringify({ type: sessionType, config, ...extraFields }),
       });
 
       if (!res.ok) {

--- a/apps/web/stores/prefillStore.ts
+++ b/apps/web/stores/prefillStore.ts
@@ -7,6 +7,7 @@ interface PrefillState {
     company_name?: string;
     expected_questions?: string[];
     resume_id?: string;
+    source_star_story_id?: string;
   } | null;
 
   /** Pre-fill data for technical setup */


### PR DESCRIPTION
## Summary

Activates the dormant `source_star_story_id` column (added in Phase 3.5 but never used) so a behavioral session can be linked to a prepared STAR story and the post-session feedback can surface drift between the prepared answer and what was actually spoken.

User flow:
1. User writes a STAR story on `/star`
2. Clicks **Practice this question** → creates a behavioral session with `source_star_story_id`
3. After the session, the feedback page shows a **Prepared vs spoken** card with 4 sections (Added / Omitted / Tightened / Loosened)

Closes #146

## Commits

1. `feat(validations): accept source_star_story_id on session create`
2. `feat(schema): add drift_analysis column to session_feedback`
3. `feat(sessions): wire source_star_story_id with cross-user guard`
4. `feat(prefill): carry source_star_story_id from STAR to behavioral setup`
5. `feat(analysis): include prepared STAR story in prompt + drift_analysis`
6. `feat(feedback): PreparedVsSpokenCard with 4-section drift rendering`
7. `test(sessions): mock checkRateLimit and use valid uuid for nonexistent-id case`

## Scope deviation from the issue

**The issue said "no migration needed"; this PR includes migration 0015** adding a `drift_analysis jsonb` column to `session_feedback`. The agent chose a dedicated column over embedding into the existing JSONB because drift data is queryable/filterable per session. Reviewer should decide whether that's the right call or we should fold it into the existing feedback JSON instead.

## Key design choices

- **Cross-user story reference returns 400, not 404** (per the issue): the client supplied bad input, not requested a resource the route owns. Failing early is the friendlier signal.
- **Prompt guardrails are snapshot-tested** — the three load-bearing instructions (don't force bullets, only flag meaningful drift, don't invent drift) are asserted verbatim in `lib/analysis-prompts.test.ts`.
- **Without `source_star_story_id`**, the analysis prompt is byte-identical to today (snapshot-guarded), so existing behavior is unchanged for the 100% of sessions without a linked story.

## Test plan

Automated (green):
- [x] Lint + typecheck clean
- [x] 854 unit+component tests (includes `PreparedVsSpokenCard.test.tsx`, prompt snapshot tests, analysis schema tests)
- [x] 340 integration tests (includes 3 new cases for `source_star_story_id`: cross-user 400, nonexistent 400, null preserved)

Manual (reviewer, once pulled):
- [ ] Write a STAR story on `/star`; click **Practice this question**
- [ ] Complete the behavioral session
- [ ] Verify the feedback page shows the **Prepared vs spoken** card
- [ ] Confirm the 4 sections render even when some are empty (card shouldn't blow up)
- [ ] Start a session directly (not from `/star`) and verify the card does NOT appear (drift_analysis should be null)
- [ ] Try POSTing to `/api/sessions` with another user's story id via curl → expect 400

## Notes for reviewer

- The scope deviation on migration 0015 is worth a conscious accept/reject — easy to roll back if you'd rather embed in existing JSONB
- `checkRateLimit` mock added to the integration test because the earlier mock shape `{ success: true, ... }` was truthy and broke the handler (route treats a truthy return as "rate-limited, return this")
- Production sanity check: `SELECT COUNT(*) FROM interview_sessions WHERE source_star_story_id IS NOT NULL` should return 0 before this merges (column has been nullable and ignored since Phase 3.5 Story 39)

🤖 Generated with [Claude Code](https://claude.com/claude-code)