### PR TITLE
feat(design): token layer overhaul — editorial coaching studio (#142 Part 2 Theme A)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,11 +4,25 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/*
+ * Preploy design tokens — "editorial coaching studio"
+ *
+ * Goal: a calm, trustworthy environment for people preparing for interviews.
+ * Not another shadcn-default SaaS. Warm paper backgrounds, grounded cedar-green
+ * brand, restrained terracotta for destructive actions, and a chart palette
+ * whose hues actually mean something (cedar = strong, amber = middling,
+ * terracotta = weak). See dev_logs/design-audit-2026-04.md for the full brief.
+ */
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-sans);
   --font-mono: var(--font-geist-mono);
+  --font-display: var(--font-display);
+  /* `font-heading` is the shadcn utility applied on card / sheet / alert-dialog
+   * titles — kept on the sans stack so dense UI doesn't turn into a wall of
+   * serif. Only h1 opts into the display face (see @layer base below). */
   --font-heading: var(--font-sans);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -46,75 +60,129 @@
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
+
+  /* Elevation — warm-tinted, not cheap black */
+  --shadow-xs: 0 1px 1px 0 oklch(0.2 0.02 260 / 0.04);
+  --shadow-sm:
+    0 1px 2px 0 oklch(0.2 0.02 260 / 0.06),
+    0 1px 1px 0 oklch(0.2 0.02 260 / 0.04);
+  --shadow-md:
+    0 6px 12px -2px oklch(0.2 0.02 260 / 0.08),
+    0 2px 4px 0 oklch(0.2 0.02 260 / 0.05);
+  --shadow-lg:
+    0 16px 32px -8px oklch(0.2 0.02 260 / 0.1),
+    0 4px 8px 0 oklch(0.2 0.02 260 / 0.06);
+  --shadow-xl:
+    0 24px 48px -12px oklch(0.15 0.02 260 / 0.14),
+    0 8px 16px 0 oklch(0.15 0.02 260 / 0.08);
+
+  /* Motion primitives — exposed as custom properties so components can
+   * reach for them via `duration-[var(--duration-base)]` or inline style.
+   * All aesthetic consumers should wrap in `motion-safe:`. */
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-in: cubic-bezier(0.5, 0, 1, 1);
+  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+  --duration-fast: 120ms;
+  --duration-base: 200ms;
+  --duration-slow: 320ms;
 }
 
+/* ─── Light mode ──────────────────────────────────────────────────────────
+ * Warm paper (H≈85) background with deep ink (H≈250) text. Cards are pure
+ * white so they lift off the warm bg with a quiet halo. Primary is a grounded
+ * cedar green (L=0.48 C=0.09 H=158) — confident, not a bright brand-emerald.
+ */
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
+  --background: oklch(0.985 0.008 85);
+  --foreground: oklch(0.22 0.018 250);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
+  --card-foreground: oklch(0.22 0.018 250);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
+  --popover-foreground: oklch(0.22 0.018 250);
+  --primary: oklch(0.48 0.09 158);
+  --primary-foreground: oklch(0.985 0.006 85);
+  --secondary: oklch(0.955 0.006 75);
+  --secondary-foreground: oklch(0.22 0.018 250);
+  --muted: oklch(0.955 0.006 75);
+  --muted-foreground: oklch(0.48 0.012 250);
+  --accent: oklch(0.94 0.03 85);
+  --accent-foreground: oklch(0.22 0.018 250);
+  --destructive: oklch(0.56 0.18 25);
+  --border: oklch(0.89 0.008 75);
+  --input: oklch(0.89 0.008 75);
+  --ring: oklch(0.48 0.09 158);
+  --chart-1: oklch(0.55 0.12 158); /* cedar — strong */
+  --chart-2: oklch(0.78 0.14 85); /* amber — middling */
+  --chart-3: oklch(0.67 0.16 50); /* burnt orange — low-mid */
+  --chart-4: oklch(0.56 0.18 25); /* terracotta — weak */
+  --chart-5: oklch(0.58 0.08 240); /* slate blue — neutral/info */
   --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar: oklch(0.98 0.006 85);
+  --sidebar-foreground: oklch(0.22 0.018 250);
+  --sidebar-primary: oklch(0.48 0.09 158);
+  --sidebar-primary-foreground: oklch(0.985 0.006 85);
+  --sidebar-accent: oklch(0.94 0.03 85);
+  --sidebar-accent-foreground: oklch(0.22 0.018 250);
+  --sidebar-border: oklch(0.89 0.008 75);
+  --sidebar-ring: oklch(0.48 0.09 158);
 }
 
+/* ─── Dark mode ───────────────────────────────────────────────────────────
+ * Ink-navy (H≈260) with warm paper text — the inverse warmth of light mode
+ * keeps the system cohesive rather than "inverted colors." Cedar lifts to
+ * L=0.68 so the brand reads at the right contrast against the dark bg.
+ */
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: oklch(0.16 0.015 260);
+  --foreground: oklch(0.94 0.006 85);
+  --card: oklch(0.2 0.018 260);
+  --card-foreground: oklch(0.94 0.006 85);
+  --popover: oklch(0.2 0.018 260);
+  --popover-foreground: oklch(0.94 0.006 85);
+  --primary: oklch(0.68 0.12 158);
+  --primary-foreground: oklch(0.16 0.015 260);
+  --secondary: oklch(0.24 0.012 260);
+  --secondary-foreground: oklch(0.94 0.006 85);
+  --muted: oklch(0.24 0.012 260);
+  --muted-foreground: oklch(0.7 0.008 85);
+  --accent: oklch(0.26 0.018 80);
+  --accent-foreground: oklch(0.94 0.006 85);
+  --destructive: oklch(0.65 0.17 25);
+  --border: oklch(0.28 0.01 260);
+  --input: oklch(0.28 0.01 260);
+  --ring: oklch(0.68 0.12 158);
+  --chart-1: oklch(0.72 0.13 158);
+  --chart-2: oklch(0.82 0.13 85);
+  --chart-3: oklch(0.72 0.15 50);
+  --chart-4: oklch(0.68 0.17 25);
+  --chart-5: oklch(0.7 0.1 240);
+  --sidebar: oklch(0.18 0.016 260);
+  --sidebar-foreground: oklch(0.94 0.006 85);
+  --sidebar-primary: oklch(0.68 0.12 158); /* brand cedar — replaces the stray blue */
+  --sidebar-primary-foreground: oklch(0.16 0.015 260);
+  --sidebar-accent: oklch(0.24 0.012 260);
+  --sidebar-accent-foreground: oklch(0.94 0.006 85);
+  --sidebar-border: oklch(0.28 0.01 260);
+  --sidebar-ring: oklch(0.68 0.12 158);
+}
+
+/* Dark-mode shadows trade drop-shadow for an inset top-highlight + deeper
+ * outer, which reads as real depth on a dark surface instead of the usual
+ * "smudge of black" you get when you naively reuse light-mode shadows. */
+.dark {
+  --shadow-xs: inset 0 1px 0 0 oklch(1 0 0 / 0.03);
+  --shadow-sm:
+    inset 0 1px 0 0 oklch(1 0 0 / 0.04),
+    0 1px 2px 0 oklch(0 0 0 / 0.3);
+  --shadow-md:
+    inset 0 1px 0 0 oklch(1 0 0 / 0.05),
+    0 6px 16px -4px oklch(0 0 0 / 0.4);
+  --shadow-lg:
+    inset 0 1px 0 0 oklch(1 0 0 / 0.06),
+    0 16px 32px -8px oklch(0 0 0 / 0.45);
+  --shadow-xl:
+    inset 0 1px 0 0 oklch(1 0 0 / 0.07),
+    0 24px 48px -12px oklch(0 0 0 / 0.5);
 }
 
 @layer base {
@@ -123,8 +191,48 @@
   }
   body {
     @apply bg-background text-foreground;
+    font-feature-settings:
+      "ss01" on,
+      "cv11" on;
   }
   html {
-    @apply font-sans;
+    @apply font-sans antialiased;
+  }
+
+  /* Only h1 opts into the serif display face automatically — the visible
+   * "this is a redesigned product" signal. h2+ stays on Instrument Sans so
+   * dense UI headings don't turn into a wall of serif. */
+  h1 {
+    font-family: var(--font-display);
+    font-optical-sizing: auto;
+    letter-spacing: -0.015em;
+  }
+
+  /* Slight negative tracking on display-sized sans headings — gives h2 a
+   * confident, settled look without crossing into cramped territory. */
+  h2 {
+    letter-spacing: -0.01em;
+  }
+
+  /* Tabular numerals for anything that looks like a number column. */
+  time,
+  .tabular-nums {
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+/* Respect `prefers-reduced-motion` globally for any consumer that forgets
+ * the `motion-safe:` prefix — animations get reduced to near-zero, never
+ * completely removed (so state changes stay perceivable), transitions
+ * snap. This is a safety net, not a license to ship motion without the
+ * prefix. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/apps/web/app/layout.test.tsx
+++ b/apps/web/app/layout.test.tsx
@@ -3,7 +3,8 @@ import { render, screen } from "@testing-library/react";
 
 // Mock next/font/google before importing layout
 vi.mock("next/font/google", () => ({
-  Geist: () => ({ variable: "--font-sans", className: "geist-sans" }),
+  Fraunces: () => ({ variable: "--font-display", className: "fraunces" }),
+  Instrument_Sans: () => ({ variable: "--font-sans", className: "instrument-sans" }),
   Geist_Mono: () => ({ variable: "--font-geist-mono", className: "geist-mono" }),
 }));
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Fraunces, Instrument_Sans, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Header } from "@/components/shared/Header";
 import { Providers } from "@/components/shared/Providers";
@@ -7,14 +7,31 @@ import { AchievementToastProvider } from "@/components/shared/AchievementToastPr
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 
-const geistSans = Geist({
-  variable: "--font-sans",
+// Display — Fraunces, used for h1 / hero / score numerals. Variable with optical
+// sizing so it looks right at every display size and reads as editorial rather
+// than "another SaaS serif."
+const fraunces = Fraunces({
+  variable: "--font-display",
   subsets: ["latin"],
+  axes: ["opsz", "SOFT"],
+  display: "swap",
 });
 
+// Body / UI — Instrument Sans. Neo-grotesque workhorse with real character,
+// replaces the previous Geist Sans default. Variable for full weight range.
+const instrumentSans = Instrument_Sans({
+  variable: "--font-sans",
+  subsets: ["latin"],
+  display: "swap",
+});
+
+// Mono — Geist Mono retained for code editor, transcript, timer, and tabular
+// numerals. The existing `--font-geist-mono` variable name is preserved so no
+// downstream components need to change.
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+  display: "swap",
 });
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? "https://preploy.tech";
@@ -53,7 +70,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable}`}
+      className={`${fraunces.variable} ${instrumentSans.variable} ${geistMono.variable}`}
       suppressHydrationWarning
     >
       <body className="min-h-screen flex flex-col" suppressHydrationWarning>


### PR DESCRIPTION
## Summary
Foundational design-system work for [#142](https://github.com/scy02718/Preploy/issues/142). Implements **Theme A (Token layer)** from the prioritized Part-2 backlog in `dev_logs/design-audit-2026-04.md`. Every downstream theme inherits from this layer, so it lands first as its own reviewable PR.

The audit called out the current UI as "typical AI-generated aesthetic" — achromatic palette, self-referential font variable, grey charts, stray dark-mode blue. This PR swaps the foundation for a considered system that reads as a calm coaching studio rather than another shadcn starter:

- **Typography (no Plus Jakarta, no Inter)**: Fraunces (variable, `opsz` + `SOFT` axes) as the display face used on `h1` only; Instrument Sans as the sans workhorse for all UI chrome; Geist Mono retained for code / transcript / timer / tabular numerals. All three loaded through `next/font/google` with `display: swap`. CSS variables `--font-display`, `--font-sans`, `--font-mono`. `--font-heading` deliberately stays on sans so shadcn card / sheet / alert-dialog titles don't turn into a wall of serif — we can promote them in a follow-up if the h1 treatment lands well.
- **Color tokens with real chroma (oklch)**: warm paper background (L=0.985 H=85) + deep-ink foreground (L=0.22 H=250) + grounded cedar primary (L=0.48 C=0.09 H=158) + terracotta destructive + amber accent. Dark mode is ink-navy (H=260) with lifted cedar at L=0.68. Every neutral carries a warm tint; no pure greys.
- **Chart tokens with meaning**: cedar (high) / amber (mid) / burnt orange (low-mid) / terracotta (low) / slate blue (info) — score visualisations now communicate via hue.
- **Sidebar-primary dark** swapped from the stray indigo to brand cedar for consistency.
- **Shadow scale**: warm-tinted drop shadows in light mode; inset top-highlight + deep outer shadow in dark mode. No more cheap CSS-black smudges on the warm bg.
- **Motion primitives**: `--ease-out/in/in-out`, `--duration-fast/base/slow` exposed as CSS vars, plus a global `prefers-reduced-motion` safety net capping animation + transition duration to 0.01ms.
- **h1 opts into the display face via `@layer base`** — every page title gets the Fraunces moment automatically, no consumer changes required.

## Scope

**Theme A only.** This PR does not touch component code or page markup — it deliberately keeps the blast radius to `app/layout.tsx`, `app/globals.css`, and the layout test's font mock, so the diff is reviewable and the follow-up themes (B–H from the audit) can land in focused PRs:

- Theme B: global icon / element hygiene (`&times;` → `<X>`, raw `*` bullets → Lucide, Planner `<Building2>` labels)
- Theme C: skeleton system completion (Sidebar Recent Sessions, conditional gaze skeleton)
- Theme D: accessibility blockers (STAR `confirm()`/`alert()` → AlertDialog, FAQ `aria-expanded`, Show Transcript `aria-controls`)
- Theme E: motion / reduced-motion audit
- Theme F: navigation + routing fixes (Header dropdown `window.location.assign` → `router.push`, feedback back-link)
- Theme G: empty & error states (Planner silent generate failure, tech session retry)
- Theme H: forms polish

## Test plan

- [x] `npx turbo lint typecheck test --filter=@preploy/web` → 3 tasks green, **889/889 tests pass**
- [x] `next dev` smoke: http://localhost:3001/ renders in both light + dark modes. Computed body background = `lab(98.29% …)` light and `lab(3.66% …)` dark; computed `--primary` = `lab(40.87% -29.4 12.9)` (cedar) light and `lab(64.46% -39.1 17.2)` (lifted cedar) dark — exactly the intended token values.
- [x] Landing page screenshots captured in light + dark; Fraunces loads on the hero `h1`, cedar CTA button renders, warm-paper bg replaces clinical white, ink-navy bg replaces flat black.
- [ ] Follow-up PRs (Themes B–H) will adopt the motion / shadow / chart tokens and carry page-level screenshots for each redesigned surface.

## Screenshots

**Light mode — warm paper + cedar + Fraunces h1**
_(verify locally via `npm run dev` and `localStorage.theme = "light"`)_

**Dark mode — ink navy + lifted cedar + Fraunces h1**
_(verify locally via `npm run dev` and `localStorage.theme = "dark"`)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)