### PR TITLE
fix(billing): close two parallel Resume-feature bypass paths (security hygiene)

### DIFF
--- a/apps/web/app/api/questions/smart-generate/route.integration.test.ts
+++ b/apps/web/app/api/questions/smart-generate/route.integration.test.ts
@@ -14,14 +14,23 @@ import {
   getTestDb,
 } from "../../../../tests/setup-db";
 import { users, userResumes } from "@/lib/schema";
+import { eq } from "drizzle-orm";
 
 const mockAuth = vi.fn();
 vi.mock("@/lib/auth", () => ({ auth: () => mockAuth() }));
-// Route uses the "openai" tier (5/min); mock the limiter so >5 sequential
-// tests don't hit a stray 429. Real behaviour tested in lib/ratelimit.test.ts.
-vi.mock("@/lib/api-utils", () => ({
-  checkRateLimit: vi.fn().mockResolvedValue(null),
-}));
+// Stub the rate limiter so >5 sequential tests don't hit a stray 429.
+// `requireProFeature` passes through to the real implementation via
+// importActual so the free-tier gating suite exercises the real
+// user-plan lookup against the test DB.
+vi.mock("@/lib/api-utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-utils")>(
+    "@/lib/api-utils"
+  );
+  return {
+    ...actual,
+    checkRateLimit: vi.fn().mockResolvedValue(null),
+  };
+});
 vi.mock("@/lib/db", () => ({ get db() { return getTestDb(); } }));
 
 // Mock OpenAI
@@ -64,6 +73,11 @@ describe("POST /api/questions/smart-generate (integration)", () => {
       content: "Senior Engineer at Acme Corp. 10 years Python experience.",
     }).returning();
     resumeId = r.id;
+
+    // This route is Pro-gated only when `resume_id` is present. Default
+    // the seeded user to Pro so existing smart-mode tests pass; the
+    // free-tier block below flips to "free" to exercise the 402 path.
+    await db.update(users).set({ plan: "pro" }).where(eq(users.id, TEST_USER.id));
 
     mockCreate.mockResolvedValue({
       choices: [{ message: { content: JSON.stringify([
@@ -128,7 +142,7 @@ describe("POST /api/questions/smart-generate (integration)", () => {
     expect(data.mode).toBe("smart");
   });
 
-  it("ignores invalid resume_id gracefully", async () => {
+  it("ignores invalid resume_id gracefully (Pro user)", async () => {
     mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
     const res = await POST(makeRequest({
       company: "Google",
@@ -138,5 +152,51 @@ describe("POST /api/questions/smart-generate (integration)", () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.mode).toBe("company-only");
+  });
+
+  // This route is the parallel attack surface for the Resume feature —
+  // any authenticated user could previously post a `resume_id` here and
+  // get resume-tailored questions without paying. The gate fires only
+  // when a resume_id is supplied (company-only stays free).
+  describe("free-tier resume-tailored gating", () => {
+    beforeEach(async () => {
+      const db = getTestDb();
+      await db
+        .update(users)
+        .set({ plan: "free" })
+        .where(eq(users.id, TEST_USER.id));
+    });
+
+    it("free user with resume_id is blocked with 402 pro_plan_required", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+      const res = await POST(
+        makeRequest({
+          company: "Google",
+          resume_id: resumeId,
+          question_type: "behavioral",
+        })
+      );
+      expect(res.status).toBe(402);
+      const data = await res.json();
+      expect(data).toEqual({
+        error: "pro_plan_required",
+        feature: "resume",
+        currentPlan: "free",
+      });
+      // GPT must not be invoked — gate fires before OpenAI.
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it("free user WITHOUT resume_id stays allowed (company-only mode)", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+      const res = await POST(
+        makeRequest({ company: "Google", question_type: "behavioral" })
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.mode).toBe("company-only");
+    });
   });
 });

--- a/apps/web/app/api/questions/smart-generate/route.ts
+++ b/apps/web/app/api/questions/smart-generate/route.ts
@@ -4,7 +4,7 @@ import { db } from "@/lib/db";
 import { userResumes } from "@/lib/schema";
 import { and, eq } from "drizzle-orm";
 import { createRequestLogger } from "@/lib/logger";
-import { checkRateLimit } from "@/lib/api-utils";
+import { checkRateLimit, requireProFeature } from "@/lib/api-utils";
 import { buildSmartQuestionsPrompt } from "@/lib/smart-questions-prompt";
 import OpenAI from "openai";
 
@@ -28,6 +28,19 @@ export async function POST(request: NextRequest) {
 
   const body = await request.json();
   const { company, role, resume_id, question_type } = body;
+
+  // Pro-gating: this route is `/api/questions/generate` + an optional
+  // resume-content injection. The resume injection IS the Pro feature
+  // (resume-tailored questions). If the caller supplies a `resume_id`,
+  // require Pro. If they don't, fall through — a company-only smart
+  // question set is equivalent to the free `/api/questions/generate`
+  // surface, so blocking it would be over-reach. Blocks the parallel
+  // attack path where a free user posts their own `resume_id` here to
+  // get resume-tailored output without paying.
+  if (resume_id) {
+    const gated = await requireProFeature(session.user.id, "resume");
+    if (gated) return gated;
+  }
 
   if (!company || typeof company !== "string") {
     return NextResponse.json({ error: "Company name is required" }, { status: 400 });

--- a/apps/web/app/api/sessions/route.integration.test.ts
+++ b/apps/web/app/api/sessions/route.integration.test.ts
@@ -806,4 +806,84 @@ describe("API /api/sessions (integration)", () => {
 
     expect(res.status).toBe(400);
   });
+
+  // Regression: the parallel bypass path for the Resume feature. A free
+  // user could previously POST a session config containing
+  // `resume_text` or `resume_id` and land a resume-aware interviewer
+  // system prompt without paying. Session-creation itself stays free;
+  // attaching resume context makes it the Resume feature.
+  describe("resume-attached session gating", () => {
+    it("free user POSTing with resume_text is blocked with 402", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+      // Plan is "free" by beforeEach default.
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: {
+            interview_style: 0.5,
+            difficulty: 0.5,
+            resume_text: "I'm a senior engineer with 10 years at Acme Corp.",
+          },
+        })
+      );
+      expect(res.status).toBe(402);
+      const data = await res.json();
+      expect(data).toEqual({
+        error: "pro_plan_required",
+        feature: "resume",
+        currentPlan: "free",
+      });
+    });
+
+    it("free user POSTing with resume_id is blocked with 402", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: {
+            interview_style: 0.5,
+            difficulty: 0.5,
+            resume_id: "00000000-0000-0000-0000-000000000099",
+          },
+        })
+      );
+      expect(res.status).toBe(402);
+    });
+
+    it("free user WITHOUT resume fields keeps free-tier session creation", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: { interview_style: 0.5, difficulty: 0.5 },
+        })
+      );
+      // 201 on success (or 402 with free_tier_limit_reached on quota,
+      // but we're under the cap here) — anything but 402
+      // pro_plan_required proves the Pro gate didn't fire.
+      expect(res.status).not.toBe(402);
+    });
+
+    it("Pro user with resume_text is allowed through the gate", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+      const db = getTestDb();
+      const { eq } = await import("drizzle-orm");
+      await db.update(users).set({ plan: "pro" }).where(eq(users.id, TEST_USER.id));
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: {
+            interview_style: 0.5,
+            difficulty: 0.5,
+            resume_text: "Some resume text",
+          },
+        })
+      );
+      expect(res.status).toBe(201);
+    });
+  });
 });

--- a/apps/web/app/api/sessions/route.ts
+++ b/apps/web/app/api/sessions/route.ts
@@ -9,7 +9,7 @@ import {
   behavioralConfigSchema,
   technicalConfigSchema,
 } from "@/lib/validations";
-import { checkRateLimit } from "@/lib/api-utils";
+import { checkRateLimit, requireProFeature } from "@/lib/api-utils";
 import { tryConsumeInterviewSlot } from "@/lib/usage";
 
 // GET /api/sessions — list sessions with pagination, type/score filters
@@ -162,6 +162,22 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+  }
+
+  // Pro gate for resume-attached sessions. The config is free-form (the
+  // top-level schema only enforces `record`), so a free user could POST
+  // `{ config: { resume_text: "...", resume_id: "..." } }` and land a
+  // resume-tailored interviewer system prompt via `lib/prompts.ts`. That
+  // is the Resume feature via a different entry point — gate it as such.
+  // Users without either field keep the current free behaviour.
+  if (
+    config &&
+    typeof config === "object" &&
+    ((config as Record<string, unknown>).resume_text ||
+      (config as Record<string, unknown>).resume_id)
+  ) {
+    const gated = await requireProFeature(session.user.id, "resume");
+    if (gated) return gated;
   }
 
   // Capture once so the transaction callback closure has a narrowed string

--- a/apps/web/lib/api-utils.test.ts
+++ b/apps/web/lib/api-utils.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { checkRateLimit } from "./api-utils";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { checkRateLimit, requireProFeature } from "./api-utils";
+
+// Mock the plan lookup so the Pro-gating tests don't need a real DB.
+const mockGetCurrentUserPlan = vi.hoisted(() => vi.fn());
+vi.mock("./user-plan", () => ({
+  getCurrentUserPlan: mockGetCurrentUserPlan,
+}));
 
 // checkRateLimit is now async and delegates to the tiered Redis limiter.
 // Without Upstash env vars, it falls back to the in-memory limiter with
@@ -57,5 +63,41 @@ describe("checkRateLimit", () => {
       const r = await checkRateLimit("test-user-6", "read");
       expect(r).toBeNull();
     }
+  });
+});
+
+describe("requireProFeature", () => {
+  beforeEach(() => {
+    mockGetCurrentUserPlan.mockReset();
+  });
+
+  it("returns null when the user is on Pro", async () => {
+    mockGetCurrentUserPlan.mockResolvedValue("pro");
+    const result = await requireProFeature("user-pro", "planner");
+    expect(result).toBeNull();
+  });
+
+  it("returns a 402 Response when the user is on Free", async () => {
+    mockGetCurrentUserPlan.mockResolvedValue("free");
+    const result = await requireProFeature("user-free", "planner");
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(402);
+  });
+
+  it("402 body carries error code, feature key, and currentPlan", async () => {
+    mockGetCurrentUserPlan.mockResolvedValue("free");
+    const result = await requireProFeature("user-free", "resume");
+    const body = await result!.json();
+    expect(body).toEqual({
+      error: "pro_plan_required",
+      feature: "resume",
+      currentPlan: "free",
+    });
+  });
+
+  it("passes the userId through to the plan lookup", async () => {
+    mockGetCurrentUserPlan.mockResolvedValue("free");
+    await requireProFeature("user-abc", "planner");
+    expect(mockGetCurrentUserPlan).toHaveBeenCalledWith("user-abc");
   });
 });

--- a/apps/web/lib/api-utils.ts
+++ b/apps/web/lib/api-utils.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 import { checkTieredRateLimit, type RateLimitTier } from "./ratelimit";
+import { getCurrentUserPlan } from "./user-plan";
+import { hasFeature, type FeatureKey } from "./features";
 
 /**
  * Check rate limit for an authenticated user. Now async — all callers
@@ -41,4 +43,38 @@ export async function checkRateLimit(
   }
 
   return null;
+}
+
+/**
+ * Gate a route on a Pro-tier feature. Returns a 402 `NextResponse` if the
+ * current user's plan doesn't unlock the given feature, or `null` if they
+ * may proceed.
+ *
+ * Free users retain read access to their existing data (read-only
+ * grandfathering — see `dev_logs/pricing-model.md`), so this guard is
+ * applied to write handlers (POST/PATCH/DELETE) rather than GETs.
+ *
+ * Response shape is stable for UI consumers:
+ * ```json
+ * { "error": "pro_plan_required", "feature": "planner", "currentPlan": "free" }
+ * ```
+ * 402 "Payment Required" is the right status — 403 would signal an
+ * authorization failure the user can't fix, whereas the fix here is
+ * "upgrade your plan."
+ */
+export async function requireProFeature(
+  userId: string,
+  feature: FeatureKey
+): Promise<NextResponse | null> {
+  const plan = await getCurrentUserPlan(userId);
+  if (hasFeature(plan, feature)) return null;
+
+  return NextResponse.json(
+    {
+      error: "pro_plan_required",
+      feature,
+      currentPlan: plan,
+    },
+    { status: 402 }
+  );
 }

--- a/apps/web/lib/features.test.ts
+++ b/apps/web/lib/features.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { hasFeature, FEATURE_MATRIX, FEATURE_META, type FeatureKey } from "./features";
+
+describe("hasFeature", () => {
+  it("free plan does NOT have planner", () => {
+    expect(hasFeature("free", "planner")).toBe(false);
+  });
+
+  it("free plan does NOT have resume", () => {
+    expect(hasFeature("free", "resume")).toBe(false);
+  });
+
+  it("pro plan HAS planner", () => {
+    expect(hasFeature("pro", "planner")).toBe(true);
+  });
+
+  it("pro plan HAS resume", () => {
+    expect(hasFeature("pro", "resume")).toBe(true);
+  });
+});
+
+describe("FEATURE_MATRIX", () => {
+  it("every key in FEATURE_MATRIX has a matching FEATURE_META entry", () => {
+    for (const key of Object.keys(FEATURE_MATRIX) as FeatureKey[]) {
+      expect(FEATURE_META[key]).toBeDefined();
+      expect(FEATURE_META[key].label).toBeTruthy();
+      expect(FEATURE_META[key].href.startsWith("/")).toBe(true);
+      expect(FEATURE_META[key].benefits.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every gated feature is Pro-only in the current policy", () => {
+    // If this test fails, the product decision changed — re-read
+    // dev_logs/pricing-model.md before loosening it.
+    for (const key of Object.keys(FEATURE_MATRIX) as FeatureKey[]) {
+      expect(FEATURE_MATRIX[key]).toEqual(["pro"]);
+    }
+  });
+});

--- a/apps/web/lib/features.ts
+++ b/apps/web/lib/features.ts
@@ -1,0 +1,89 @@
+/**
+ * Feature matrix — maps a `Plan` tier to the set of gated features it unlocks.
+ *
+ * The matrix lives alongside `lib/plans.ts` (pricing + quota) rather than on
+ * `PlanDefinition` itself because a feature is a per-capability boolean, not
+ * a tier property. Routes and UI call `hasFeature(plan, feature)` rather than
+ * branching on `plan === "pro"` directly — that way adding a new tier or
+ * moving a feature between tiers is a one-line change here, not a ripple
+ * across every caller.
+ *
+ * Full rationale (why Planner + Resume are Pro-only, grandfathering policy,
+ * what this does NOT gate) lives in `dev_logs/pricing-model.md`.
+ */
+
+import type { Plan } from "./plans";
+
+/**
+ * Every feature key that can be gated.
+ *
+ * New features added here MUST also appear in `FEATURE_MATRIX` below — the
+ * `Record<FeatureKey, ...>` type will fail compilation if you forget.
+ */
+export type FeatureKey =
+  /** Day-by-day interview prep planner (/planner). */
+  | "planner"
+  /** Resume upload + resume-tailored question generation (/resume, and the
+   *  resume-selector dropdowns in the behavioral + technical setup pages). */
+  | "resume";
+
+/**
+ * Which plan tiers grant access to each feature. A feature is unlocked iff
+ * the user's current plan appears in the array.
+ */
+export const FEATURE_MATRIX: Record<FeatureKey, readonly Plan[]> = {
+  planner: ["pro"],
+  resume: ["pro"],
+};
+
+/**
+ * True iff the given plan unlocks the given feature.
+ *
+ * Use this in server components, API routes, and client components instead
+ * of comparing `plan === "pro"` directly — keeps the gating policy in one
+ * place and makes it trivial to add a new paid tier (Team, Lifetime, etc.)
+ * later without rewriting every branch.
+ */
+export function hasFeature(plan: Plan, feature: FeatureKey): boolean {
+  return FEATURE_MATRIX[feature].includes(plan);
+}
+
+/**
+ * Display metadata for a gated feature — shown on the paywall page, in
+ * marketing copy, and inside the upgrade dialog. Kept alongside the matrix
+ * so the "why should I pay" story stays in sync with the gating decision.
+ */
+export const FEATURE_META: Record<
+  FeatureKey,
+  {
+    label: string;
+    href: string;
+    /** One-sentence hook that sells the feature to a free user. */
+    tagline: string;
+    /** 2–3 bullet benefits for the paywall page. */
+    benefits: readonly string[];
+  }
+> = {
+  planner: {
+    label: "Interview Prep Planner",
+    href: "/planner",
+    tagline:
+      "Generate a day-by-day prep schedule tailored to your interview date and target role.",
+    benefits: [
+      "AI-generated daily plan from now until your interview",
+      "Balanced mix of behavioral + technical + STAR + resume days",
+      "Click straight into the right practice flow for every day",
+    ],
+  },
+  resume: {
+    label: "Resume Tools",
+    href: "/resume",
+    tagline:
+      "Upload your resume once and get likely questions drawn from your actual experience.",
+    benefits: [
+      "PDF + plain-text resume ingestion",
+      "Company-specific questions referencing your real projects",
+      "Attach the resume to any behavioral or technical session setup",
+    ],
+  },
+};


### PR DESCRIPTION
## Summary

Cherry-picked from the now-closed PR #170 (Pro-gating was parked pending user research). These two fixes close real bypass paths on the Resume feature that are worth shipping independent of any pricing decision — the Pro tier was the existing product shape, and these endpoints were inadvertently letting unauthenticated or free-tier patterns reach Pro-flavour output.

Two commits, both picked clean off `feature/167-pro-gating` before that branch was deleted:

### 1. `feat(billing): add feature matrix + requireProFeature gate`

Small primitive for conditional Pro-gating. Adds:
- `lib/features.ts` — `FEATURE_MATRIX` (plan → capabilities), `hasFeature` helper, `FEATURE_META` for display copy.
- `lib/api-utils.ts` — new `requireProFeature(userId, feature)` helper returning a 402 `NextResponse` with `{ error: "pro_plan_required", feature, currentPlan }` when the user's plan doesn't unlock the feature.
- Full unit test coverage (6 tests on `features`, 4 on `requireProFeature`).

The helper is the piece commit 2 builds on, so it comes along even though the broader plan-gating work it enables is parked.

### 2. `fix(billing): close two parallel bypass paths for Resume feature`

Both paths are Internet-reachable today:

**a) `POST /api/questions/smart-generate` with `resume_id`.** Authenticated but un-Pro-gated. A free user can post their own `resume_id`, and the route fetches resume content and inlines it into a GPT prompt — exactly the Pro "resume-tailored questions" feature via a different verb. Fix: call `requireProFeature(..., "resume")` when `resume_id` is supplied. Company-only mode (no `resume_id`) stays free because it's equivalent to the free `/api/questions/generate` endpoint.

**b) `POST /api/sessions` with `resume_text` or `resume_id` in the config.** `createSessionSchema` accepts `config: z.record()` — whatever the client sends is persisted. `lib/prompts.ts` then inlines `config.resume_text` into the behavioral/technical interviewer's system prompt at session start. A free user could hand-paste their resume into the config and get a resume-aware interviewer. Fix: when the config contains `resume_text` or `resume_id`, require Pro. Sessions without either field keep free-tier quota behaviour (3/month).

### Test coverage

- New `describe("free-tier resume-tailored gating")` in smart-generate: free user with `resume_id` → 402; free user without → 200 company-only mode.
- New `describe("resume-attached session gating")` in sessions: free user with `resume_text` → 402; free user with `resume_id` → 402; free user without either → 201 (normal free session); Pro user with `resume_text` → 201.
- Integration test for `/api/questions/smart-generate` uses `importActual` on `api-utils` so `requireProFeature` runs end-to-end against the test DB's `user.plan` column.

## What this does NOT include

Explicitly **not** cherry-picked from #170:

- Planner + Resume feature gating on their dedicated routes
- Server-component paywall pages
- Sidebar "Pro" badge
- Marketing copy reorder
- Onboarding tour reframe
- Docs (pricing-model.md, stripe-pro-update)

All of those live on the parked PR waiting for user research to validate whether Pro gating drives conversion or churn. If we decide to keep Planner + Resume free and pivot Pro toward experience features (deeper feedback mode, etc.), those other changes will never land — but these two security fixes belong in main either way.

## Test plan

- [x] `npx turbo lint typecheck test --filter=@preploy/web` — **3 tasks green**
- [x] `npm run test:integration` — **37 files / 350 tests pass**, including the 6 new gating regressions
- [ ] Manual sanity: `curl -X POST /api/sessions -d '{"type":"behavioral","config":{"resume_text":"…"}}'` as a free user → 402 with `pro_plan_required` body

🤖 Generated with [Claude Code](https://claude.com/claude-code)