### PR TITLE
feat(plan): Pro badge + usePlan() hook (Phase 0 of Pro gating)

### DIFF
--- a/apps/web/app/api/users/me/route.integration.test.ts
+++ b/apps/web/app/api/users/me/route.integration.test.ts
@@ -77,6 +77,21 @@ describe("API /api/users/me (integration)", () => {
     expect(data.plan).toBe("free");
   });
 
+  it("GET returns plan === \"pro\" when the user row is pro", async () => {
+    const db = getTestDb();
+    // Set plan to "pro" for this test
+    await db.update(users).set({ plan: "pro" }).where(eq(users.id, TEST_USER.id));
+
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.plan).toBe("pro");
+
+    // Reset to "free" for other tests
+    await db.update(users).set({ plan: "free" }).where(eq(users.id, TEST_USER.id));
+  });
+
   it("GET returns gazeTrackingEnabled field", async () => {
     mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
     const res = await GET();

--- a/apps/web/components/shared/Header.test.tsx
+++ b/apps/web/components/shared/Header.test.tsx
@@ -19,9 +19,17 @@ vi.mock("next/navigation", () => ({
   }),
 }));
 
+// Hoisted mock for usePlan so individual tests can flip the return value
+const { usePlanMock } = vi.hoisted(() => ({ usePlanMock: vi.fn() }));
+vi.mock("@/hooks/usePlan", () => ({
+  usePlan: usePlanMock,
+  signOutAndClearPlan: vi.fn(),
+}));
+
 // Mock next-auth/react
+const mockUseSession = vi.fn();
 vi.mock("next-auth/react", () => ({
-  useSession: () => ({ data: null, status: "unauthenticated" }),
+  useSession: () => mockUseSession(),
   signOut: vi.fn(),
 }));
 
@@ -32,12 +40,16 @@ vi.mock("next-themes", () => ({
 
 describe("Header", () => {
   it("renders the app title", () => {
+    usePlanMock.mockReturnValue({ plan: undefined });
+    mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });
     mockPathname.value = "/dashboard";
     render(<Header />);
     expect(screen.getAllByText("Preploy").length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders the theme toggle button", () => {
+    usePlanMock.mockReturnValue({ plan: undefined });
+    mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });
     mockPathname.value = "/dashboard";
     const { container } = render(<Header />);
     const toggle = container.querySelector("[aria-label='Toggle theme']");
@@ -45,12 +57,16 @@ describe("Header", () => {
   });
 
   it("renders Sign In link when unauthenticated", () => {
+    usePlanMock.mockReturnValue({ plan: undefined });
+    mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });
     mockPathname.value = "/dashboard";
     render(<Header />);
     expect(screen.getAllByText("Sign In").length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders navigation links", () => {
+    usePlanMock.mockReturnValue({ plan: undefined });
+    mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });
     mockPathname.value = "/dashboard";
     render(<Header />);
     expect(screen.getAllByText("Dashboard").length).toBeGreaterThanOrEqual(1);
@@ -60,6 +76,8 @@ describe("Header", () => {
   });
 
   it("renders STAR Prep, Resume, and Achievements navigation links", () => {
+    usePlanMock.mockReturnValue({ plan: undefined });
+    mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });
     mockPathname.value = "/dashboard";
     render(<Header />);
     const starLinks = screen.getAllByRole("link", { name: "STAR Prep" });
@@ -76,6 +94,8 @@ describe("Header", () => {
   });
 
   it("highlights active route for STAR Prep", () => {
+    usePlanMock.mockReturnValue({ plan: undefined });
+    mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });
     mockPathname.value = "/star";
     render(<Header />);
     const starLinks = screen.getAllByRole("link", { name: "STAR Prep" });
@@ -84,5 +104,56 @@ describe("Header", () => {
       el.className.includes("bg-accent") && el.className.includes("text-accent-foreground")
     );
     expect(activeLink).toBeTruthy();
+  });
+
+  // ---- Pro badge tests ----
+
+  it("renders \"Pro\" badge with aria-label \"Pro plan\" when plan is \"pro\"", () => {
+    usePlanMock.mockReturnValue({ plan: "pro" });
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "u1", name: "Alice", email: "alice@example.com", image: null } },
+      status: "authenticated",
+    });
+    mockPathname.value = "/dashboard";
+    render(<Header />);
+
+    // Badge text
+    expect(screen.getAllByText("Pro").length).toBeGreaterThanOrEqual(1);
+    // aria-label
+    expect(screen.getByLabelText("Pro plan")).toBeTruthy();
+  });
+
+  it("does not render the Pro badge when plan is \"free\"", () => {
+    usePlanMock.mockReturnValue({ plan: "free" });
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "u1", name: "Alice", email: "alice@example.com", image: null } },
+      status: "authenticated",
+    });
+    mockPathname.value = "/dashboard";
+    render(<Header />);
+
+    // No badge with aria-label
+    expect(screen.queryByLabelText("Pro plan")).toBeNull();
+    // No element with text "Pro" (nav links have none)
+    expect(screen.queryByText("Pro")).toBeNull();
+  });
+
+  it("does not render the Pro badge (or any placeholder) when plan is undefined (loading)", () => {
+    usePlanMock.mockReturnValue({ plan: undefined });
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "u1", name: "Alice", email: "alice@example.com", image: null } },
+      status: "authenticated",
+    });
+    mockPathname.value = "/dashboard";
+    const { container } = render(<Header />);
+
+    // No badge text
+    expect(screen.queryByText("Pro")).toBeNull();
+    // No aria-label on a badge
+    expect(screen.queryByLabelText("Pro plan")).toBeNull();
+    // No animate-pulse sibling next to the avatar (only the loading state div has animate-pulse)
+    const pulsing = container.querySelectorAll(".animate-pulse");
+    // The only animate-pulse allowed is from status==="loading" branch, which isn't active here
+    expect(pulsing.length).toBe(0);
   });
 });

--- a/apps/web/components/shared/Header.tsx
+++ b/apps/web/components/shared/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useSession, signOut } from "next-auth/react";
+import { useSession } from "next-auth/react";
 import { cn } from "@/lib/utils";
 import {
   DropdownMenu,
@@ -12,11 +12,13 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
 import { Menu, Sun, Moon } from "lucide-react";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { useTheme } from "next-themes";
 import { Sidebar } from "./Sidebar";
+import { usePlan, signOutAndClearPlan } from "@/hooks/usePlan";
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard" },
@@ -34,6 +36,7 @@ export function Header() {
   const router = useRouter();
   const { data: session, status } = useSession();
   const { theme, setTheme } = useTheme();
+  const { plan } = usePlan();
   const user = session?.user;
 
   const toggleTheme = () => {
@@ -103,6 +106,15 @@ export function Header() {
         {status === "loading" ? (
           <div className="h-8 w-8 rounded-full bg-muted animate-pulse" />
         ) : user ? (
+          <>
+            {plan === "pro" && (
+              <Badge
+                aria-label="Pro plan"
+                className="h-auto bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[color:var(--primary)] border-transparent"
+              >
+                Pro
+              </Badge>
+            )}
           <DropdownMenu>
             <DropdownMenuTrigger className="rounded-full">
               <Avatar className="h-8 w-8">
@@ -123,11 +135,12 @@ export function Header() {
               <DropdownMenuItem onClick={() => router.push("/profile")}>
                 Profile
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/" })}>
+              <DropdownMenuItem onClick={() => signOutAndClearPlan({ callbackUrl: "/" })}>
                 Sign Out
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
+          </>
         ) : (
           <Link
             href="/login"

--- a/apps/web/components/shared/Header.tsx
+++ b/apps/web/components/shared/Header.tsx
@@ -107,6 +107,8 @@ export function Header() {
           <div className="h-8 w-8 rounded-full bg-muted animate-pulse" />
         ) : user ? (
           <>
+            {/* Intentionally no skeleton: a 20×14px badge chip is too small for a
+                skeleton placeholder — absence during load is better UX here. */}
             {plan === "pro" && (
               <Badge
                 aria-label="Pro plan"
@@ -115,31 +117,31 @@ export function Header() {
                 Pro
               </Badge>
             )}
-          <DropdownMenu>
-            <DropdownMenuTrigger className="rounded-full">
-              <Avatar className="h-8 w-8">
-                {user.image && (
-                  <AvatarImage src={user.image} alt={user.name ?? ""} />
-                )}
-                <AvatarFallback className="text-xs">
-                  {user.name?.charAt(0).toUpperCase() ?? "U"}
-                </AvatarFallback>
-              </Avatar>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <div className="px-2 py-1.5">
-                <p className="text-sm font-medium">{user.name}</p>
-                <p className="text-xs text-muted-foreground">{user.email}</p>
-              </div>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => router.push("/profile")}>
-                Profile
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => signOutAndClearPlan({ callbackUrl: "/" })}>
-                Sign Out
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+            <DropdownMenu>
+              <DropdownMenuTrigger className="rounded-full">
+                <Avatar className="h-8 w-8">
+                  {user.image && (
+                    <AvatarImage src={user.image} alt={user.name ?? ""} />
+                  )}
+                  <AvatarFallback className="text-xs">
+                    {user.name?.charAt(0).toUpperCase() ?? "U"}
+                  </AvatarFallback>
+                </Avatar>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <div className="px-2 py-1.5">
+                  <p className="text-sm font-medium">{user.name}</p>
+                  <p className="text-xs text-muted-foreground">{user.email}</p>
+                </div>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => router.push("/profile")}>
+                  Profile
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => signOutAndClearPlan({ callbackUrl: "/" })}>
+                  Sign Out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </>
         ) : (
           <Link

--- a/apps/web/hooks/usePlan.test.ts
+++ b/apps/web/hooks/usePlan.test.ts
@@ -1,15 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor, act } from "@testing-library/react";
 
 // NOTE: We do NOT wrap with <StrictMode> here. In StrictMode, React double-
 // invokes effects in development, but usePlan guards against double-fetch via
 // the `cancelled` flag and the `if (plan !== undefined) return` early exit
 // from the cached sessionStorage value on the second invocation.
 
-// Mock next-auth/react so signOut is controllable
+// Mock next-auth/react so signOut and useSession are controllable
 const mockSignOut = vi.fn();
+const mockUseSession = vi.fn();
 vi.mock("next-auth/react", () => ({
   signOut: (...args: Parameters<typeof mockSignOut>) => mockSignOut(...args),
+  useSession: () => mockUseSession(),
 }));
 
 // Import after mocks are registered
@@ -17,10 +19,20 @@ import { usePlan, clearPlanCache, signOutAndClearPlan } from "./usePlan";
 
 const PLAN_CACHE_KEY = "preploy:plan";
 
+// Default: authenticated session for tests that don't override it
+function setAuthenticatedSession() {
+  mockUseSession.mockReturnValue({
+    status: "authenticated",
+    data: { user: { id: "test" } },
+  });
+}
+
 describe("usePlan", () => {
   beforeEach(() => {
     sessionStorage.clear();
     vi.clearAllMocks();
+    // Most tests run with an authenticated session; individual tests may override
+    setAuthenticatedSession();
   });
 
   it("first call with empty sessionStorage fires exactly one fetch to /api/users/me and exposes plan", async () => {
@@ -139,5 +151,80 @@ describe("usePlan", () => {
     expect(cacheValueAtSignOutTime).toBeNull();
     expect(mockSignOut).toHaveBeenCalledTimes(1);
     expect(mockSignOut).toHaveBeenCalledWith({ callbackUrl: "/" });
+  });
+
+  it("does not cache or set plan when fetch returns a non-2xx response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => usePlan());
+
+    // Give the effect time to settle
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(result.current.plan).toBeUndefined();
+    expect(sessionStorage.getItem(PLAN_CACHE_KEY)).toBeNull();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("does not cache or set plan when fetch rejects with a network error", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => usePlan());
+
+    // Give the effect time to settle
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(result.current.plan).toBeUndefined();
+    expect(sessionStorage.getItem(PLAN_CACHE_KEY)).toBeNull();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("does not fetch when useSession returns status: \"unauthenticated\"", async () => {
+    mockUseSession.mockReturnValue({ status: "unauthenticated", data: null });
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => usePlan());
+
+    // Give effects time to settle
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+    expect(result.current.plan).toBeUndefined();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("clears stale cached value when status transitions to \"unauthenticated\"", async () => {
+    // Seed a stale pro cache (simulating a prior authenticated session)
+    sessionStorage.setItem(PLAN_CACHE_KEY, "pro");
+
+    // Start as unauthenticated
+    mockUseSession.mockReturnValue({ status: "unauthenticated", data: null });
+
+    const { result } = renderHook(() => usePlan());
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    // Stale cached value must be cleared
+    expect(result.current.plan).toBeUndefined();
+    expect(sessionStorage.getItem(PLAN_CACHE_KEY)).toBeNull();
   });
 });

--- a/apps/web/hooks/usePlan.test.ts
+++ b/apps/web/hooks/usePlan.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+// NOTE: We do NOT wrap with <StrictMode> here. In StrictMode, React double-
+// invokes effects in development, but usePlan guards against double-fetch via
+// the `cancelled` flag and the `if (plan !== undefined) return` early exit
+// from the cached sessionStorage value on the second invocation.
+
+// Mock next-auth/react so signOut is controllable
+const mockSignOut = vi.fn();
+vi.mock("next-auth/react", () => ({
+  signOut: (...args: Parameters<typeof mockSignOut>) => mockSignOut(...args),
+}));
+
+// Import after mocks are registered
+import { usePlan, clearPlanCache, signOutAndClearPlan } from "./usePlan";
+
+const PLAN_CACHE_KEY = "preploy:plan";
+
+describe("usePlan", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("first call with empty sessionStorage fires exactly one fetch to /api/users/me and exposes plan", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ plan: "pro" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => usePlan());
+
+    // Initially undefined while loading
+    expect(result.current.plan).toBeUndefined();
+
+    await waitFor(() => {
+      expect(result.current.plan).toBe("pro");
+    });
+
+    // Exactly one fetch, to the correct endpoint
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith("/api/users/me");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("second render with cached value fires no additional fetch", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ plan: "free" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // First render — populates the cache
+    const { result: first } = renderHook(() => usePlan());
+    await waitFor(() => {
+      expect(first.current.plan).toBe("free");
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Second render — reads from sessionStorage, no additional fetch
+    fetchMock.mockClear();
+    const { result: second } = renderHook(() => usePlan());
+
+    // Should resolve synchronously from cache
+    expect(second.current.plan).toBe("free");
+    // No additional fetch should have been fired
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("normalizes legacy \"max\" to \"pro\"", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ plan: "max" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => usePlan());
+
+    await waitFor(() => {
+      expect(result.current.plan).toBe("pro");
+    });
+
+    // Also verify it was cached as "pro", not "max"
+    expect(sessionStorage.getItem(PLAN_CACHE_KEY)).toBe("pro");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("clearPlanCache removes the sessionStorage entry so next render re-fetches", async () => {
+    // Seed the cache directly
+    sessionStorage.setItem(PLAN_CACHE_KEY, "pro");
+
+    // First render reads from cache
+    const { result: first } = renderHook(() => usePlan());
+    expect(first.current.plan).toBe("pro");
+
+    // Clear the cache
+    clearPlanCache();
+    expect(sessionStorage.getItem(PLAN_CACHE_KEY)).toBeNull();
+
+    // Next render should start undefined (would fetch, but we don't need to wait)
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ plan: "free" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result: second } = renderHook(() => usePlan());
+
+    // Starts undefined — fetch was triggered
+    expect(second.current.plan).toBeUndefined();
+    await waitFor(() => {
+      expect(second.current.plan).toBe("free");
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("signOutAndClearPlan clears cache before invoking next-auth signOut", () => {
+    // Seed the cache
+    sessionStorage.setItem(PLAN_CACHE_KEY, "pro");
+
+    let cacheValueAtSignOutTime: string | null = "not-captured";
+    mockSignOut.mockImplementation(() => {
+      // Capture what sessionStorage looks like at the moment signOut is called
+      cacheValueAtSignOutTime = sessionStorage.getItem(PLAN_CACHE_KEY);
+      return Promise.resolve(undefined);
+    });
+
+    signOutAndClearPlan({ callbackUrl: "/" });
+
+    // Cache must have been cleared BEFORE signOut was called
+    expect(cacheValueAtSignOutTime).toBeNull();
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+    expect(mockSignOut).toHaveBeenCalledWith({ callbackUrl: "/" });
+  });
+});

--- a/apps/web/hooks/usePlan.ts
+++ b/apps/web/hooks/usePlan.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { signOut } from "next-auth/react";
+import type { Plan } from "@/lib/plans";
+
+const PLAN_CACHE_KEY = "preploy:plan"; // values: "free" | "pro"
+
+/**
+ * Returns the current user's plan, fetched once per session.
+ *
+ * - First render with no cached value fires exactly one fetch to /api/users/me.
+ * - Subsequent renders read from sessionStorage — no additional fetch.
+ * - Returns `undefined` while loading (callers should render nothing, not a placeholder).
+ * - On non-200 or network error, leaves state undefined and does NOT cache,
+ *   so a later mount can retry.
+ */
+export function usePlan(): { plan: Plan | undefined } {
+  const [plan, setPlan] = useState<Plan | undefined>(() => {
+    // Read sessionStorage synchronously on mount (guards SSR via window check)
+    if (typeof window === "undefined") return undefined;
+    const cached = sessionStorage.getItem(PLAN_CACHE_KEY);
+    if (cached === "pro" || cached === "free") return cached;
+    return undefined;
+  });
+
+  useEffect(() => {
+    // If we already have a plan from the cache, skip the fetch
+    if (plan !== undefined) return;
+
+    let cancelled = false;
+
+    fetch("/api/users/me")
+      .then((res) => {
+        if (!res.ok) return undefined;
+        return res.json() as Promise<{ plan?: string }>;
+      })
+      .then((data) => {
+        if (cancelled || data === undefined) return;
+        // Normalize: "max" or "pro" → "pro", anything else → "free"
+        // Mirrors lib/user-plan.ts coercion
+        const normalized: Plan =
+          data.plan === "max" || data.plan === "pro" ? "pro" : "free";
+        if (typeof window !== "undefined") {
+          sessionStorage.setItem(PLAN_CACHE_KEY, normalized);
+        }
+        setPlan(normalized);
+      })
+      .catch(() => {
+        // Network error — leave state undefined, do NOT cache
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // intentionally empty — we only fetch once per mount
+
+  return { plan };
+}
+
+/**
+ * Removes the cached plan from sessionStorage so the next usePlan() call
+ * will re-fetch from the server.
+ */
+export function clearPlanCache(): void {
+  if (typeof window === "undefined") return;
+  sessionStorage.removeItem(PLAN_CACHE_KEY);
+}
+
+/**
+ * Clears the plan cache and then delegates to next-auth's signOut.
+ * Cache is cleared BEFORE signOut so the hook can't read a stale value
+ * on any screen that renders between signOut() being called and the
+ * callbackUrl redirect completing.
+ */
+export function signOutAndClearPlan(
+  options?: Parameters<typeof signOut>[0]
+): ReturnType<typeof signOut> {
+  clearPlanCache();
+  return signOut(options);
+}

--- a/apps/web/hooks/usePlan.ts
+++ b/apps/web/hooks/usePlan.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { signOut } from "next-auth/react";
+import { signOut, useSession } from "next-auth/react";
 import type { Plan } from "@/lib/plans";
 
 const PLAN_CACHE_KEY = "preploy:plan"; // values: "free" | "pro"
@@ -12,10 +12,17 @@ const PLAN_CACHE_KEY = "preploy:plan"; // values: "free" | "pro"
  * - First render with no cached value fires exactly one fetch to /api/users/me.
  * - Subsequent renders read from sessionStorage — no additional fetch.
  * - Returns `undefined` while loading (callers should render nothing, not a placeholder).
+ *   Intentional: a skeleton for a 20×14px badge chip would be worse UX than
+ *   its absence. This is an explicit exception to the app-wide "fetches need
+ *   skeletons" rule.
  * - On non-200 or network error, leaves state undefined and does NOT cache,
  *   so a later mount can retry.
+ * - Gated on session status: does not fetch when unauthenticated or while the
+ *   session is still loading, preventing spurious 401s on public pages.
  */
 export function usePlan(): { plan: Plan | undefined } {
+  const { status } = useSession();
+
   const [plan, setPlan] = useState<Plan | undefined>(() => {
     // Read sessionStorage synchronously on mount (guards SSR via window check)
     if (typeof window === "undefined") return undefined;
@@ -24,7 +31,22 @@ export function usePlan(): { plan: Plan | undefined } {
     return undefined;
   });
 
+  // Clear stale cached plan when signed out. We rely on signOutAndClearPlan()
+  // in the normal sign-out flow, but guard here for any path that transitions
+  // to "unauthenticated" without going through that helper.
   useEffect(() => {
+    if (status === "unauthenticated") {
+      if (typeof window !== "undefined") {
+        sessionStorage.removeItem(PLAN_CACHE_KEY);
+      }
+      setPlan(undefined);
+    }
+  }, [status]);
+
+  useEffect(() => {
+    // Don't fetch until we know the user is authenticated
+    if (status !== "authenticated") return;
+
     // If we already have a plan from the cache, skip the fetch
     if (plan !== undefined) return;
 
@@ -54,7 +76,7 @@ export function usePlan(): { plan: Plan | undefined } {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // intentionally empty — we only fetch once per mount
+  }, [status]); // re-run when auth status changes (e.g., session loads)
 
   return { plan };
 }


### PR DESCRIPTION
## Summary
- Introduces `usePlan()` hook — fetches `/api/users/me` once per session, caches the plan in `sessionStorage`, and gates the fetch on `useSession` status so unauthenticated pages (e.g. `/login`) don't fire spurious 401s.
- Adds `clearPlanCache()` and `signOutAndClearPlan()` helpers; the sign-out dropdown in `Header.tsx` now calls the latter so no stale cache survives across sessions. An extra effect also auto-clears the cache if the session transitions to `unauthenticated` by any other path.
- Renders a small cedar "Pro" chip immediately left of the avatar in `Header.tsx` when `plan === "pro"`. Free users see nothing; loading state renders nothing (intentional exception to the app-wide skeleton rule — documented inline).
- Legacy `"max"` plan is normalized to `"pro"` client-side to mirror `lib/user-plan.ts`.
- Phase 0 of the larger Pro-gating rollout — downstream stories (#177, #178, #179, #180) will consume `usePlan()`.

## Test plan

Manual smoke checklist (run in Vercel preview):

- [ ] Sign in as a Pro account — "Pro" chip is visible left of the avatar on every authenticated page
- [ ] Chip is legible in both light and dark mode (cedar on `primary/10` background)
- [ ] Reload while signed in — chip reappears instantly from sessionStorage (no flash, no re-fetch)
- [ ] Navigate between pages — DevTools Network tab shows a single `/api/users/me` call for the session
- [ ] DevTools → Application → Session Storage → `preploy:plan` key is present during the session
- [ ] Sign out — `preploy:plan` key is removed; chip is gone
- [ ] Sign in as a Free account — no chip anywhere in the header
- [ ] Visit `/login` while signed out — no 401 in the Network tab for `/api/users/me` (fetch is gated)

Automated: 913 unit/component tests + 351 integration tests pass. 9 unit tests in `usePlan.test.ts` cover happy path, cache hit, `max` normalization, cache clear, sign-out ordering, non-2xx response, network error, unauthenticated skip, and stale-cache-clear on logout.

Closes #175

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>