### PR TITLE
docs(marketing): align plan copy with what each tier delivers (fixes #172)

### DIFF
--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { PLAN_DEFINITIONS } from "@/lib/plans";
+import { PLAN_DEFINITIONS, FREE_PLAN_MONTHLY_INTERVIEW_LIMIT } from "@/lib/plans";
 
 export const dynamic = "force-static";
 
@@ -19,21 +19,25 @@ export const metadata: Metadata = {
   robots: { index: true, follow: true },
 };
 
+// These lists describe what each tier actually delivers today. Nothing
+// listed under Pro is also available on Free — that mismatch confused
+// users in an earlier cut of this page (see issue #172). New Pro-only
+// capabilities (e.g. a deeper feedback mode) will land in separate PRs
+// alongside the code that gates them.
 const FREE_FEATURES = [
-  "3 mock interviews per month",
+  `${FREE_PLAN_MONTHLY_INTERVIEW_LIMIT} mock interviews per month`,
   "Behavioral & technical modes",
   "Voice-to-voice AI interviewer",
   "Scored feedback on every session",
   "STAR story prep with AI analysis",
+  "Interview-day planner with AI schedule",
+  "Resume upload + resume-tailored questions",
+  "Coaching guides & progress dashboard",
 ];
 
 const PRO_FEATURES = [
-  `${PLAN_DEFINITIONS.pro.limits.monthlyInterviews} mock interviews per month`,
   "Everything in Free, plus:",
-  "Resume-tailored questions",
-  "Company-specific question generation",
-  "Interview day planner with AI schedule",
-  "Progress tracking & streak badges",
+  `${PLAN_DEFINITIONS.pro.limits.monthlyInterviews} mock interviews per month (up from ${FREE_PLAN_MONTHLY_INTERVIEW_LIMIT})`,
   "Priority during high-traffic periods",
 ];
 

--- a/apps/web/components/billing/UpgradePromptDialog.test.tsx
+++ b/apps/web/components/billing/UpgradePromptDialog.test.tsx
@@ -55,7 +55,11 @@ describe("UpgradePromptDialog", () => {
       <UpgradePromptDialog open={true} onClose={() => {}} used={3} limit={3} />
     );
     expect(
-      screen.getAllByText(/Unlimited mock interviews/).length
+      // Copy updated in issue #172 — the old "Unlimited mock interviews"
+      // claim misrepresented Pro (cap is 40/month, not unlimited). Also,
+      // the benefits now lead with the genuine quota bump rather than
+      // listing free-tier features.
+      screen.getAllByText(/40 mock interviews per month/).length
     ).toBeGreaterThanOrEqual(1);
   });
 

--- a/apps/web/components/billing/UpgradePromptDialog.tsx
+++ b/apps/web/components/billing/UpgradePromptDialog.tsx
@@ -11,11 +11,15 @@ interface UpgradePromptDialogProps {
   limit: number;
 }
 
+// Modal fires on quota exhaustion — so the value prop has to be honest
+// about what Pro actually delivers beyond the quota bump the user just
+// hit. Everything listed below is either the quota bump itself or a
+// genuine Pro-exclusive capability. See issue #172 for the prior copy
+// (which listed free-tier features as Pro benefits).
 const PRO_BENEFITS = [
-  "Unlimited mock interviews — no monthly cap",
-  "Behavioral and technical interviews, both formats",
-  "Voice-to-voice practice with scored feedback",
-  "Save and revisit your STAR stories with AI scoring",
+  `${PLAN_DEFINITIONS.pro.limits.monthlyInterviews} mock interviews per month (up from 3)`,
+  "Priority during high-traffic periods",
+  "Cancel anytime from your profile",
 ];
 
 /**

--- a/apps/web/components/landing/LandingFAQ.tsx
+++ b/apps/web/components/landing/LandingFAQ.tsx
@@ -8,7 +8,7 @@ const faqs = [
   {
     question: "How much does Preploy cost?",
     answer:
-      "Preploy has a free tier — 3 mock interviews a month, behavioral and technical, with full scored feedback. Pro is $15/month (or $120/year — roughly $10/month billed annually) and lifts the cap to 40 sessions a month plus resume-tailored questions, company-specific question generation, and the interview-day planner. Full breakdown on the pricing page.",
+      "Preploy has a free tier — 3 mock interviews a month, behavioral and technical, with full scored feedback, STAR prep, resume upload, and the interview-day planner. Pro is $15/month (or $120/year — roughly $10/month billed annually) and lifts the cap to 40 sessions a month, plus priority during high-traffic periods. Full breakdown on the pricing page.",
   },
   {
     question: "Does Preploy store my audio or transcripts?",


### PR DESCRIPTION
## Summary

Closes #172. Doc-only fix — no code behaviour changes. Main branch advertises Planner + Resume + company-specific questions as Pro-only on three surfaces, but the code doesn't gate them. Free users have always had access. This PR corrects the copy so each tier honestly describes what it delivers today.

### Changes

- **`/pricing`** — moved Planner, Resume tools, and coaching/dashboard from `PRO_FEATURES` into `FREE_FEATURES` (they were advertised as Pro-only but have always been free). `PRO_FEATURES` now lists only the quota bump (3 → 40 sessions/month) and priority during high-traffic periods. Quota numbers pull from `lib/plans.ts` (`FREE_PLAN_MONTHLY_INTERVIEW_LIMIT` + `PLAN_DEFINITIONS.pro.limits.monthlyInterviews`) so they can't drift.
- **`UpgradePromptDialog.PRO_BENEFITS`** — replaced the stale "Unlimited mock interviews — no monthly cap" list (never accurate — Pro is 40/month) with the honest quota bump + priority + cancel-anytime triplet. This modal fires on quota exhaustion, so it's the worst possible place for misleading claims.
- **`LandingFAQ`** pricing answer — dropped the "…plus resume-tailored questions, company-specific question generation, and the interview-day planner" clause that implied those are Pro-only.
- Tests — `UpgradePromptDialog.test.tsx` asserts on the new `40 mock interviews per month` text. `LandingFAQ` assertions (`free tier`, `Pro`, `$15/month`) still hold.

### Test plan

- [x] `npx turbo lint typecheck test --filter=@preploy/web` — 3 tasks green
- [ ] Preview the `/pricing` page, the landing FAQ, and trigger `UpgradePromptDialog` (hit session quota on free tier) before merging

### Not in this PR

- **No feature gating** — the Pro gating of Planner + Resume was explored in PR #170, then parked pending user research on whether it drives conversion or churn. This PR assumes the gating stays parked. If it's ever shipped, the copy here is easily extended.
- **Security bypass fixes** — cherry-picked to PR #171 separately.
- **Stripe product descriptions** — no change needed; they already describe quota+features reasonably.
- **New Pro features** (deeper feedback mode, etc.) — those will add lines to the PRO list when they land, alongside the code that gates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)