### PR TITLE
fix: OpenAI rate-limit gaps + feedback sticky gap + stale landing copy

### DIFF
--- a/apps/web/app/api/analysis/behavioral/route.integration.test.ts
+++ b/apps/web/app/api/analysis/behavioral/route.integration.test.ts
@@ -22,6 +22,16 @@ vi.mock("openai", () => ({
   },
 }));
 
+// The route now auths + rate-limits like any other OpenAI-burning endpoint.
+// Tests stub both to return "signed-in, not rate-limited" by default; any
+// test that wants to exercise the 401 / 429 paths can override in-file.
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn().mockResolvedValue({ user: { id: "test-user" } }),
+}));
+vi.mock("@/lib/api-utils", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(null),
+}));
+
 vi.stubEnv("OPENAI_API_KEY", "sk-integration-test");
 
 import { POST } from "./route";

--- a/apps/web/app/api/analysis/behavioral/route.test.ts
+++ b/apps/web/app/api/analysis/behavioral/route.test.ts
@@ -10,6 +10,14 @@ vi.mock("openai", () => ({
   },
 }));
 
+// Route now auths + rate-limits; tests default to "signed-in, not limited".
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn().mockResolvedValue({ user: { id: "test-user" } }),
+}));
+vi.mock("@/lib/api-utils", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(null),
+}));
+
 import { POST } from "./route";
 
 const VALID_GPT_RESPONSE = readFileSync(

--- a/apps/web/app/api/analysis/behavioral/route.ts
+++ b/apps/web/app/api/analysis/behavioral/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { auth } from "@/lib/auth";
+import { checkRateLimit } from "@/lib/api-utils";
 import { runBehavioralAnalysis } from "@/lib/analysis-behavioral";
 import { feedbackRequestSchema } from "@/lib/analysis-schemas";
 import { createRequestLogger } from "@/lib/logger";
@@ -8,12 +10,22 @@ import { OpenAIRetryError } from "@/lib/openai-retry";
 /**
  * POST /api/analysis/behavioral
  *
- * Internal, server-to-server route. No auth. Thin HTTP wrapper around
- * `runBehavioralAnalysis()` in `@/lib/analysis-behavioral`; the feedback route
- * imports that function directly rather than self-fetching this endpoint.
+ * Thin HTTP wrapper around `runBehavioralAnalysis()` in
+ * `@/lib/analysis-behavioral`. Production code doesn't call this over HTTP
+ * (the feedback route imports the function directly), but the route is
+ * still Internet-reachable, so it must auth and rate-limit like any other
+ * OpenAI-burning endpoint — otherwise an attacker can run up the API bill.
  */
 export async function POST(request: NextRequest) {
   const log = createRequestLogger({ route: "POST /api/analysis/behavioral" });
+
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const rateLimited = await checkRateLimit(session.user.id, "openai");
+  if (rateLimited) return rateLimited;
 
   let body: unknown;
   try {

--- a/apps/web/app/api/analysis/technical/route.integration.test.ts
+++ b/apps/web/app/api/analysis/technical/route.integration.test.ts
@@ -22,6 +22,14 @@ vi.mock("openai", () => ({
   },
 }));
 
+// The route now auths + rate-limits like any other OpenAI-burning endpoint.
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn().mockResolvedValue({ user: { id: "test-user" } }),
+}));
+vi.mock("@/lib/api-utils", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(null),
+}));
+
 vi.stubEnv("OPENAI_API_KEY", "sk-integration-test");
 
 import { POST } from "./route";

--- a/apps/web/app/api/analysis/technical/route.test.ts
+++ b/apps/web/app/api/analysis/technical/route.test.ts
@@ -10,6 +10,14 @@ vi.mock("openai", () => ({
   },
 }));
 
+// Route now auths + rate-limits; tests default to "signed-in, not limited".
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn().mockResolvedValue({ user: { id: "test-user" } }),
+}));
+vi.mock("@/lib/api-utils", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(null),
+}));
+
 import { POST } from "./route";
 
 const VALID_GPT_RESPONSE = readFileSync(

--- a/apps/web/app/api/analysis/technical/route.ts
+++ b/apps/web/app/api/analysis/technical/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { auth } from "@/lib/auth";
+import { checkRateLimit } from "@/lib/api-utils";
 import { runTechnicalAnalysis } from "@/lib/analysis-technical";
 import { technicalFeedbackRequestSchema } from "@/lib/analysis-schemas";
 import { createRequestLogger } from "@/lib/logger";
@@ -8,8 +10,10 @@ import { OpenAIRetryError } from "@/lib/openai-retry";
 /**
  * POST /api/analysis/technical
  *
- * Internal, server-to-server route. No auth. Thin HTTP wrapper around
- * `runTechnicalAnalysis()`; the feedback route imports that function directly.
+ * Thin HTTP wrapper around `runTechnicalAnalysis()`. Production code imports
+ * the function directly (feedback route); this HTTP surface is not used by
+ * the app, but it is Internet-reachable, so it must auth and rate-limit like
+ * every other OpenAI-burning endpoint.
  *
  * The deterministic timeline is built inside `runTechnicalAnalysis` via
  * `buildTimeline()` and overwrites whatever GPT returns for `timeline_analysis`
@@ -17,6 +21,14 @@ import { OpenAIRetryError } from "@/lib/openai-retry";
  */
 export async function POST(request: NextRequest) {
   const log = createRequestLogger({ route: "POST /api/analysis/technical" });
+
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const rateLimited = await checkRateLimit(session.user.id, "openai");
+  if (rateLimited) return rateLimited;
 
   let body: unknown;
   try {

--- a/apps/web/app/api/problems/generate/route.test.ts
+++ b/apps/web/app/api/problems/generate/route.test.ts
@@ -8,6 +8,13 @@ vi.mock("@/lib/auth", () => ({
   auth: () => mockAuth(),
 }));
 
+// Mock the rate limiter so tests don't exhaust the "openai" bucket (5/min)
+// when more than five cases fire sequentially inside one suite. Real
+// rate-limit behaviour is covered by `lib/ratelimit.test.ts`.
+vi.mock("@/lib/api-utils", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(null),
+}));
+
 // Mock OpenAI
 const mockChatCreate = vi.fn();
 vi.mock("openai", () => ({

--- a/apps/web/app/api/problems/generate/route.ts
+++ b/apps/web/app/api/problems/generate/route.ts
@@ -13,7 +13,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const rateLimited = await checkRateLimit(session.user.id);
+  // GPT problem generation hits OpenAI — use the "openai" tier (5/min).
+  const rateLimited = await checkRateLimit(session.user.id, "openai");
   if (rateLimited) return rateLimited;
 
   const body = await request.json();

--- a/apps/web/app/api/questions/generate/route.integration.test.ts
+++ b/apps/web/app/api/questions/generate/route.integration.test.ts
@@ -20,6 +20,12 @@ vi.mock("@/lib/auth", () => ({
   auth: () => mockAuth(),
 }));
 
+// Mock the rate limiter — route now uses the "openai" tier (5/min). Real
+// behaviour is covered by `lib/ratelimit.test.ts`.
+vi.mock("@/lib/api-utils", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(null),
+}));
+
 vi.mock("@/lib/db", () => ({
   get db() {
     return getTestDb();

--- a/apps/web/app/api/questions/generate/route.ts
+++ b/apps/web/app/api/questions/generate/route.ts
@@ -35,7 +35,8 @@ export async function POST(request: NextRequest) {
   const userId = session.user.id;
   const log = createRequestLogger({ route: "POST /api/questions/generate", userId });
 
-  const rateLimited = await checkRateLimit(userId);
+  // Question generation calls OpenAI — "openai" tier (5/min).
+  const rateLimited = await checkRateLimit(userId, "openai");
   if (rateLimited) return rateLimited;
 
   let body: unknown;

--- a/apps/web/app/api/questions/smart-generate/route.integration.test.ts
+++ b/apps/web/app/api/questions/smart-generate/route.integration.test.ts
@@ -17,6 +17,11 @@ import { users, userResumes } from "@/lib/schema";
 
 const mockAuth = vi.fn();
 vi.mock("@/lib/auth", () => ({ auth: () => mockAuth() }));
+// Route uses the "openai" tier (5/min); mock the limiter so >5 sequential
+// tests don't hit a stray 429. Real behaviour tested in lib/ratelimit.test.ts.
+vi.mock("@/lib/api-utils", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(null),
+}));
 vi.mock("@/lib/db", () => ({ get db() { return getTestDb(); } }));
 
 // Mock OpenAI

--- a/apps/web/app/api/questions/smart-generate/route.ts
+++ b/apps/web/app/api/questions/smart-generate/route.ts
@@ -20,7 +20,8 @@ export async function POST(request: NextRequest) {
   // is missing at construction time.
   const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
-  const rateLimited = await checkRateLimit(session.user.id);
+  // Smart generation issues an OpenAI call per request — "openai" tier (5/min).
+  const rateLimited = await checkRateLimit(session.user.id, "openai");
   if (rateLimited) return rateLimited;
 
   const log = createRequestLogger({ route: "POST /api/questions/smart-generate", userId: session.user.id });

--- a/apps/web/app/api/realtime/token/route.ts
+++ b/apps/web/app/api/realtime/token/route.ts
@@ -1,13 +1,20 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
+import { checkRateLimit } from "@/lib/api-utils";
 import { logger } from "@/lib/logger";
 
-// POST /api/realtime/token — get an ephemeral token for OpenAI Realtime API
+// POST /api/realtime/token — get an ephemeral token for OpenAI Realtime API.
+// Rate-limited on the "openai" tier (5/min): each token mints a billable
+// Realtime session, which is OpenAI's most expensive surface. Without this,
+// an authenticated attacker could loop-mint tokens to run up the API bill.
 export async function POST() {
   const session = await auth();
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  const rateLimited = await checkRateLimit(session.user.id, "openai");
+  if (rateLimited) return rateLimited;
 
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {

--- a/apps/web/app/api/transcribe/route.integration.test.ts
+++ b/apps/web/app/api/transcribe/route.integration.test.ts
@@ -20,6 +20,13 @@ vi.mock("@/lib/auth", () => ({
   auth: () => mockAuth(),
 }));
 
+// Mock the rate limiter so >5 sequential tests in this suite don't hit the
+// "openai" tier cap (5/min). Real rate-limit behaviour is covered in
+// `lib/ratelimit.test.ts`.
+vi.mock("@/lib/api-utils", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(null),
+}));
+
 // Point db import to the real test database
 vi.mock("@/lib/db", () => ({
   get db() {

--- a/apps/web/app/api/transcribe/route.ts
+++ b/apps/web/app/api/transcribe/route.ts
@@ -17,7 +17,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const rateLimited = await checkRateLimit(session.user.id);
+  // Whisper is a billable OpenAI endpoint — use the "openai" tier (5/min).
+  const rateLimited = await checkRateLimit(session.user.id, "openai");
   if (rateLimited) return rateLimited;
 
   const formData = await request.formData();

--- a/apps/web/app/dashboard/sessions/[id]/feedback/page.tsx
+++ b/apps/web/app/dashboard/sessions/[id]/feedback/page.tsx
@@ -234,15 +234,19 @@ export default function FeedbackPage() {
       {/* Sticky back-link so the path home is always visible, not buried
           below a long per-answer breakdown.
 
-          The dashboard layout wraps this page in `<div className="flex-1
-          overflow-auto p-6">` — that `overflow-auto` makes the div (not the
-          viewport) the nearest scrolling ancestor, so `sticky` anchors to
-          IT. We therefore `top-0` (not `top-14`, which would have anchored
-          56px DOWN from the scroll container's top — mid-way through the
-          p-6 padding zone, floating over content). The `-mx-6 -mt-6` pulls
-          the bar edge-to-edge and flush with the Header by escaping the
-          layout's padding. */}
-      <div className="sticky top-0 z-20 -mx-6 -mt-6 border-b bg-background/80 backdrop-blur">
+          Dashboard layout wraps this page in `<div className="flex-1
+          overflow-auto p-6">`. Two separate offsets have to line up:
+
+          - `-mt-6 -mx-6` pulls the bar OUT of the `p-6` so it spans the
+            scroll container edge-to-edge (and not inset by 24px).
+          - `-top-6` sets the STICKY anchor. The CSS spec measures sticky
+            `top` from the scroll container's *padding* edge, not the
+            border edge. With `p-6` on the container, `top: 0` would pin
+            the bar 24px DOWN from the visible top. `top: -1.5rem` (i.e.
+            `-top-6`) backs that offset out so the bar pins flush against
+            the header. Without this, the bar renders 24px below the
+            header — which is the "ample space above" the user reported. */}
+      <div className="sticky -top-6 z-20 -mx-6 -mt-6 border-b bg-background/80 backdrop-blur">
         <div className="mx-auto flex max-w-6xl items-center px-4 py-2">
           <Link
             href="/dashboard"

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -4,7 +4,6 @@ import { LandingHowItWorks } from "@/components/landing/LandingHowItWorks";
 import { LandingPersonas } from "@/components/landing/LandingPersonas";
 import { LandingFeatures } from "@/components/landing/LandingFeatures";
 import { LandingFAQ } from "@/components/landing/LandingFAQ";
-import { LandingSocialProof } from "@/components/landing/LandingSocialProof";
 import { LandingFooter } from "@/components/landing/LandingFooter";
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? "https://preploy.tech";
@@ -49,6 +48,10 @@ export const metadata: Metadata = {
   },
 };
 
+// Uses AggregateOffer (not a single $0 Offer) because Preploy has a free
+// tier + a paid Pro tier. The canonical pricing listing lives at /pricing;
+// this structured-data block only needs to communicate the price range to
+// crawlers.
 const jsonLd = {
   "@context": "https://schema.org",
   "@type": "WebApplication",
@@ -59,9 +62,12 @@ const jsonLd = {
   description:
     "Ace your next job interview with Preploy. Practice mock interviews with an AI interviewer and get instant, detailed feedback on your answers.",
   offers: {
-    "@type": "Offer",
-    price: "0",
+    "@type": "AggregateOffer",
+    lowPrice: "0",
+    highPrice: "15",
     priceCurrency: "USD",
+    offerCount: "2",
+    url: `${BASE_URL}/pricing`,
   },
 };
 
@@ -77,7 +83,10 @@ export default function Home() {
         <LandingHowItWorks />
         <LandingPersonas />
         <LandingFeatures />
-        <LandingSocialProof />
+        {/* LandingSocialProof intentionally dropped from the composition
+            while real testimonials don't exist — rendering an empty
+            `<section aria-label="Testimonials">` created a ghost landmark
+            and a visible gap. Re-add when testimonials ship. */}
         <LandingFAQ />
         <LandingFooter />
       </div>

--- a/apps/web/components/landing/LandingFAQ.test.tsx
+++ b/apps/web/components/landing/LandingFAQ.test.tsx
@@ -49,11 +49,15 @@ describe("LandingFAQ", () => {
     expect(contents[1].className).toContain("max-h-96");
   });
 
-  it("pricing answer mentions free beta", () => {
+  it("pricing answer describes free + Pro tiers", () => {
     render(<LandingFAQ />);
     const triggers = screen.getAllByTestId("faq-trigger");
     fireEvent.click(triggers[0]);
-    expect(screen.getByText(/free while in beta/i)).toBeTruthy();
+    // Copy changed when the Pro tier shipped; previously said "free while in
+    // beta", now describes both tiers and points at the /pricing page.
+    expect(screen.getByText(/free tier/i)).toBeTruthy();
+    expect(screen.getByText(/Pro/)).toBeTruthy();
+    expect(screen.getByText(/\$15\/month/)).toBeTruthy();
   });
 
   it("privacy answer explains audio handling", () => {

--- a/apps/web/components/landing/LandingFAQ.tsx
+++ b/apps/web/components/landing/LandingFAQ.tsx
@@ -8,7 +8,7 @@ const faqs = [
   {
     question: "How much does Preploy cost?",
     answer:
-      "Preploy is free while in beta. You can run as many mock interviews as you like at no charge. Pricing has not been finalized — you will receive notice before any paid tier is introduced.",
+      "Preploy has a free tier — 3 mock interviews a month, behavioral and technical, with full scored feedback. Pro is $15/month (or $120/year — roughly $10/month billed annually) and lifts the cap to 40 sessions a month plus resume-tailored questions, company-specific question generation, and the interview-day planner. Full breakdown on the pricing page.",
   },
   {
     question: "Does Preploy store my audio or transcripts?",


### PR DESCRIPTION
## Summary

Three follow-ups from the post-#142 audit, bundled so they ship with one CI run.

### 1. OpenAI rate-limit gaps (security audit — medium)

The audit flagged that a logged-in attacker could burn the OpenAI bill by looping the heavy endpoints — several either had no rate limit at all, or used the default tier (20/min) when the project already exposes an `"openai"` tier (5/min) in `lib/ratelimit.ts`.

**Added rate limit (previously none):**
- `/api/analysis/behavioral`, `/api/analysis/technical` — also added `await auth()`. These were documented as "internal server-to-server, no auth" but they're Internet-reachable Next.js routes. Production code never hits the HTTP surface (the feedback route imports the lib functions directly), but external attackers can. Now they auth + rate-limit like every other protected route.
- `/api/realtime/token` — auth was present, rate-limit was missing. Each call mints a billable Realtime ephemeral token.

**Upgraded from default tier → `"openai"` tier:**
- `/api/transcribe`, `/api/problems/generate`, `/api/questions/generate`, `/api/questions/smart-generate` — all four burn OpenAI per request and should share the tighter bucket.

**Test updates:** added `vi.mock("@/lib/api-utils", { checkRateLimit: () => null })` to the 6 affected test files. Without this the real in-memory rate limiter would trip 429 on the 6th sequential POST in a suite now that the tier is 5/min. Real rate-limit behaviour stays covered by `lib/ratelimit.test.ts`.

### 2. Feedback "Back to Dashboard" sticky bar — residual gap

The previous fix closed most of the gap but left ~24px between the `<Header>` and the bar.

**Root cause** (CSS spec detail that cost me 20 minutes the first time around): `position: sticky` measures `top` from the scroll container's **padding edge**, not the border edge. Dashboard layout wraps content in `<div className="flex-1 overflow-auto p-6">`, so `top: 0` was pinning the bar 24px inside the `p-6` zone.

Fix: `-top-6` (= `top: -1.5rem`) on the sticky. `-mt-6 -mx-6` already handles the *natural* position; `-top-6` handles the *anchor*. Added an extended comment in the file documenting the two-offset dance so the next person doesn't re-debug it.

### 3. Stale landing copy + misleading structured data

- **LandingFAQ pricing answer** claimed "free while in beta... Pricing has not been finalized." Flat wrong since the Pro tier shipped. Rewrote to describe free (3/mo) vs Pro ($15/mo or $120/yr for 40/mo + Pro-gated tools) and point at `/pricing` as the canonical source. Test assertion updated to match.
- **LandingSocialProof** was still mounted on the landing page as an empty `<section aria-label="Testimonials">` — ghost landmark in the a11y tree and a visible gap between Features and FAQ. Dropped from the page composition; the component file stays for when real testimonials ship.
- **Root `jsonLd` structured data** declared `{ "@type": "Offer", "price": "0", "priceCurrency": "USD" }`. Actively misleading for crawlers now that Pro exists. Swapped to `AggregateOffer` with `lowPrice: "0"`, `highPrice: "15"`, `offerCount: "2"`, `url: /pricing`.

## Test plan

- [x] `npx turbo lint typecheck test --filter=@preploy/web` — **3 tasks green, 91 files / 891 tests pass**
- [x] Landing: Playwright smoke — new FAQ pricing copy renders; `section[aria-label="Testimonials"]` count = 0
- [ ] Manual verify feedback sticky: complete a session, open `/dashboard/sessions/[id]/feedback`, confirm the "Back to Dashboard" bar sits flush against the header at scroll=0 with no gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)