### PR TITLE
fix: STAR/planner prefill survives + Planner in top navbar

### DIFF
--- a/apps/web/components/interview/BehavioralSetupForm.test.tsx
+++ b/apps/web/components/interview/BehavioralSetupForm.test.tsx
@@ -33,10 +33,15 @@ vi.mock("@/stores/interviewStore", () => {
   return { useInterviewStore };
 });
 
+const { mockPrefillRef, mockClearPrefill } = vi.hoisted(() => ({
+  mockPrefillRef: { current: null as { expected_questions?: string[]; company_name?: string; resume_id?: string } | null },
+  mockClearPrefill: vi.fn(),
+}));
+
 vi.mock("@/stores/prefillStore", () => ({
   usePrefillStore: () => ({
-    behavioralPrefill: null,
-    clearPrefill: vi.fn(),
+    behavioralPrefill: mockPrefillRef.current,
+    clearPrefill: mockClearPrefill,
   }),
 }));
 
@@ -52,6 +57,7 @@ global.fetch = mockFetch;
 describe("BehavioralSetupForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPrefillRef.current = null;
   });
 
   it("renders company name input", () => {
@@ -149,5 +155,65 @@ describe("BehavioralSetupForm", () => {
     await vi.waitFor(() => {
       expect(screen.getByTestId("gaze-session-checkbox")).toBeTruthy();
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Regression: STAR "Practice this question" prefill must survive the effect
+  // that runs `setType("behavioral")`. The bug (pre-fix) was that the prefill
+  // effect and the setType effect were combined into one useEffect keyed on
+  // `behavioralPrefill`; `clearPrefill` at the end of the first run changed
+  // the dep, re-ran the effect, which re-called setType — and setType resets
+  // config to DEFAULT_BEHAVIORAL_CONFIG, wiping the just-applied prefill.
+  // ---------------------------------------------------------------------------
+  it("prefill survives: setType fires exactly once on mount even when prefill clears", () => {
+    mockPrefillRef.current = {
+      expected_questions: ["Tell me about a time you led under pressure"],
+    };
+    render(<BehavioralSetupForm />);
+    expect(mockSetType).toHaveBeenCalledTimes(1);
+    expect(mockSetType).toHaveBeenCalledWith("behavioral");
+  });
+
+  it("prefill survives: setConfig is called with expected_questions from STAR handoff", () => {
+    mockPrefillRef.current = {
+      expected_questions: [
+        "Tell me about a time you led under pressure",
+        "Describe a difficult technical challenge",
+      ],
+    };
+    render(<BehavioralSetupForm />);
+    expect(mockSetConfig).toHaveBeenCalledWith({
+      expected_questions: [
+        "Tell me about a time you led under pressure",
+        "Describe a difficult technical challenge",
+      ],
+    });
+    expect(mockClearPrefill).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefill survives: setConfig is called with company_name + resume_id together", () => {
+    mockPrefillRef.current = {
+      company_name: "Stripe",
+      resume_id: "resume-123",
+      expected_questions: ["Walk me through your resume"],
+    };
+    render(<BehavioralSetupForm />);
+    expect(mockSetConfig).toHaveBeenCalledWith({ company_name: "Stripe" });
+    expect(mockSetConfig).toHaveBeenCalledWith({
+      expected_questions: ["Walk me through your resume"],
+    });
+    expect(mockSetConfig).toHaveBeenCalledWith({ resume_id: "resume-123" });
+  });
+
+  it("no prefill: setConfig is NOT called on mount (empty prefill path)", () => {
+    mockPrefillRef.current = null;
+    render(<BehavioralSetupForm />);
+    // setConfig may be called by unrelated effects (e.g. gaze preference fetch)
+    // but never with prefill fields on a null-prefill mount.
+    const prefillCalls = mockSetConfig.mock.calls.filter((call) => {
+      const arg = call[0] as Record<string, unknown>;
+      return "expected_questions" in arg || "company_name" in arg || "resume_id" in arg;
+    });
+    expect(prefillCalls).toHaveLength(0);
   });
 });

--- a/apps/web/components/interview/BehavioralSetupForm.tsx
+++ b/apps/web/components/interview/BehavioralSetupForm.tsx
@@ -61,25 +61,33 @@ export function BehavioralSetupForm() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Set the interview type on mount. `setType` resets config to defaults,
+  // so this effect MUST NOT depend on `behavioralPrefill` — otherwise
+  // clearing the prefill triggers a re-run that wipes the just-applied
+  // values.
   useEffect(() => {
     setType("behavioral");
-    // Apply prefill from other pages (resume questions, planner, etc.)
-    if (behavioralPrefill) {
-      if (behavioralPrefill.company_name) {
-        setConfig({ company_name: behavioralPrefill.company_name });
-      }
-      if (behavioralPrefill.expected_questions?.length) {
-        setConfig({ expected_questions: behavioralPrefill.expected_questions });
-      }
-      if (behavioralPrefill.resume_id) {
-        setConfig({ resume_id: behavioralPrefill.resume_id });
-      }
-      if (behavioralPrefill.source_star_story_id) {
-        setSourceStarStoryId(behavioralPrefill.source_star_story_id);
-      }
-      clearPrefill();
+  }, [setType]);
+
+  // Apply prefill from other pages (resume questions, STAR, planner, etc.).
+  // Runs after the mount-only setType effect, then clears the prefill so the
+  // next visit doesn't redundantly re-apply stale values.
+  useEffect(() => {
+    if (!behavioralPrefill) return;
+    if (behavioralPrefill.company_name) {
+      setConfig({ company_name: behavioralPrefill.company_name });
     }
-  }, [setType, behavioralPrefill, clearPrefill, setConfig]);
+    if (behavioralPrefill.expected_questions?.length) {
+      setConfig({ expected_questions: behavioralPrefill.expected_questions });
+    }
+    if (behavioralPrefill.resume_id) {
+      setConfig({ resume_id: behavioralPrefill.resume_id });
+    }
+    if (behavioralPrefill.source_star_story_id) {
+      setSourceStarStoryId(behavioralPrefill.source_star_story_id);
+    }
+    clearPrefill();
+  }, [behavioralPrefill, clearPrefill, setConfig]);
 
   const behavioralConfig = config as BehavioralSessionConfig;
   const interviewStyle = typeof behavioralConfig.interview_style === "number" ? behavioralConfig.interview_style : 0.5;

--- a/apps/web/components/interview/TechnicalSetupForm.tsx
+++ b/apps/web/components/interview/TechnicalSetupForm.tsx
@@ -86,24 +86,32 @@ export function TechnicalSetupForm() {
     return segment ? segment.slice(OTHER_PREFIX.length) : "";
   })();
 
+  // Set the interview type on mount. `setType` resets config to defaults,
+  // so this effect MUST NOT depend on `technicalPrefill` — otherwise
+  // clearing the prefill triggers a re-run that wipes the just-applied
+  // values.
   useEffect(() => {
     setType("technical");
-    if (technicalPrefill) {
-      if (technicalPrefill.interview_type) {
-        setConfig({ interview_type: technicalPrefill.interview_type, focus_areas: [] });
-      }
-      if (technicalPrefill.focus_areas?.length) {
-        setConfig({ focus_areas: technicalPrefill.focus_areas });
-      }
-      if (technicalPrefill.additional_instructions) {
-        setConfig({ additional_instructions: technicalPrefill.additional_instructions });
-      }
-      if (technicalPrefill.resume_id) {
-        setConfig({ resume_id: technicalPrefill.resume_id });
-      }
-      clearPrefill();
+  }, [setType]);
+
+  // Apply prefill from other pages (resume, planner, etc.). Runs after
+  // setType and clears the prefill so the next visit starts fresh.
+  useEffect(() => {
+    if (!technicalPrefill) return;
+    if (technicalPrefill.interview_type) {
+      setConfig({ interview_type: technicalPrefill.interview_type, focus_areas: [] });
     }
-  }, [setType, technicalPrefill, clearPrefill, setConfig]);
+    if (technicalPrefill.focus_areas?.length) {
+      setConfig({ focus_areas: technicalPrefill.focus_areas });
+    }
+    if (technicalPrefill.additional_instructions) {
+      setConfig({ additional_instructions: technicalPrefill.additional_instructions });
+    }
+    if (technicalPrefill.resume_id) {
+      setConfig({ resume_id: technicalPrefill.resume_id });
+    }
+    clearPrefill();
+  }, [technicalPrefill, clearPrefill, setConfig]);
 
   const toggleFocusArea = (area: string) => {
     if (area === "other") {

--- a/apps/web/components/shared/Header.tsx
+++ b/apps/web/components/shared/Header.tsx
@@ -20,6 +20,7 @@ import { Sidebar } from "./Sidebar";
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard" },
+  { href: "/planner", label: "Planner" },
   { href: "/interview/behavioral/setup", label: "Behavioral" },
   { href: "/interview/technical/setup", label: "Technical" },
   { href: "/star", label: "STAR Prep" },


### PR DESCRIPTION
## Summary

Two independent UX bugs in one fix branch.

### Bug 1 — STAR "Practice this question" lands on an empty form

\`BehavioralSetupForm\` and \`TechnicalSetupForm\` each had a single \`useEffect\` that both set the interview type AND applied prefill, keyed on the prefill value. Walk-through:

1. First run: \`setType("behavioral")\` resets config to defaults → prefill values merged in → \`clearPrefill()\`
2. \`clearPrefill\` flips the prefill ref to null in the Zustand store
3. That change re-runs the effect
4. \`setType("behavioral")\` fires **again** — which resets config to defaults
5. The \`if (prefill)\` block skips (prefill is now null)
6. **Result: prefill values wiped.** User lands on empty form.

Root cause: \`setType\` isn't idempotent — it wipes config on every call. Keying it on a dep that mutates during the same tick is fatal.

Fix: split into two effects — mount-only \`setType\` (deps=\`[setType]\`, stable), prefill application runs when prefill changes. Technical form had the identical bug; same fix applied.

### Bug 2 — Planner missing from top navbar

Present in the mobile sidebar, absent in \`components/shared/Header.tsx\`. Added it between Dashboard and Behavioral to match Sidebar ordering.

## Test plan

- [x] 17 component tests pass on \`BehavioralSetupForm.test.tsx\` (13 original + 4 new regression tests asserting setType fires exactly once and setConfig is called with prefill values)
- [x] Full \`npx turbo lint typecheck test --filter=@preploy/web\` suite green
- [ ] Manual: from \`/star\`, click "Practice this question" on a story — behavioral setup should pre-populate the expected_questions list and company (if present on the story)
- [ ] Manual: from \`/planner\`, click a technical day CTA — technical setup should pre-populate interview_type + focus_areas
- [ ] Manual: confirm Planner link appears in the desktop top navbar

## Notes

- The bug is load-bearing for PR #158 (STAR drift analysis) — without this fix, \`source_star_story_id\` would also be wiped by the same mechanism, breaking the whole drift feature. Worth merging this before #158.
- The split-effect pattern is a common React footgun; the comments added inline explain *why* they must stay separate so future edits don't accidentally recombine them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)