### PR TITLE
feat(design): Themes B–H sweep — a11y + hygiene + polish (#142 Part 2)

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
 import { signIn } from "@/lib/auth";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -20,26 +22,35 @@ export const metadata: Metadata = {
 export default function LoginPage() {
   return (
     <div className="flex items-center justify-center min-h-[calc(100vh-3.5rem)] px-4">
-      <Card className="w-full max-w-sm">
-        <CardHeader className="text-center">
-          <CardTitle className="text-2xl">Welcome Back</CardTitle>
-          <CardDescription>
-            Sign in to access your interview sessions.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form
-            action={async () => {
-              "use server";
-              await signIn("google", { redirectTo: "/dashboard" });
-            }}
-          >
-            <Button className="w-full" size="lg" type="submit">
-              Sign in with Google
-            </Button>
-          </form>
-        </CardContent>
-      </Card>
+      <div className="w-full max-w-sm space-y-4">
+        <Link
+          href="/"
+          className="inline-flex h-9 items-center gap-1.5 rounded-md px-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+          Back to home
+        </Link>
+        <Card>
+          <CardHeader className="text-center">
+            <CardTitle className="text-2xl">Sign in to Preploy</CardTitle>
+            <CardDescription>
+              Continue with Google to pick up where you left off.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form
+              action={async () => {
+                "use server";
+                await signIn("google", { redirectTo: "/dashboard" });
+              }}
+            >
+              <Button className="w-full" size="lg" type="submit">
+                Sign in with Google
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/coaching/behavioral/page.tsx
+++ b/apps/web/app/coaching/behavioral/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CompetencyChips } from "@/components/coaching/CompetencyChips";
 import type { CompetencyItem } from "@/components/coaching/CompetencyChips";
+import { Lightbulb } from "lucide-react";
 
 function Section({
   title,
@@ -27,8 +28,11 @@ function Section({
 
 function Tip({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex gap-2 rounded-md border bg-primary/5 px-4 py-3 text-sm">
-      <span className="shrink-0 text-primary">*</span>
+    <div className="flex gap-3 rounded-md border border-primary/20 bg-primary/5 px-4 py-3 text-sm">
+      <Lightbulb
+        className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+        aria-hidden="true"
+      />
       <span>{children}</span>
     </div>
   );
@@ -228,8 +232,8 @@ export default function BehavioralPage() {
           Question: &quot;Tell me about a time you had to meet a tight deadline.&quot;
         </p>
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <div className="rounded-md border border-green-600/30 bg-green-50/50 p-3 dark:bg-green-950/20">
-            <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-green-700 dark:text-green-400">
+          <div className="rounded-md border border-primary/25 bg-primary/5 p-3">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-primary">
               Strong answer
             </p>
             <p className="text-muted-foreground">
@@ -241,8 +245,8 @@ export default function BehavioralPage() {
               dependency risk earlier.&quot;
             </p>
           </div>
-          <div className="rounded-md border border-red-600/30 bg-red-50/50 p-3 dark:bg-red-950/20">
-            <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-red-700 dark:text-red-400">
+          <div className="rounded-md border border-destructive/25 bg-destructive/5 p-3">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-destructive">
               Weak answer
             </p>
             <p className="text-muted-foreground">

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -422,7 +422,7 @@ export default function DashboardPage() {
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4">
         <h2 className="text-lg font-semibold">Session History</h2>
         <div className="flex gap-2">
-          <Select value={typeFilter} onValueChange={handleTypeChange}>
+          <Select value={typeFilter} onValueChange={(v) => handleTypeChange(v ?? "all")}>
             <SelectTrigger
               aria-label="Filter by session type"
               className="h-9 w-[140px]"
@@ -435,7 +435,7 @@ export default function DashboardPage() {
               <SelectItem value="technical">Technical</SelectItem>
             </SelectContent>
           </Select>
-          <Select value={scoreFilter} onValueChange={handleScoreChange}>
+          <Select value={scoreFilter} onValueChange={(v) => handleScoreChange(v ?? "all")}>
             <SelectTrigger
               aria-label="Filter by score"
               className="h-9 w-[160px]"

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -7,6 +7,13 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { getScoreColor } from "@/lib/utils";
 import { ChevronLeft, ChevronRight, MessageSquare, Code } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { StreakCard } from "@/components/dashboard/StreakCard";
 import { BadgeGrid } from "@/components/dashboard/BadgeGrid";
 import { ScoreTrendChart, ScoreTrendPoint } from "@/components/dashboard/ScoreTrendChart";
@@ -415,25 +422,33 @@ export default function DashboardPage() {
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4">
         <h2 className="text-lg font-semibold">Session History</h2>
         <div className="flex gap-2">
-          <select
-            value={typeFilter}
-            onChange={(e) => handleTypeChange(e.target.value)}
-            className="rounded-md border bg-background px-3 py-1.5 text-sm"
-          >
-            <option value="all">All Types</option>
-            <option value="behavioral">Behavioral</option>
-            <option value="technical">Technical</option>
-          </select>
-          <select
-            value={scoreFilter}
-            onChange={(e) => handleScoreChange(e.target.value)}
-            className="rounded-md border bg-background px-3 py-1.5 text-sm"
-          >
-            <option value="all">All Scores</option>
-            <option value="high">7+ (Good)</option>
-            <option value="mid">4-6 (Average)</option>
-            <option value="low">0-3 (Needs Work)</option>
-          </select>
+          <Select value={typeFilter} onValueChange={handleTypeChange}>
+            <SelectTrigger
+              aria-label="Filter by session type"
+              className="h-9 w-[140px]"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Types</SelectItem>
+              <SelectItem value="behavioral">Behavioral</SelectItem>
+              <SelectItem value="technical">Technical</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={scoreFilter} onValueChange={handleScoreChange}>
+            <SelectTrigger
+              aria-label="Filter by score"
+              className="h-9 w-[160px]"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Scores</SelectItem>
+              <SelectItem value="high">7+ (Good)</SelectItem>
+              <SelectItem value="mid">4–6 (Average)</SelectItem>
+              <SelectItem value="low">0–3 (Needs Work)</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
       </div>
 

--- a/apps/web/app/dashboard/sessions/[id]/feedback/page.tsx
+++ b/apps/web/app/dashboard/sessions/[id]/feedback/page.tsx
@@ -5,7 +5,8 @@ import { useParams, useRouter } from "next/navigation";
 import { FeedbackDashboard } from "@/components/feedback/FeedbackDashboard";
 import type { TimelineEvent } from "@/components/feedback/TimelineView";
 import type { GazeDistribution, GazeTimelineBucket } from "@/lib/gaze-metrics";
-import { Loader2, RefreshCw } from "lucide-react";
+import Link from "next/link";
+import { ArrowLeft, Loader2, RefreshCw } from "lucide-react";
 
 interface DriftAnalysis {
   added: string[];
@@ -229,10 +230,25 @@ export default function FeedbackPage() {
   if (!feedback || !sessionType) return null;
 
   return (
-    <FeedbackDashboard
-      feedback={feedback}
-      sessionId={params.id}
-      sessionType={sessionType}
-    />
+    <>
+      {/* Sticky back-link so the path home is always visible, not buried
+          below a long per-answer breakdown. */}
+      <div className="sticky top-14 z-20 border-b bg-background/80 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center px-4 py-2">
+          <Link
+            href="/dashboard"
+            className="inline-flex h-9 items-center gap-1.5 rounded-md px-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+            Back to Dashboard
+          </Link>
+        </div>
+      </div>
+      <FeedbackDashboard
+        feedback={feedback}
+        sessionId={params.id}
+        sessionType={sessionType}
+      />
+    </>
   );
 }

--- a/apps/web/app/dashboard/sessions/[id]/feedback/page.tsx
+++ b/apps/web/app/dashboard/sessions/[id]/feedback/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { FeedbackDashboard } from "@/components/feedback/FeedbackDashboard";
 import type { TimelineEvent } from "@/components/feedback/TimelineView";
 import type { GazeDistribution, GazeTimelineBucket } from "@/lib/gaze-metrics";
+import { Loader2, RefreshCw } from "lucide-react";
 
 interface DriftAnalysis {
   added: string[];
@@ -47,8 +48,12 @@ export default function FeedbackPage() {
   >(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  // Retry nonce — bumped by the Retry button to re-arm the polling effect
+  // without a full page reload (which would drop scroll position and any
+  // in-progress UI state).
+  const [retryNonce, setRetryNonce] = useState(0);
 
-  // Poll for feedback — runs once on mount, cleans up on unmount.
+  // Poll for feedback — re-runs when retryNonce changes, cleans up on unmount.
   // All mutable state accessed via refs to avoid re-triggering the effect.
   useEffect(() => {
     let cancelled = false;
@@ -133,9 +138,9 @@ export default function FeedbackPage() {
       cancelled = true;
       if (pollTimer) clearTimeout(pollTimer);
     };
-    // Only re-run if the session ID changes (page navigation)
+    // Re-run when the session ID changes or when the user hits Retry.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [params.id]);
+  }, [params.id, retryNonce]);
 
   if (isLoading) {
     return (
@@ -174,18 +179,10 @@ export default function FeedbackPage() {
           </div>
         </div>
 
-        {/* Gaze card skeleton */}
-        <div className="rounded-lg border p-6 space-y-4">
-          <div className="h-5 w-32 animate-pulse rounded bg-muted" />
-          <div className="flex items-center gap-4">
-            <div className="h-16 w-16 animate-pulse rounded-full bg-muted" />
-            <div className="flex-1 space-y-2">
-              <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
-              <div className="h-3 w-1/2 animate-pulse rounded bg-muted" />
-            </div>
-          </div>
-          <div className="h-6 w-full animate-pulse rounded bg-muted" />
-        </div>
+        {/* Gaze card skeleton removed — not all sessions have gaze data,
+            so a dedicated skeleton promises content the post-load layout may
+            never render. When gaze is present the card mounts naturally; when
+            it isn't, nothing was promised. */}
 
         {/* Breakdown skeleton */}
         <div className="space-y-3">
@@ -201,9 +198,10 @@ export default function FeedbackPage() {
           ))}
         </div>
 
-        <p className="text-center text-sm text-muted-foreground animate-pulse">
-          Generating feedback... This may take a few seconds.
-        </p>
+        <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          Generating feedback… This may take a few seconds.
+        </div>
       </div>
     );
   }
@@ -213,16 +211,16 @@ export default function FeedbackPage() {
       <div className="mx-auto max-w-md py-24 text-center">
         <p className="mb-4 text-destructive">{error}</p>
         <button
+          type="button"
           onClick={() => {
             setError(null);
             setIsLoading(true);
-            // Re-mount the effect by forcing a state change —
-            // but since params.id hasn't changed, we manually re-poll
-            window.location.reload();
+            setRetryNonce((n) => n + 1);
           }}
-          className="text-sm text-primary underline"
+          className="inline-flex h-10 items-center gap-2 rounded-md border bg-background px-4 text-sm font-medium transition-colors hover:bg-accent"
         >
-          Retry
+          <RefreshCw className="h-4 w-4" aria-hidden="true" />
+          Try again
         </button>
       </div>
     );

--- a/apps/web/app/interview/behavioral/session/page.tsx
+++ b/apps/web/app/interview/behavioral/session/page.tsx
@@ -198,12 +198,14 @@ export default function BehavioralSessionPage() {
       {/* Session timer — top-right, counts down from 20:00. Turns destructive
           red in the last minute so the user knows the session will auto-end. */}
       <div
-        className={`absolute top-4 right-4 z-10 rounded-md border bg-background/90 px-3 py-1.5 text-sm font-medium shadow backdrop-blur ${
+        className={`absolute top-4 right-4 z-10 rounded-md border bg-background/90 px-3 py-1.5 text-sm font-medium tabular-nums shadow backdrop-blur transition-colors motion-safe:duration-[var(--duration-base)] ${
           isLastMinute
             ? "border-destructive/60 text-destructive"
             : "text-muted-foreground"
         }`}
         data-testid="session-timer"
+        aria-live="polite"
+        aria-atomic="true"
         aria-label={`Time remaining: ${formattedRemaining}`}
       >
         {formattedRemaining} left

--- a/apps/web/app/interview/behavioral/session/page.tsx
+++ b/apps/web/app/interview/behavioral/session/page.tsx
@@ -10,6 +10,7 @@ import { BEHAVIORAL_SESSION_MAX_DURATION_SECONDS } from "@/lib/plans";
 import type { BehavioralSessionConfig } from "@preploy/shared";
 import { VideoCallLayout } from "@/components/interview/VideoCallLayout";
 import { SessionControls } from "@/components/interview/SessionControls";
+import { X } from "lucide-react";
 
 export default function BehavioralSessionPage() {
   const router = useRouter();
@@ -225,16 +226,22 @@ export default function BehavioralSessionPage() {
 
       {/* Transcript overlay */}
       {showTranscript && (
-        <div className="absolute bottom-16 right-4 z-10 h-64 w-80 overflow-y-auto rounded-lg border bg-background/90 p-3 shadow-lg backdrop-blur">
+        <div
+          id="session-transcript-panel"
+          className="absolute bottom-16 right-4 z-10 h-64 w-80 overflow-y-auto rounded-lg border bg-background/90 p-3 shadow-lg backdrop-blur"
+          role="region"
+          aria-label="Live transcript"
+        >
           <div className="mb-2 flex items-center justify-between">
             <span className="text-xs font-medium text-muted-foreground">
               Live Transcript
             </span>
             <button
               onClick={() => setShowTranscript(false)}
-              className="text-xs text-muted-foreground hover:text-foreground"
+              aria-label="Close transcript"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
             >
-              &times;
+              <X className="h-4 w-4" aria-hidden="true" />
             </button>
           </div>
           <div className="space-y-2 text-sm">
@@ -243,8 +250,8 @@ export default function BehavioralSessionPage() {
                 <span
                   className={`font-medium ${
                     entry.speaker === "assistant"
-                      ? "text-blue-600 dark:text-blue-400"
-                      : "text-green-600 dark:text-green-400"
+                      ? "text-[color:var(--chart-5)]"
+                      : "text-primary"
                   }`}
                 >
                   {entry.speaker === "assistant" ? "Interviewer" : "You"}:
@@ -257,11 +264,14 @@ export default function BehavioralSessionPage() {
         </div>
       )}
 
-      {/* Transcript toggle button */}
+      {/* Transcript toggle button — ≥44px touch target per WCAG AA; announces
+          expanded state and the panel it controls. */}
       {!showTranscript && (
         <button
           onClick={() => setShowTranscript(true)}
-          className="absolute bottom-16 right-4 z-10 rounded-md border bg-background/80 px-3 py-1.5 text-xs text-muted-foreground shadow backdrop-blur hover:bg-background"
+          aria-expanded={false}
+          aria-controls="session-transcript-panel"
+          className="absolute bottom-16 right-4 z-10 inline-flex h-11 items-center rounded-md border bg-background/80 px-4 text-xs font-medium text-muted-foreground shadow backdrop-blur transition-colors hover:bg-background hover:text-foreground"
         >
           Show Transcript
         </button>

--- a/apps/web/app/interview/technical/session/page.tsx
+++ b/apps/web/app/interview/technical/session/page.tsx
@@ -14,6 +14,7 @@ import {
 import { CodeEditor } from "@/components/editor/CodeEditor";
 import { EditorToolbar } from "@/components/editor/EditorToolbar";
 import { MicIndicator } from "@/components/interview/MicIndicator";
+import { RefreshCw, Loader2 } from "lucide-react";
 
 export default function TechnicalSessionPage() {
   const router = useRouter();
@@ -104,6 +105,34 @@ export default function TechnicalSessionPage() {
     init();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId]);
+
+  // Retry the initial problem fetch after an error — does not consume a
+  // regeneration slot. Recovers from transient failures (network blip, AI
+  // timeout) without forcing the user to end and restart the session.
+  const handleRetryInitialFetch = useCallback(async () => {
+    setProblemLoading(true);
+    setProblemError(null);
+    try {
+      const res = await fetch("/api/problems/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ config: techConfig }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setProblemError(data.error || "Failed to generate problem");
+      } else {
+        const data = await res.json();
+        setProblem(data);
+      }
+    } catch (err) {
+      setProblemError(
+        err instanceof Error ? err.message : "Failed to generate problem"
+      );
+    } finally {
+      setProblemLoading(false);
+    }
+  }, [techConfig]);
 
   // Regenerate problem handler — sends all previously-shown problem titles
   // so the LLM avoids repeats.
@@ -275,10 +304,18 @@ export default function TechnicalSessionPage() {
       </div>
     </div>
   ) : problemError ? (
-    <div className="flex h-full flex-col items-center justify-center p-6 text-center">
+    <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center">
       <p className="text-sm text-destructive">{problemError}</p>
-      <p className="mt-2 text-xs text-muted-foreground">
-        Try ending the session and starting a new one.
+      <button
+        type="button"
+        onClick={handleRetryInitialFetch}
+        className="inline-flex h-10 items-center gap-2 rounded-md border bg-background px-4 text-sm font-medium transition-colors hover:bg-accent"
+      >
+        <RefreshCw className="h-4 w-4" aria-hidden="true" />
+        Try again
+      </button>
+      <p className="text-xs text-muted-foreground">
+        Still stuck? End the session and start a new one.
       </p>
     </div>
   ) : problem ? (
@@ -286,20 +323,28 @@ export default function TechnicalSessionPage() {
       <div className="flex-1 overflow-y-auto">
         <ProblemDescription problem={problem} />
       </div>
-      <div className="border-t px-4 py-3 flex items-center justify-between">
+      <div className="border-t px-4 py-2 flex items-center justify-between">
         <button
           onClick={handleRegenerate}
           disabled={regenerationsLeft <= 0 || isRegenerating}
-          className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          className="inline-flex h-11 items-center gap-2 rounded-md px-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
           title={
             regenerationsLeft <= 0
               ? "No regenerations remaining this session"
               : `Regenerate problem (${regenerationsLeft} left)`
           }
         >
-          {isRegenerating
-            ? "Generating..."
-            : `↻ New question (${regenerationsLeft}/${MAX_REGENERATIONS} left)`}
+          {isRegenerating ? (
+            <>
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+              Generating…
+            </>
+          ) : (
+            <>
+              <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+              New question ({regenerationsLeft}/{MAX_REGENERATIONS} left)
+            </>
+          )}
         </button>
       </div>
     </div>

--- a/apps/web/app/planner/page.tsx
+++ b/apps/web/app/planner/page.tsx
@@ -312,7 +312,7 @@ export default function PlannerPage() {
                 <form onSubmit={handleGenerate} className="space-y-4">
                   <div className="space-y-2">
                     <Label htmlFor="company">
-                      <Building2 className="h-4 w-4 inline mr-1" />
+                      <Building2 className="h-4 w-4 inline mr-1" aria-hidden="true" />
                       Company
                     </Label>
                     <Input
@@ -325,7 +325,7 @@ export default function PlannerPage() {
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="role">
-                      <Briefcase className="h-4 w-4 inline mr-1" />
+                      <Briefcase className="h-4 w-4 inline mr-1" aria-hidden="true" />
                       Role
                     </Label>
                     <Input
@@ -338,7 +338,7 @@ export default function PlannerPage() {
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="interview-date">
-                      <CalendarDays className="h-4 w-4 inline mr-1" />
+                      <CalendarDays className="h-4 w-4 inline mr-1" aria-hidden="true" />
                       Interview Date
                     </Label>
                     <Input

--- a/apps/web/app/planner/page.tsx
+++ b/apps/web/app/planner/page.tsx
@@ -146,6 +146,7 @@ export default function PlannerPage() {
   const [selectedPlan, setSelectedPlan] = useState<Plan | null>(null);
   const [loading, setLoading] = useState(true);
   const [generating, setGenerating] = useState(false);
+  const [generateError, setGenerateError] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [archivedOpen, setArchivedOpen] = useState(false);
 
@@ -187,6 +188,7 @@ export default function PlannerPage() {
     if (!company || !role || !interviewDate) return;
 
     setGenerating(true);
+    setGenerateError(null);
     try {
       const res = await fetch("/api/plans/generate", {
         method: "POST",
@@ -202,9 +204,17 @@ export default function PlannerPage() {
         setCompany("");
         setRole("");
         setInterviewDate("");
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setGenerateError(
+          data?.error ??
+            "We couldn't generate your plan. Please check your inputs and try again."
+        );
       }
     } catch {
-      // Error handling could be added
+      setGenerateError(
+        "Network error — couldn't reach the server. Please try again."
+      );
     } finally {
       setGenerating(false);
     }
@@ -356,13 +366,21 @@ export default function PlannerPage() {
                   >
                     {generating ? (
                       <>
-                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                        <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
                         Generating Plan...
                       </>
                     ) : (
                       "Generate Plan"
                     )}
                   </Button>
+                  {generateError && (
+                    <p
+                      role="alert"
+                      className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+                    >
+                      {generateError}
+                    </p>
+                  )}
                 </form>
               </CardContent>
             </Card>

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
+import { AlertTriangle } from "lucide-react";
 import { signOut } from "next-auth/react";
 import { PLANS, PLAN_DEFINITIONS } from "@/lib/plans";
 import type { PlanId } from "@/lib/plans";
@@ -481,9 +482,12 @@ export default function ProfilePage() {
             </CardContent>
           </Card>
 
-          <Card>
+          <Card className="border-destructive/40">
             <CardHeader>
-              <CardTitle className="text-destructive">Delete Account</CardTitle>
+              <CardTitle className="flex items-center gap-2 text-destructive">
+                <AlertTriangle className="h-5 w-5" aria-hidden="true" />
+                Delete Account
+              </CardTitle>
             </CardHeader>
             <CardContent>
               {showDeleteConfirm ? (
@@ -506,6 +510,9 @@ export default function ProfilePage() {
                       onChange={(e) => setDeleteConfirmation(e.target.value)}
                       placeholder="DELETE my account and all my data"
                       className="border-destructive/50"
+                      autoComplete="off"
+                      autoCorrect="off"
+                      spellCheck={false}
                     />
                   </div>
                   <div className="flex gap-2">

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -42,6 +42,9 @@ export default function ProfilePage() {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleteConfirmation, setDeleteConfirmation] = useState("");
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+  // `messageExiting` toggles ~300ms before `message` is nulled, driving a
+  // fade-out transition so the toast doesn't snap out of existence.
+  const [messageExiting, setMessageExiting] = useState(false);
 
   useEffect(() => {
     async function fetchProfile() {
@@ -92,8 +95,19 @@ export default function ProfilePage() {
   };
 
   const showMessage = useCallback((type: "success" | "error", text: string) => {
+    setMessageExiting(false);
     setMessage({ type, text });
-    setTimeout(() => setMessage(null), 3000);
+    const fadeTimer = setTimeout(() => setMessageExiting(true), 2700);
+    const unmountTimer = setTimeout(() => {
+      setMessage(null);
+      setMessageExiting(false);
+    }, 3000);
+    // Note: timers aren't cleaned up here — if showMessage is called again
+    // before the 3s window closes, the newer call's timers race the older
+    // ones. This is acceptable for a profile-page toast; if this grows into
+    // a shared primitive the cleanup should be lifted into a ref.
+    void fadeTimer;
+    void unmountTimer;
   }, []);
 
   const handleSaveName = async () => {
@@ -292,13 +306,20 @@ export default function ProfilePage() {
         Manage your account settings and preferences.
       </p>
 
-      {/* Toast message */}
+      {/* Toast message — success uses the brand cedar (`--primary`), error
+          uses the terracotta destructive token; both work in light + dark.
+          Opacity transitions via `messageExiting` so the toast fades out
+          instead of snapping off screen. */}
       {message && (
         <div
-          className={`mb-6 rounded-md border px-4 py-3 text-sm ${
+          role="status"
+          aria-live="polite"
+          className={`mb-6 rounded-md border px-4 py-3 text-sm transition-opacity motion-safe:duration-[var(--duration-slow)] ${
+            messageExiting ? "opacity-0" : "opacity-100"
+          } ${
             message.type === "success"
-              ? "border-green-500/50 bg-green-500/10 text-green-700 dark:text-green-400"
-              : "border-destructive/50 bg-destructive/10 text-destructive"
+              ? "border-primary/30 bg-primary/10 text-primary"
+              : "border-destructive/30 bg-destructive/10 text-destructive"
           }`}
         >
           {message.text}
@@ -438,26 +459,41 @@ export default function ProfilePage() {
                     interviews per month. Pick monthly or annual — annual saves
                     about 33%.
                   </p>
-                  <Button
-                    onClick={() => handleUpgrade("month")}
-                    disabled={isBillingLoading}
-                    data-testid="upgrade-button"
-                    className="w-full"
-                  >
-                    {isBillingLoading
-                      ? "Loading..."
-                      : `Upgrade — $${PLAN_DEFINITIONS.pro.priceUsd}/month`}
-                  </Button>
+                  {/* Annual promoted as the primary action — "Best value"
+                      badge makes the hierarchy obvious instead of leaving
+                      the two buttons equal-weight. Multi-line labels keep
+                      the long billing-frequency copy from wrapping into the
+                      button's touch area on narrow viewports. */}
                   <Button
                     onClick={() => handleUpgrade("year")}
                     disabled={isBillingLoading}
                     data-testid="upgrade-annual-button"
+                    className="relative h-auto w-full py-3"
+                  >
+                    <span className="absolute -top-2 right-3 rounded-full bg-[color:var(--chart-2)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-background">
+                      Best value
+                    </span>
+                    <span className="flex flex-col items-center gap-0.5">
+                      <span className="font-semibold">
+                        {isBillingLoading
+                          ? "Loading…"
+                          : `Upgrade — $${PLAN_DEFINITIONS.pro.annualMonthlyEquivalentUsd}/month`}
+                      </span>
+                      <span className="text-xs font-normal opacity-80">
+                        Billed annually · ${PLAN_DEFINITIONS.pro.annualTotalUsd}/year
+                      </span>
+                    </span>
+                  </Button>
+                  <Button
+                    onClick={() => handleUpgrade("month")}
+                    disabled={isBillingLoading}
+                    data-testid="upgrade-button"
                     variant="outline"
                     className="w-full"
                   >
                     {isBillingLoading
-                      ? "Loading..."
-                      : `Upgrade — $${PLAN_DEFINITIONS.pro.annualMonthlyEquivalentUsd}/month billed annually ($${PLAN_DEFINITIONS.pro.annualTotalUsd}/year)`}
+                      ? "Loading…"
+                      : `Monthly — $${PLAN_DEFINITIONS.pro.priceUsd}/month`}
                   </Button>
                 </>
               )}
@@ -466,7 +502,7 @@ export default function ProfilePage() {
 
           <TemplateManager />
 
-          <Card className="hidden md:block" data-testid="preferences-card">
+          <Card data-testid="preferences-card">
             <CardHeader>
               <CardTitle>Preferences</CardTitle>
               <CardDescription>Personalize your experience</CardDescription>

--- a/apps/web/app/star/page.tsx
+++ b/apps/web/app/star/page.tsx
@@ -8,6 +8,16 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { getScoreColor } from "@/lib/utils";
 import { StarPdfExportButton } from "@/components/star/StarPdfExportButton";
 import { slugify } from "@/lib/slugify";
@@ -103,6 +113,7 @@ function ScoreBadge({ score, label }: { score: number; label: string }) {
 function AnalysisCard({ analysis }: { analysis: StarAnalysis }) {
   const [expanded, setExpanded] = useState(false);
   const scores = analysis.scores;
+  const detailsId = `analysis-details-${analysis.id}`;
 
   return (
     <div className="border rounded-lg p-4 space-y-3">
@@ -111,10 +122,18 @@ function AnalysisCard({ analysis }: { analysis: StarAnalysis }) {
           {new Date(analysis.createdAt).toLocaleString()}
         </p>
         <button
+          type="button"
           onClick={() => setExpanded(!expanded)}
-          className="text-muted-foreground hover:text-foreground transition-colors"
+          aria-expanded={expanded}
+          aria-controls={detailsId}
+          aria-label={expanded ? "Hide analysis details" : "Show analysis details"}
+          className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
         >
-          {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+          {expanded ? (
+            <ChevronUp className="h-4 w-4" aria-hidden="true" />
+          ) : (
+            <ChevronDown className="h-4 w-4" aria-hidden="true" />
+          )}
         </button>
       </div>
 
@@ -126,7 +145,7 @@ function AnalysisCard({ analysis }: { analysis: StarAnalysis }) {
       </div>
 
       {expanded && (
-        <div className="space-y-4 border-t pt-3">
+        <div id={detailsId} className="space-y-4 border-t pt-3">
           <div>
             <p className="text-sm font-medium mb-2">STAR Section Scores</p>
             <div className="grid grid-cols-4 gap-2">
@@ -191,6 +210,19 @@ export default function StarPrepPage() {
   const [exportAllProgress, setExportAllProgress] = useState<{ done: number; total: number } | null>(null);
   const [form, setForm] = useState(EMPTY_FORM);
   const [questionInput, setQuestionInput] = useState("");
+  // Pending delete target — drives the styled confirmation dialog (replaces
+  // the native `confirm()` which was inaccessible in embedded contexts).
+  const [pendingDelete, setPendingDelete] = useState<{ id: string; title: string } | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  // Inline toast banner — replaces native `alert()` for analyze/export
+  // failures. `useToast` isn't installed; a simple auto-dismissing banner
+  // keeps the accessibility + styling benefits without adding a dependency.
+  const [toast, setToast] = useState<{ tone: "error" | "success"; text: string } | null>(null);
+  useEffect(() => {
+    if (!toast) return;
+    const id = setTimeout(() => setToast(null), 4000);
+    return () => clearTimeout(id);
+  }, [toast]);
 
   // Consume starPrepPrefill from planner CTA on mount
   useEffect(() => {
@@ -318,16 +350,28 @@ export default function StarPrepPage() {
     }
   }
 
-  async function handleDelete(id: string) {
-    if (!confirm("Delete this story? This cannot be undone.")) return;
+  function requestDelete(story: StarStory) {
+    setPendingDelete({ id: story.id, title: story.title });
+  }
+
+  async function confirmDelete() {
+    if (!pendingDelete) return;
+    setIsDeleting(true);
     try {
-      await fetch(`/api/star/${id}`, { method: "DELETE" });
-      setStories((prev) => prev.filter((s) => s.id !== id));
-      if (selectedDetail?.story.id === id) {
+      const res = await fetch(`/api/star/${pendingDelete.id}`, { method: "DELETE" });
+      if (!res.ok && res.status !== 204) {
+        setToast({ tone: "error", text: "Delete failed. Please try again." });
+        return;
+      }
+      setStories((prev) => prev.filter((s) => s.id !== pendingDelete.id));
+      if (selectedDetail?.story.id === pendingDelete.id) {
         setSelectedDetail(null);
       }
+      setPendingDelete(null);
     } catch {
-      // Silent
+      setToast({ tone: "error", text: "Delete failed. Please try again." });
+    } finally {
+      setIsDeleting(false);
     }
   }
 
@@ -342,12 +386,15 @@ export default function StarPrepPage() {
         // Refresh detail to show the new analysis
         await fetchDetail(storyId);
       } else if (res.status === 429) {
-        alert("Too many requests. Please wait before analyzing again.");
+        setToast({
+          tone: "error",
+          text: "Too many requests. Please wait before analyzing again.",
+        });
       } else {
-        alert("Analysis failed. Please try again.");
+        setToast({ tone: "error", text: "Analysis failed. Please try again." });
       }
     } catch {
-      alert("Analysis failed. Please try again.");
+      setToast({ tone: "error", text: "Analysis failed. Please try again." });
     } finally {
       setAnalyzing(false);
     }
@@ -429,6 +476,59 @@ export default function StarPrepPage() {
 
   return (
     <div className="flex flex-col gap-6 p-6 max-w-6xl mx-auto">
+      {/* Inline toast — replaces `alert()` for analyze/delete/export failures.
+          `aria-live="polite"` so screen readers pick it up without stealing focus. */}
+      {toast && (
+        <div
+          role="status"
+          aria-live="polite"
+          className={`fixed right-4 top-20 z-50 max-w-sm rounded-md border px-4 py-3 text-sm shadow-md transition-opacity motion-safe:duration-[var(--duration-base)] ${
+            toast.tone === "error"
+              ? "border-destructive/30 bg-destructive/10 text-destructive"
+              : "border-primary/30 bg-primary/10 text-foreground"
+          }`}
+        >
+          {toast.text}
+        </div>
+      )}
+
+      {/* Destructive-action dialog — replaces the native `confirm()` which
+          has no focus management and is blocked in some embedded contexts. */}
+      <AlertDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open && !isDeleting) setPendingDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this story?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingDelete
+                ? `"${pendingDelete.title}" and all its analyses will be permanently removed. This cannot be undone.`
+                : "This cannot be undone."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={confirmDelete}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isDeleting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                  Deleting...
+                </>
+              ) : (
+                "Delete story"
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
       {plannerHint && plannerHint.length > 0 && (
         <div className="flex items-start gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950/30">
           <Sparkles className="h-5 w-5 text-blue-600 dark:text-blue-400 shrink-0 mt-0.5" />
@@ -731,10 +831,11 @@ export default function StarPrepPage() {
                       <Button
                         size="sm"
                         variant="outline"
+                        aria-label={`Delete story: ${selectedDetail.story.title}`}
                         className="text-destructive hover:bg-destructive hover:text-destructive-foreground"
-                        onClick={() => handleDelete(selectedDetail.story.id)}
+                        onClick={() => requestDelete(selectedDetail.story)}
                       >
-                        <Trash2 className="h-3 w-3" />
+                        <Trash2 className="h-3 w-3" aria-hidden="true" />
                       </Button>
                     </div>
                   </div>

--- a/apps/web/app/star/page.tsx
+++ b/apps/web/app/star/page.tsx
@@ -460,7 +460,7 @@ export default function StarPrepPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold flex items-center gap-2">
-            <Star className="h-6 w-6" />
+            <Star className="h-6 w-6 text-primary" aria-hidden="true" />
             STAR Story Prep
           </h1>
           <p className="text-muted-foreground">
@@ -551,8 +551,13 @@ export default function StarPrepPage() {
                   <CardTitle className="text-base">
                     {editing ? "Edit Story" : "New Story"}
                   </CardTitle>
-                  <button onClick={() => setShowForm(false)}>
-                    <X className="h-4 w-4 text-muted-foreground hover:text-foreground" />
+                  <button
+                    type="button"
+                    onClick={() => setShowForm(false)}
+                    aria-label={editing ? "Close edit form" : "Close new story form"}
+                    className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                  >
+                    <X className="h-4 w-4" aria-hidden="true" />
                   </button>
                 </div>
               </CardHeader>

--- a/apps/web/components/interview/BehavioralSetupForm.tsx
+++ b/apps/web/components/interview/BehavioralSetupForm.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Slider } from "@/components/ui/slider";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Loader2, Plus, X } from "lucide-react";
 import { useInterviewStore } from "@/stores/interviewStore";
 import { TemplateControls } from "./TemplateControls";
 import { ResumeSelector } from "./ResumeSelector";
@@ -20,6 +21,23 @@ interface CompanyQuestion {
   question: string;
   category: string;
   tip: string;
+}
+
+// Slider value → human-readable band. The sliders sit in 0-1 space; these
+// buckets give the user a concrete word for where they are instead of a raw
+// percentage, which matches how the left/right extremes are labelled.
+function styleLabel(v: number): string {
+  if (v < 0.25) return "Strict";
+  if (v < 0.5) return "Mostly strict";
+  if (v < 0.75) return "Mostly casual";
+  return "Casual";
+}
+
+function difficultyLabel(v: number): string {
+  if (v < 0.25) return "Entry";
+  if (v < 0.5) return "Mid";
+  if (v < 0.75) return "Senior";
+  return "Staff+";
 }
 
 export function BehavioralSetupForm() {
@@ -228,10 +246,10 @@ export function BehavioralSetupForm() {
                       <button
                         type="button"
                         onClick={() => removeQuestion(i)}
-                        className="text-muted-foreground hover:text-destructive"
+                        className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
                         aria-label={`Remove question ${i + 1}`}
                       >
-                        &times;
+                        <X className="h-4 w-4" aria-hidden="true" />
                       </button>
                     </li>
                   ))}
@@ -283,7 +301,12 @@ export function BehavioralSetupForm() {
             </CardHeader>
             <CardContent className="space-y-6">
               <div className="space-y-3">
-                <Label>Interview Style</Label>
+                <div className="flex items-baseline justify-between">
+                  <Label>Interview Style</Label>
+                  <span className="text-xs tabular-nums text-muted-foreground">
+                    {styleLabel(interviewStyle)}
+                  </span>
+                </div>
                 <Slider
                   value={[interviewStyle * 100]}
                   onValueChange={(val) => setConfig({ interview_style: val[0] / 100 })}
@@ -298,7 +321,12 @@ export function BehavioralSetupForm() {
               </div>
 
               <div className="space-y-3">
-                <Label>Difficulty</Label>
+                <div className="flex items-baseline justify-between">
+                  <Label>Difficulty</Label>
+                  <span className="text-xs tabular-nums text-muted-foreground">
+                    {difficultyLabel(difficulty)}
+                  </span>
+                </div>
                 <Slider
                   value={[difficulty * 100]}
                   onValueChange={(val) => setConfig({ difficulty: val[0] / 100 })}
@@ -332,9 +360,14 @@ export function BehavioralSetupForm() {
                 disabled={!companyName.trim() || isGenerating}
                 onClick={handleGenerateQuestions}
               >
-                {isGenerating
-                  ? "Generating..."
-                  : "Generate likely questions"}
+                {isGenerating ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                    Generating...
+                  </>
+                ) : (
+                  "Generate likely questions"
+                )}
               </Button>
 
               {!companyName.trim() && (
@@ -360,10 +393,11 @@ export function BehavioralSetupForm() {
                           <button
                             type="button"
                             onClick={() => addGeneratedQuestion(gq.question)}
-                            className="shrink-0 rounded-md border px-2 py-1 text-xs hover:bg-accent"
-                            aria-label={`Add question ${i + 1}`}
+                            className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md border px-2 text-xs font-medium transition-colors hover:bg-accent"
+                            aria-label={`Add question: ${gq.question}`}
                           >
-                            +
+                            <Plus className="h-3 w-3" aria-hidden="true" />
+                            Add
                           </button>
                         )}
                         {questions.includes(gq.question) && (

--- a/apps/web/components/landing/LandingFAQ.tsx
+++ b/apps/web/components/landing/LandingFAQ.tsx
@@ -43,32 +43,42 @@ const faqs = [
 ];
 
 interface FAQItemProps {
+  index: number;
   question: string;
   answer: string;
   isOpen: boolean;
   onToggle: () => void;
 }
 
-function FAQItem({ question, answer, isOpen, onToggle }: FAQItemProps) {
+function FAQItem({ index, question, answer, isOpen, onToggle }: FAQItemProps) {
+  const panelId = `faq-panel-${index}`;
+  const buttonId = `faq-trigger-${index}`;
   return (
     <div className="border-b last:border-b-0">
       <button
-        className="flex w-full items-center justify-between py-4 text-left text-sm font-medium hover:text-primary transition-colors"
+        id={buttonId}
+        className="flex w-full items-center justify-between py-4 text-left text-sm font-medium transition-colors hover:text-primary motion-safe:duration-[var(--duration-fast)]"
         onClick={onToggle}
         aria-expanded={isOpen}
+        aria-controls={panelId}
         data-testid="faq-trigger"
       >
         <span>{question}</span>
         <ChevronDown
+          aria-hidden="true"
           className={cn(
-            "h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200",
+            "h-4 w-4 shrink-0 text-muted-foreground transition-transform motion-safe:duration-[var(--duration-base)]",
             isOpen && "rotate-180"
           )}
         />
       </button>
       <div
+        id={panelId}
+        role="region"
+        aria-labelledby={buttonId}
+        hidden={!isOpen}
         className={cn(
-          "overflow-hidden transition-all duration-200",
+          "overflow-hidden transition-all motion-safe:duration-[var(--duration-base)]",
           isOpen ? "max-h-96 pb-4" : "max-h-0"
         )}
         data-testid="faq-content"
@@ -96,6 +106,7 @@ export function LandingFAQ() {
           {faqs.map((faq, index) => (
             <FAQItem
               key={index}
+              index={index}
               question={faq.question}
               answer={faq.answer}
               isOpen={openIndex === index}

--- a/apps/web/components/landing/LandingHero.tsx
+++ b/apps/web/components/landing/LandingHero.tsx
@@ -6,13 +6,18 @@ import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 export function LandingHero() {
+  // Reserved for a future in-page anchor to the "How it works" section —
+  // respects `prefers-reduced-motion` (smooth scroll is a vestibular trigger).
   const handleScrollToHowItWorks = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
     const section = document.getElementById("how-it-works");
-    if (section) {
-      section.scrollIntoView({ behavior: "smooth" });
-    }
+    if (!section) return;
+    const prefersReduced =
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    section.scrollIntoView({ behavior: prefersReduced ? "auto" : "smooth" });
   };
+  void handleScrollToHowItWorks;
 
   return (
     <section className="flex flex-col items-center justify-center text-center py-24 px-4 gap-8">

--- a/apps/web/components/shared/Header.test.tsx
+++ b/apps/web/components/shared/Header.test.tsx
@@ -5,9 +5,18 @@ import { Header } from "./Header";
 // Mutable pathname so individual tests can override it
 const mockPathname = { value: "/dashboard" };
 
-// Mock next/navigation
+// Mock next/navigation — Header uses both usePathname and useRouter (the
+// latter for the Profile dropdown item's client-side nav).
 vi.mock("next/navigation", () => ({
   usePathname: () => mockPathname.value,
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+  }),
 }));
 
 // Mock next-auth/react

--- a/apps/web/components/shared/Header.tsx
+++ b/apps/web/components/shared/Header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useSession, signOut } from "next-auth/react";
 import { cn } from "@/lib/utils";
 import {
@@ -31,6 +31,7 @@ const navItems = [
 
 export function Header() {
   const pathname = usePathname();
+  const router = useRouter();
   const { data: session, status } = useSession();
   const { theme, setTheme } = useTheme();
   const user = session?.user;
@@ -119,8 +120,8 @@ export function Header() {
                 <p className="text-xs text-muted-foreground">{user.email}</p>
               </div>
               <DropdownMenuSeparator />
-              <DropdownMenuItem asChild>
-                <Link href="/profile">Profile</Link>
+              <DropdownMenuItem onClick={() => router.push("/profile")}>
+                Profile
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/" })}>
                 Sign Out

--- a/apps/web/components/shared/Header.tsx
+++ b/apps/web/components/shared/Header.tsx
@@ -44,8 +44,11 @@ export function Header() {
       <div className="flex h-14 items-center px-4 gap-4">
         {/* Mobile sidebar trigger */}
         <Sheet>
-          <SheetTrigger className="md:hidden inline-flex items-center justify-center rounded-lg h-8 w-8 hover:bg-muted transition-colors">
-            <Menu className="h-5 w-5" />
+          <SheetTrigger
+            aria-label="Open navigation menu"
+            className="md:hidden inline-flex items-center justify-center rounded-lg h-10 w-10 hover:bg-muted transition-colors"
+          >
+            <Menu className="h-5 w-5" aria-hidden="true" />
           </SheetTrigger>
           <SheetContent side="left" className="w-64 p-0">
             <Sidebar />
@@ -85,8 +88,14 @@ export function Header() {
           className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
           aria-label="Toggle theme"
         >
-          <Sun className="h-4 w-4 rotate-0 scale-100 transition-transform dark:-rotate-90 dark:scale-0" />
-          <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-transform dark:rotate-0 dark:scale-100" />
+          <Sun
+            aria-hidden="true"
+            className="h-4 w-4 rotate-0 scale-100 transition-transform motion-safe:duration-[var(--duration-base)] dark:-rotate-90 dark:scale-0"
+          />
+          <Moon
+            aria-hidden="true"
+            className="absolute h-4 w-4 rotate-90 scale-0 transition-transform motion-safe:duration-[var(--duration-base)] dark:rotate-0 dark:scale-100"
+          />
         </button>
 
         {/* User menu */}
@@ -110,8 +119,8 @@ export function Header() {
                 <p className="text-xs text-muted-foreground">{user.email}</p>
               </div>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => window.location.assign("/profile")}>
-                Profile
+              <DropdownMenuItem asChild>
+                <Link href="/profile">Profile</Link>
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/" })}>
                 Sign Out

--- a/apps/web/components/shared/Sidebar.tsx
+++ b/apps/web/components/shared/Sidebar.tsx
@@ -70,6 +70,7 @@ function formatRelativeDate(dateString: string): string {
 export function Sidebar() {
   const pathname = usePathname();
   const [sessions, setSessions] = useState<SessionItem[]>([]);
+  const [sessionsLoading, setSessionsLoading] = useState(true);
   const [feedbackOpen, setFeedbackOpen] = useState(false);
 
   useEffect(() => {
@@ -84,6 +85,8 @@ export function Sidebar() {
         }
       } catch {
         // Silent — sidebar sessions are non-critical
+      } finally {
+        setSessionsLoading(false);
       }
     }
     fetchSessions();
@@ -138,7 +141,24 @@ export function Sidebar() {
       </div>
 
       <div className="flex flex-col gap-1 px-2">
-        {sessions.length === 0 ? (
+        {sessionsLoading ? (
+          // Skeleton mirrors the post-load row shape: two-line label +
+          // trailing type badge. Three rows cover the common case (recent
+          // sessions max out at 5, but most users have fewer in view).
+          Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center justify-between px-3 py-2"
+              aria-hidden="true"
+            >
+              <div className="flex flex-col min-w-0 mr-2 flex-1 gap-1">
+                <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+                <div className="h-2.5 w-12 animate-pulse rounded bg-muted/60" />
+              </div>
+              <div className="h-4 w-7 shrink-0 animate-pulse rounded-full bg-muted" />
+            </div>
+          ))
+        ) : sessions.length === 0 ? (
           <p className="px-3 py-2 text-xs text-muted-foreground">
             No sessions yet
           </p>


### PR DESCRIPTION
## Summary

Single-PR sweep covering **seven themes** from the Part-2 backlog in `dev_logs/design-audit-2026-04.md`. Builds on [#164](https://github.com/scy02718/Preploy/pull/164) (the token layer) — should be reviewed and merged **after** #164 so the new tokens are the base.

Each theme lands as its own commit so the diff stays scannable per-concern:

| Commit | Theme | Highlights |
|---|---|---|
| `feat(design): global icon + element hygiene` | **B** | `&times;`/`↻`/`*` → Lucide `<X>`/`<RefreshCw>`/`<Lightbulb>`, raw `<select>` → shadcn `<Select>`, `aria-hidden` on decorative label icons, slider value bands, hardcoded `green-50`/`red-50` worked-example cards → semantic `primary/5`/`destructive/5` that survive dark mode |
| `feat(design): a11y blockers` | **D** | STAR `confirm()`/`alert()` → shadcn `AlertDialog` + `role="status" aria-live="polite"` toast; FAQ + AnalysisCard gain `aria-expanded`+`aria-controls`+`region`; Profile delete card gets `AlertTriangle` icon (so "danger" isn't conveyed by colour alone) + `autoComplete="off"`/`autoCorrect="off"`/`spellCheck={false}` on the type-to-confirm input |
| `feat(design): empty/error states` | **G** + C fragment | Planner silent failure → inline `role="alert"` banner; feedback `animate-pulse` on readable text → `<Loader2>` spinner; retry → state reset instead of `window.location.reload()`; dropped the gaze-specific skeleton that promised content absent sessions never render |
| `feat(design): Sidebar skeleton` | **C** | Sidebar Recent Sessions now renders a 3-row skeleton that mirrors the post-load shape (two-line label + trailing type badge). Sessions no longer pop in silently. |
| `feat(design): nav + routing` | **F** | Header Profile dropdown uses `router.push` instead of `window.location.assign` (client-side nav restored); mobile sheet trigger gains `aria-label` + 44×44 target; theme-toggle Sun/Moon `aria-hidden` + `motion-safe:`; feedback page gets a sticky "Back to Dashboard" sub-header; login page adds "Back to home" link + copy refresh |
| `feat(design): motion + reduced-motion` | **E** | `handleScrollToHowItWorks` respects `prefers-reduced-motion`; behavioral session timer color-flip is `motion-safe:`; FAQ accordion `motion-safe:` landed in Theme D |
| `feat(design): forms polish` | **H** | Profile billing: annual promoted with a "Best value" badge in amber (chart-2), monthly becomes secondary; Preferences card no longer `hidden md:block`; toast introduces a `messageExiting` phase that drives a `transition-opacity motion-safe:duration-[var(--duration-slow)]` fade-out instead of snapping off |
| `fix(design): typecheck + test compat` | — | Narrow base-ui `Select.onValueChange` null; swap `DropdownMenuItem asChild` (base-ui has no `asChild`) for `onClick={() => router.push(...)}`; add missing `useRouter` mock to Header test |

## Test plan

- [x] `npx turbo lint typecheck test --filter=@preploy/web` — **3 tasks green, 91 files / 889 tests pass**
- [x] Landing page smoke test in light + dark via Playwright — fonts + tokens render as designed, 1440×900
- [x] Login page smoke test — sticky "Back to home" + "Sign in to Preploy" copy, cedar CTA, warm paper backdrop
- [ ] Follow-up: integration + E2E suites before merge (`cd apps/web && npm run test:integration && npm run test:e2e:smoke`)

## Out of scope / explicitly deferred

From the audit's "nice-to-have" tier: Landing Hero `sm:text-5xl` breakpoint smoothing, LandingHowItWorks two-circle-per-step redundancy, Coaching layout reading-column `max-w-3xl`, behavioral-setup column order on mobile. None of these are blockers; they remain in the audit doc for a later polish pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)