### PR TITLE
fix: Change order of top Navbar so that it matches the order of Sidebar

### DIFF
--- a/apps/web/components/shared/Header.tsx
+++ b/apps/web/components/shared/Header.tsx
@@ -20,11 +20,11 @@ import { Sidebar } from "./Sidebar";
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard" },
-  { href: "/planner", label: "Planner" },
   { href: "/interview/behavioral/setup", label: "Behavioral" },
   { href: "/interview/technical/setup", label: "Technical" },
   { href: "/star", label: "STAR Prep" },
   { href: "/coaching", label: "Coaching" },
+  { href: "/planner", label: "Planner" },
   { href: "/resume", label: "Resume" },
   { href: "/achievements", label: "Achievements" },
 ];


### PR DESCRIPTION
The order of top Navbar (especially with the Planner link) was different to the relative order on the side Navbar. This could cause confusion and unnatural experience to the users. 