### PR TITLE
fix(planner): harden resolveDayType against off-enum day_type values

### DIFF
--- a/apps/web/lib/plan-generator.test.ts
+++ b/apps/web/lib/plan-generator.test.ts
@@ -210,6 +210,22 @@ describe("resolveDayType", () => {
     const day = makeDay({ focus: "behavioral", day_type: "technical" });
     expect(resolveDayType(day)).toBe("technical");
   });
+
+  it("ignores an off-enum day_type and falls back to focus", () => {
+    const day = makeDay({
+      focus: "technical",
+      day_type: "star_prep" as unknown as PlanDay["day_type"],
+    });
+    expect(resolveDayType(day)).toBe("technical");
+  });
+
+  it("returns behavioral when both day_type and focus are off-enum", () => {
+    const day = makeDay({
+      focus: "review" as unknown as PlanDay["focus"],
+      day_type: "mock-interview" as unknown as PlanDay["day_type"],
+    });
+    expect(resolveDayType(day)).toBe("behavioral");
+  });
 });
 
 describe("extractWeakAreas", () => {

--- a/apps/web/lib/plan-generator.ts
+++ b/apps/web/lib/plan-generator.ts
@@ -134,14 +134,32 @@ export function extractWeakAreas(
     .map(([weakness]) => weakness);
 }
 
+const VALID_DAY_TYPES: readonly PlanDayType[] = [
+  "behavioral",
+  "technical",
+  "star-prep",
+  "resume",
+  "coaching",
+];
+
+function isValidDayType(value: unknown): value is PlanDayType {
+  return (
+    typeof value === "string" &&
+    (VALID_DAY_TYPES as readonly string[]).includes(value)
+  );
+}
+
 /**
  * Resolve the effective day type for a PlanDay.
- * Uses `day_type` if present (new plans), otherwise falls back to `focus`
- * (legacy plans generated before day_type was added).
+ * Uses `day_type` if present and valid (new plans), otherwise falls back to
+ * `focus` (legacy plans generated before day_type was added). Unknown values
+ * produced by older GPT outputs collapse to `"behavioral"` so render paths
+ * keyed on the enum never blow up.
  */
 export function resolveDayType(day: PlanDay): PlanDayType {
-  if (day.day_type) return day.day_type;
-  return day.focus;
+  if (isValidDayType(day.day_type)) return day.day_type;
+  if (isValidDayType(day.focus)) return day.focus;
+  return "behavioral";
 }
 
 /**


### PR DESCRIPTION
## Summary
- Planner page was crashing on render with `TypeError: Cannot read properties of undefined (reading 'variant')` whenever a stored plan contained a `day_type` that didn't match the `PlanDayType` union (e.g. an older GPT response emitting `"star_prep"`, `"review"`, or `"mock-interview"`). `DAY_TYPE_BADGE[dayType]` / `DAY_TYPE_CONFIG[dayType]` returned `undefined`, the throw bubbled through the whole tree, and `global-error.tsx` took over — users saw the skeleton briefly, then "Something went wrong."
- `resolveDayType` now validates `day.day_type` against the enum, falls back to `day.focus` when it's valid, and collapses any remaining unknown value to `"behavioral"` so the render path can never land on an undefined config.
- Added two regression tests covering off-enum `day_type` + valid `focus`, and off-enum on both fields.

## Test plan
- [x] `npx vitest run lib/plan-generator.test.ts` — 33 passed
- [x] `npx vitest run app/planner/planner.test.tsx components/planner/DayActionButton.test.tsx` — 17 passed
- [x] `npx turbo lint typecheck --filter=@preploy/web` — clean
- [ ] Load `/planner` in dev with a plan whose `day_type` is off-enum and confirm it renders as a behavioral day instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)