### PR TITLE
feat(pro): deeper feedback with stronger model for Pro users (#177)

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -212,6 +212,7 @@ task definition / secrets manager.
 | `ORPHANED_SESSION_TIMEOUT_HOURS` | RUNTIME_ONLY | How long (hours) before an `in_progress` session is auto-marked `failed` by the cleanup cron (default: `2`). |
 | `RESEND_API_KEY`             | RUNTIME_ONLY       | Resend API key for transactional email (welcome, feedback-ready, upgrade nudge). Create at [resend.com](https://resend.com). Emails silently skipped when unset. |
 | `RESEND_FROM_ADDRESS`        | RUNTIME_ONLY       | Override the FROM address for transactional emails. Defaults to `Preploy <onboarding@resend.dev>`. Switch to your verified domain (e.g. `Preploy <noreply@preploy.tech>`) after DNS verification in Resend. |
+| `PRO_ANALYSIS_MODEL`       | RUNTIME_ONLY       | Override model used for Pro users' session feedback analysis (default: `gpt-5`). Set per environment; point at an available model (e.g. `gpt-4o`) until `gpt-5` is GA. |
 
 Server-only secrets (`SUPABASE_DB_URL`, `OPENAI_API_KEY`, `GOOGLE_CLIENT_SECRET`,
 `SENTRY_DSN`) must never be referenced from a file marked `"use client"` and

--- a/apps/web/app/api/analysis/behavioral/route.integration.test.ts
+++ b/apps/web/app/api/analysis/behavioral/route.integration.test.ts
@@ -9,13 +9,22 @@
  *
  * Story 22 acceptance criteria: "Integration tests mock OpenAI and assert
  * full Zod-validated response shapes."
+ *
+ * Story 177: tier tests verify Pro users get the stronger model + Pro prompt.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { getTestDb } from "../../../../tests/setup-db";
+import { users } from "@/lib/schema";
+import { eq, or } from "drizzle-orm";
 
-const mockChatCreate = vi.fn();
+const { mockChatCreate, mockAuthFn } = vi.hoisted(() => ({
+  mockChatCreate: vi.fn(),
+  mockAuthFn: vi.fn(),
+}));
+
 vi.mock("openai", () => ({
   default: class MockOpenAI {
     chat = { completions: { create: mockChatCreate } };
@@ -26,16 +35,29 @@ vi.mock("openai", () => ({
 // Tests stub both to return "signed-in, not rate-limited" by default; any
 // test that wants to exercise the 401 / 429 paths can override in-file.
 vi.mock("@/lib/auth", () => ({
-  auth: vi.fn().mockResolvedValue({ user: { id: "test-user" } }),
+  auth: () => mockAuthFn(),
 }));
 vi.mock("@/lib/api-utils", () => ({
   checkRateLimit: vi.fn().mockResolvedValue(null),
+}));
+
+// getCurrentUserPlan queries @/lib/db — redirect to test DB so the function
+// can run for real (unknown users fall back to "free"; pro tests seed a pro user).
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return getTestDb();
+  },
 }));
 
 vi.stubEnv("OPENAI_API_KEY", "sk-integration-test");
 
 import { POST } from "./route";
 import { feedbackResponseSchema } from "@/lib/analysis-schemas";
+import {
+  BEHAVIORAL_SYSTEM_PROMPT,
+  BEHAVIORAL_SYSTEM_PROMPT_PRO,
+} from "@/lib/analysis-prompts";
+
 
 const VALID_GPT_RESPONSE = readFileSync(
   join(__dirname, "..", "__fixtures__", "behavioral-gpt-response.json"),
@@ -68,6 +90,10 @@ const VALID_BODY = {
   },
 };
 
+// Auth mock returns this user ID by default
+const FREE_USER_ID = "bbbbbbbb-0000-0000-0000-000000000001";
+const PRO_USER_ID = "bbbbbbbb-0000-0000-0000-000000000002";
+
 function makeRequest(body: unknown): NextRequest {
   return new NextRequest("http://localhost:3000/api/analysis/behavioral", {
     method: "POST",
@@ -77,8 +103,37 @@ function makeRequest(body: unknown): NextRequest {
 }
 
 describe("POST /api/analysis/behavioral (integration)", () => {
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db
+      .insert(users)
+      .values({ id: FREE_USER_ID, email: "free-behavioral@example.com", name: "Free User" })
+      .onConflictDoNothing();
+    await db
+      .insert(users)
+      .values({ id: PRO_USER_ID, email: "pro-behavioral@example.com", name: "Pro User", plan: "pro" })
+      .onConflictDoNothing();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: authenticated as free user
+    mockAuthFn.mockResolvedValue({ user: { id: FREE_USER_ID } });
+    // Ensure OPENAI_API_KEY is always set — vi.unstubAllEnvs() in afterEach
+    // would clear the module-level vi.stubEnv call otherwise.
+    vi.stubEnv("OPENAI_API_KEY", "sk-integration-test");
+  });
+
+  afterEach(() => {
+    // Only unstub test-specific env overrides; re-stub of OPENAI_API_KEY happens in beforeEach.
+    vi.unstubAllEnvs();
+  });
+
+  afterAll(async () => {
+    // Only clean up the users we seeded — don't tear down the shared test DB
+    // connection or delete other test suites' data.
+    const db = getTestDb();
+    await db.delete(users).where(or(eq(users.id, FREE_USER_ID), eq(users.id, PRO_USER_ID)));
   });
 
   it("returns 400 on empty transcript", async () => {
@@ -147,5 +202,39 @@ describe("POST /api/analysis/behavioral (integration)", () => {
     const body = await res.json();
     expect(feedbackResponseSchema.safeParse(body).success).toBe(true);
     expect(body.overall_score).toBe(7.5);
+  });
+
+  it("pro user: uses PRO_ANALYSIS_MODEL + Pro system prompt", async () => {
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
+    // Authenticate as pro user (seeded in beforeAll with plan="pro")
+    mockAuthFn.mockResolvedValue({ user: { id: PRO_USER_ID } });
+
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: VALID_GPT_RESPONSE } }],
+    });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(mockChatCreate).toHaveBeenCalledOnce();
+    const call = mockChatCreate.mock.calls[0][0];
+    expect(call.model).toBe("gpt-5-test-pro");
+    expect(call.messages[0].content).toBe(BEHAVIORAL_SYSTEM_PROMPT_PRO);
+  });
+
+  it("free user: uses gpt-5.4-mini + Free system prompt", async () => {
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
+    // Authenticate as free user (seeded in beforeAll with plan="free" default)
+    mockAuthFn.mockResolvedValue({ user: { id: FREE_USER_ID } });
+
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: VALID_GPT_RESPONSE } }],
+    });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(mockChatCreate).toHaveBeenCalledOnce();
+    const call = mockChatCreate.mock.calls[0][0];
+    expect(call.model).toBe("gpt-5.4-mini");
+    expect(call.messages[0].content).toBe(BEHAVIORAL_SYSTEM_PROMPT);
   });
 });

--- a/apps/web/app/api/analysis/behavioral/route.test.ts
+++ b/apps/web/app/api/analysis/behavioral/route.test.ts
@@ -17,6 +17,9 @@ vi.mock("@/lib/auth", () => ({
 vi.mock("@/lib/api-utils", () => ({
   checkRateLimit: vi.fn().mockResolvedValue(null),
 }));
+vi.mock("@/lib/user-plan", () => ({
+  getCurrentUserPlan: vi.fn().mockResolvedValue("free"),
+}));
 
 import { POST } from "./route";
 

--- a/apps/web/app/api/analysis/behavioral/route.ts
+++ b/apps/web/app/api/analysis/behavioral/route.ts
@@ -6,6 +6,8 @@ import { runBehavioralAnalysis } from "@/lib/analysis-behavioral";
 import { feedbackRequestSchema } from "@/lib/analysis-schemas";
 import { createRequestLogger } from "@/lib/logger";
 import { OpenAIRetryError } from "@/lib/openai-retry";
+import { getCurrentUserPlan } from "@/lib/user-plan";
+import type { AnalysisTier } from "@/lib/analysis-model";
 
 /**
  * POST /api/analysis/behavioral
@@ -54,8 +56,15 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Plan is read once per feedback request, not cached from session creation —
+  // in-flight analyses finish at the tier the user has at the moment they hit
+  // POST. Downgrade mid-session → Free output on this POST if the DB flip
+  // landed first. Next session always uses the then-current tier.
+  const plan = await getCurrentUserPlan(session.user.id);
+  const tier: AnalysisTier = plan === "pro" ? "pro" : "free";
+
   try {
-    const result = await runBehavioralAnalysis(parsed.data, { log });
+    const result = await runBehavioralAnalysis(parsed.data, { log, tier });
     return NextResponse.json(result);
   } catch (err) {
     if (err instanceof OpenAIRetryError) {

--- a/apps/web/app/api/analysis/technical/route.integration.test.ts
+++ b/apps/web/app/api/analysis/technical/route.integration.test.ts
@@ -9,13 +9,22 @@
  * The "timeline_injected_from_correlator_not_gpt" test asserts that even if
  * GPT returns an empty timeline_analysis, the route MUST overwrite it with
  * the deterministic `buildTimeline()` result before validation.
+ *
+ * Story 177: tier tests verify Pro users get the stronger model + Pro prompt.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { getTestDb } from "../../../../tests/setup-db";
+import { users } from "@/lib/schema";
+import { eq, or } from "drizzle-orm";
 
-const mockChatCreate = vi.fn();
+const { mockChatCreate, mockAuthFn } = vi.hoisted(() => ({
+  mockChatCreate: vi.fn(),
+  mockAuthFn: vi.fn(),
+}));
+
 vi.mock("openai", () => ({
   default: class MockOpenAI {
     chat = { completions: { create: mockChatCreate } };
@@ -24,16 +33,29 @@ vi.mock("openai", () => ({
 
 // The route now auths + rate-limits like any other OpenAI-burning endpoint.
 vi.mock("@/lib/auth", () => ({
-  auth: vi.fn().mockResolvedValue({ user: { id: "test-user" } }),
+  auth: () => mockAuthFn(),
 }));
 vi.mock("@/lib/api-utils", () => ({
   checkRateLimit: vi.fn().mockResolvedValue(null),
+}));
+
+// getCurrentUserPlan queries @/lib/db — redirect to test DB so the function
+// can run for real (unknown users fall back to "free"; pro tests seed a pro user).
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return getTestDb();
+  },
 }));
 
 vi.stubEnv("OPENAI_API_KEY", "sk-integration-test");
 
 import { POST } from "./route";
 import { technicalFeedbackResponseSchema } from "@/lib/analysis-schemas";
+import {
+  TECHNICAL_SYSTEM_PROMPT,
+  TECHNICAL_SYSTEM_PROMPT_PRO,
+} from "@/lib/analysis-prompts";
+
 
 const VALID_GPT_RESPONSE_RAW = readFileSync(
   join(__dirname, "..", "__fixtures__", "technical-gpt-response.json"),
@@ -68,6 +90,10 @@ const VALID_BODY = {
   },
 };
 
+// Distinct UUIDs to avoid conflicts with other integration test suites
+const FREE_USER_ID = "cccccccc-0000-0000-0000-000000000001";
+const PRO_USER_ID = "cccccccc-0000-0000-0000-000000000002";
+
 function makeRequest(body: unknown): NextRequest {
   return new NextRequest("http://localhost:3000/api/analysis/technical", {
     method: "POST",
@@ -77,8 +103,37 @@ function makeRequest(body: unknown): NextRequest {
 }
 
 describe("POST /api/analysis/technical (integration)", () => {
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db
+      .insert(users)
+      .values({ id: FREE_USER_ID, email: "free-technical@example.com", name: "Free User Tech" })
+      .onConflictDoNothing();
+    await db
+      .insert(users)
+      .values({ id: PRO_USER_ID, email: "pro-technical@example.com", name: "Pro User Tech", plan: "pro" })
+      .onConflictDoNothing();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: authenticated as free user
+    mockAuthFn.mockResolvedValue({ user: { id: FREE_USER_ID } });
+    // Ensure OPENAI_API_KEY is always set — vi.unstubAllEnvs() in afterEach
+    // would clear the module-level vi.stubEnv call otherwise.
+    vi.stubEnv("OPENAI_API_KEY", "sk-integration-test");
+  });
+
+  afterEach(() => {
+    // Only unstub test-specific env overrides; re-stub of OPENAI_API_KEY happens in beforeEach.
+    vi.unstubAllEnvs();
+  });
+
+  afterAll(async () => {
+    // Only clean up the users we seeded — don't tear down the shared test DB
+    // connection or delete other test suites' data.
+    const db = getTestDb();
+    await db.delete(users).where(or(eq(users.id, FREE_USER_ID), eq(users.id, PRO_USER_ID)));
   });
 
   it("returns 400 on empty transcript", async () => {
@@ -182,5 +237,39 @@ describe("POST /api/analysis/technical (integration)", () => {
     expect(timestamps).toEqual(sorted);
     // Earliest event should be the first snapshot at 500ms.
     expect(timestamps[0]).toBe(500);
+  });
+
+  it("pro user: uses PRO_ANALYSIS_MODEL + Pro system prompt", async () => {
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
+    // Authenticate as pro user (seeded in beforeAll with plan="pro")
+    mockAuthFn.mockResolvedValue({ user: { id: PRO_USER_ID } });
+
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: VALID_GPT_RESPONSE_RAW } }],
+    });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(mockChatCreate).toHaveBeenCalledOnce();
+    const call = mockChatCreate.mock.calls[0][0];
+    expect(call.model).toBe("gpt-5-test-pro");
+    expect(call.messages[0].content).toBe(TECHNICAL_SYSTEM_PROMPT_PRO);
+  });
+
+  it("free user: uses gpt-5.4-mini + Free system prompt", async () => {
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
+    // Authenticate as free user (seeded in beforeAll with plan="free" default)
+    mockAuthFn.mockResolvedValue({ user: { id: FREE_USER_ID } });
+
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: VALID_GPT_RESPONSE_RAW } }],
+    });
+
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(200);
+    expect(mockChatCreate).toHaveBeenCalledOnce();
+    const call = mockChatCreate.mock.calls[0][0];
+    expect(call.model).toBe("gpt-5.4-mini");
+    expect(call.messages[0].content).toBe(TECHNICAL_SYSTEM_PROMPT);
   });
 });

--- a/apps/web/app/api/analysis/technical/route.test.ts
+++ b/apps/web/app/api/analysis/technical/route.test.ts
@@ -17,6 +17,9 @@ vi.mock("@/lib/auth", () => ({
 vi.mock("@/lib/api-utils", () => ({
   checkRateLimit: vi.fn().mockResolvedValue(null),
 }));
+vi.mock("@/lib/user-plan", () => ({
+  getCurrentUserPlan: vi.fn().mockResolvedValue("free"),
+}));
 
 import { POST } from "./route";
 

--- a/apps/web/app/api/analysis/technical/route.ts
+++ b/apps/web/app/api/analysis/technical/route.ts
@@ -6,6 +6,8 @@ import { runTechnicalAnalysis } from "@/lib/analysis-technical";
 import { technicalFeedbackRequestSchema } from "@/lib/analysis-schemas";
 import { createRequestLogger } from "@/lib/logger";
 import { OpenAIRetryError } from "@/lib/openai-retry";
+import { getCurrentUserPlan } from "@/lib/user-plan";
+import type { AnalysisTier } from "@/lib/analysis-model";
 
 /**
  * POST /api/analysis/technical
@@ -57,8 +59,15 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Plan is read once per feedback request, not cached from session creation —
+  // in-flight analyses finish at the tier the user has at the moment they hit
+  // POST. Downgrade mid-session → Free output on this POST if the DB flip
+  // landed first. Next session always uses the then-current tier.
+  const plan = await getCurrentUserPlan(session.user.id);
+  const tier: AnalysisTier = plan === "pro" ? "pro" : "free";
+
   try {
-    const result = await runTechnicalAnalysis(parsed.data, { log });
+    const result = await runTechnicalAnalysis(parsed.data, { log, tier });
     return NextResponse.json(result);
   } catch (err) {
     if (err instanceof OpenAIRetryError) {

--- a/apps/web/app/api/sessions/[id]/feedback/route.integration.test.ts
+++ b/apps/web/app/api/sessions/[id]/feedback/route.integration.test.ts
@@ -6,6 +6,7 @@ import {
   beforeAll,
   beforeEach,
   afterAll,
+  afterEach,
 } from "vitest";
 import { NextRequest } from "next/server";
 import { readFileSync } from "node:fs";
@@ -37,6 +38,13 @@ vi.mock("@/lib/db", () => ({
     return getTestDb();
   },
 }));
+
+import {
+  BEHAVIORAL_SYSTEM_PROMPT,
+  BEHAVIORAL_SYSTEM_PROMPT_PRO,
+  TECHNICAL_SYSTEM_PROMPT,
+  TECHNICAL_SYSTEM_PROMPT_PRO,
+} from "@/lib/analysis-prompts";
 
 // Mock OpenAI at module scope — same pattern as the analysis route integration
 // tests. The extracted `runBehavioralAnalysis` / `runTechnicalAnalysis` lib
@@ -73,6 +81,13 @@ const OTHER_USER = {
   name: "Other User",
 };
 
+const PRO_USER = {
+  id: "00000000-0000-0000-0000-000000000003",
+  email: "pro@example.com",
+  name: "Pro User",
+  plan: "pro" as const,
+};
+
 let behavioralSessionId: string;
 let technicalSessionId: string;
 
@@ -104,6 +119,7 @@ describe("API /api/sessions/[id]/feedback (integration)", () => {
     const db = getTestDb();
     await db.insert(users).values(TEST_USER).onConflictDoNothing();
     await db.insert(users).values(OTHER_USER).onConflictDoNothing();
+    await db.insert(users).values(PRO_USER).onConflictDoNothing();
   });
 
   beforeEach(async () => {
@@ -164,6 +180,10 @@ describe("API /api/sessions/[id]/feedback (integration)", () => {
         eventType: "submit",
       },
     ]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   afterAll(async () => {
@@ -589,5 +609,252 @@ describe("API /api/sessions/[id]/feedback (integration)", () => {
     expect(body.gazeDistribution).not.toBeNull();
     expect(body.gazeDistribution.center_pct).toBe(82.5);
     expect(body.gazeTimeline).toHaveLength(1);
+  });
+
+  // ---- Tier / model selection tests ----
+
+  it("POST uses gpt-5.4-mini + Free system prompt for Free users (behavioral)", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
+
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: BEHAVIORAL_GPT_RESPONSE_RAW } }],
+    });
+
+    const res = await POST(
+      makePostRequest(behavioralSessionId),
+      makeParams(behavioralSessionId)
+    );
+    expect(res.status).toBe(201);
+    expect(mockChatCreate).toHaveBeenCalledOnce();
+    const call = mockChatCreate.mock.calls[0][0];
+    expect(call.model).toBe("gpt-5.4-mini");
+    expect(call.messages[0].content).toBe(BEHAVIORAL_SYSTEM_PROMPT);
+  });
+
+  it("POST uses PRO_ANALYSIS_MODEL + Pro system prompt for Pro users (behavioral)", async () => {
+    const db = getTestDb();
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
+
+    // Create a behavioral session owned by the Pro user
+    const [proSession] = await db
+      .insert(interviewSessions)
+      .values({
+        userId: PRO_USER.id,
+        type: "behavioral",
+        config: { interview_style: 0.5, difficulty: 0.5 },
+      })
+      .returning();
+
+    await db.insert(transcripts).values({
+      sessionId: proSession.id,
+      entries: SAMPLE_TRANSCRIPT,
+    });
+
+    mockAuth.mockResolvedValue({ user: { id: PRO_USER.id } });
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: BEHAVIORAL_GPT_RESPONSE_RAW } }],
+    });
+
+    const res = await POST(
+      makePostRequest(proSession.id),
+      makeParams(proSession.id)
+    );
+    expect(res.status).toBe(201);
+    expect(mockChatCreate).toHaveBeenCalledOnce();
+    const call = mockChatCreate.mock.calls[0][0];
+    expect(call.model).toBe("gpt-5-test-pro");
+    expect(call.messages[0].content).toBe(BEHAVIORAL_SYSTEM_PROMPT_PRO);
+  });
+
+  it("POST uses gpt-5.4-mini for Free users (technical)", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
+
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: TECHNICAL_GPT_RESPONSE_RAW } }],
+    });
+
+    const res = await POST(
+      makePostRequest(technicalSessionId),
+      makeParams(technicalSessionId)
+    );
+    expect(res.status).toBe(201);
+    expect(mockChatCreate).toHaveBeenCalledOnce();
+    const call = mockChatCreate.mock.calls[0][0];
+    expect(call.model).toBe("gpt-5.4-mini");
+    expect(call.messages[0].content).toBe(TECHNICAL_SYSTEM_PROMPT);
+  });
+
+  it("POST uses PRO_ANALYSIS_MODEL for Pro users (technical)", async () => {
+    const db = getTestDb();
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
+
+    // Create a technical session owned by the Pro user
+    const [proTechSession] = await db
+      .insert(interviewSessions)
+      .values({
+        userId: PRO_USER.id,
+        type: "technical",
+        config: { interview_type: "leetcode", focus_areas: ["arrays"], language: "python", difficulty: "medium" },
+      })
+      .returning();
+
+    await db.insert(transcripts).values({
+      sessionId: proTechSession.id,
+      entries: SAMPLE_TRANSCRIPT,
+    });
+
+    await db.insert(codeSnapshots).values([
+      {
+        sessionId: proTechSession.id,
+        code: "def solution(): pass",
+        language: "python",
+        timestampMs: 1000,
+        eventType: "edit",
+      },
+    ]);
+
+    mockAuth.mockResolvedValue({ user: { id: PRO_USER.id } });
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: TECHNICAL_GPT_RESPONSE_RAW } }],
+    });
+
+    const res = await POST(
+      makePostRequest(proTechSession.id),
+      makeParams(proTechSession.id)
+    );
+    expect(res.status).toBe(201);
+    expect(mockChatCreate).toHaveBeenCalledOnce();
+    const call = mockChatCreate.mock.calls[0][0];
+    expect(call.model).toBe("gpt-5-test-pro");
+    expect(call.messages[0].content).toBe(TECHNICAL_SYSTEM_PROMPT_PRO);
+  });
+
+  it("POST re-reads the plan on each request (downgrade semantics)", async () => {
+    const db = getTestDb();
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
+
+    // Create a behavioral session owned by Pro user
+    const [proSession] = await db
+      .insert(interviewSessions)
+      .values({
+        userId: PRO_USER.id,
+        type: "behavioral",
+        config: { interview_style: 0.5, difficulty: 0.5 },
+      })
+      .returning();
+
+    await db.insert(transcripts).values({
+      sessionId: proSession.id,
+      entries: SAMPLE_TRANSCRIPT,
+    });
+
+    mockAuth.mockResolvedValue({ user: { id: PRO_USER.id } });
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: BEHAVIORAL_GPT_RESPONSE_RAW } }],
+    });
+
+    // First POST — Pro user → should use Pro model
+    const res1 = await POST(
+      makePostRequest(proSession.id),
+      makeParams(proSession.id)
+    );
+    expect(res1.status).toBe(201);
+    const call1 = mockChatCreate.mock.calls[0][0];
+    expect(call1.model).toBe("gpt-5-test-pro");
+
+    // Downgrade: flip plan to "free" in DB
+    await db
+      .update(users)
+      .set({ plan: "free" })
+      .where(eq(users.id, PRO_USER.id));
+
+    // Clean up the feedback row so we can POST again
+    await db
+      .delete(sessionFeedback)
+      .where(eq(sessionFeedback.sessionId, proSession.id));
+
+    vi.clearAllMocks();
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: BEHAVIORAL_GPT_RESPONSE_RAW } }],
+    });
+
+    // Second POST — plan now "free" → should use Free model
+    const res2 = await POST(
+      makePostRequest(proSession.id),
+      makeParams(proSession.id)
+    );
+    expect(res2.status).toBe(201);
+    const call2 = mockChatCreate.mock.calls[0][0];
+    expect(call2.model).toBe("gpt-5.4-mini");
+
+    // Restore Pro plan to not pollute other tests' PRO_USER assertions
+    await db
+      .update(users)
+      .set({ plan: "pro" })
+      .where(eq(users.id, PRO_USER.id));
+  });
+
+  it("POST persists the same response shape regardless of tier", async () => {
+    const db = getTestDb();
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
+
+    // Create a Pro session
+    const [proSession] = await db
+      .insert(interviewSessions)
+      .values({
+        userId: PRO_USER.id,
+        type: "behavioral",
+        config: { interview_style: 0.5, difficulty: 0.5 },
+      })
+      .returning();
+
+    await db.insert(transcripts).values({
+      sessionId: proSession.id,
+      entries: SAMPLE_TRANSCRIPT,
+    });
+
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: BEHAVIORAL_GPT_RESPONSE_RAW } }],
+    });
+
+    // POST as Free user (TEST_USER owns behavioralSessionId)
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const resFree = await POST(
+      makePostRequest(behavioralSessionId),
+      makeParams(behavioralSessionId)
+    );
+    expect(resFree.status).toBe(201);
+    const freeBody = await resFree.json();
+
+    vi.clearAllMocks();
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: BEHAVIORAL_GPT_RESPONSE_RAW } }],
+    });
+
+    // POST as Pro user
+    mockAuth.mockResolvedValue({ user: { id: PRO_USER.id } });
+    const resPro = await POST(
+      makePostRequest(proSession.id),
+      makeParams(proSession.id)
+    );
+    expect(resPro.status).toBe(201);
+    const proBody = await resPro.json();
+
+    // Both rows must have the same DB column set populated — no new columns
+    const freeKeys = Object.keys(freeBody).sort();
+    const proKeys = Object.keys(proBody).sort();
+    expect(proKeys).toEqual(freeKeys);
+
+    // Core response fields present in both
+    expect(freeBody.overallScore).toBeDefined();
+    expect(proBody.overallScore).toBeDefined();
+    expect(freeBody.summary).toBeDefined();
+    expect(proBody.summary).toBeDefined();
+    expect(freeBody.strengths).toBeDefined();
+    expect(proBody.strengths).toBeDefined();
+    expect(freeBody.answerAnalyses).toBeDefined();
+    expect(proBody.answerAnalyses).toBeDefined();
   });
 });

--- a/apps/web/app/api/sessions/[id]/feedback/route.ts
+++ b/apps/web/app/api/sessions/[id]/feedback/route.ts
@@ -27,6 +27,8 @@ import type {
   TechnicalFeedbackResponse,
 } from "@/lib/analysis-schemas";
 import { OpenAIRetryError } from "@/lib/openai-retry";
+import { getCurrentUserPlan } from "@/lib/user-plan";
+import type { AnalysisTier } from "@/lib/analysis-model";
 
 // POST /api/sessions/[id]/feedback — trigger feedback generation
 export async function POST(
@@ -62,6 +64,14 @@ export async function POST(
   }
 
   setSentryContext({ sessionType: found.type, sessionId: id });
+
+  // Plan is read once per feedback request, not cached from session creation —
+  // in-flight analyses finish at the tier the user has at the moment they hit
+  // POST. Downgrade mid-session → Free output on this POST if the DB flip
+  // landed first. Next session always uses the then-current tier.
+  const plan = await getCurrentUserPlan(session.user.id);
+  const tier: AnalysisTier = plan === "pro" ? "pro" : "free";
+  log.info({ tier, sessionId: id }, "feedback tier resolved");
 
   // Check if feedback already exists
   const [existing] = await db
@@ -160,7 +170,7 @@ export async function POST(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           config: (found.config ?? {}) as any,
         },
-        { log, userId: session.user.id },
+        { log, userId: session.user.id, tier },
       );
     } else {
       feedbackData = await runBehavioralAnalysis(
@@ -170,7 +180,7 @@ export async function POST(
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           config: (found.config ?? {}) as any,
         },
-        { log, userId: session.user.id, preparedStory },
+        { log, userId: session.user.id, preparedStory, tier },
       );
     }
   } catch (err) {

--- a/apps/web/lib/analysis-behavioral.test.ts
+++ b/apps/web/lib/analysis-behavioral.test.ts
@@ -3,7 +3,7 @@
  * exercises happy-path + retry-exhaustion branches. Mirrors the mock pattern
  * used in `app/api/analysis/behavioral/route.integration.test.ts`.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import pino from "pino";
@@ -23,6 +23,10 @@ import {
   feedbackResponseSchema,
 } from "@/lib/analysis-schemas";
 import { OpenAIRetryError } from "@/lib/openai-retry";
+import {
+  BEHAVIORAL_SYSTEM_PROMPT,
+  BEHAVIORAL_SYSTEM_PROMPT_PRO,
+} from "@/lib/analysis-prompts";
 
 const VALID_GPT_RESPONSE = readFileSync(
   join(
@@ -76,6 +80,10 @@ describe("runBehavioralAnalysis", () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("happy path: returns a valid FeedbackResponse from a fixture GPT reply", async () => {
     mockChatCreate.mockResolvedValueOnce({
       choices: [{ message: { content: VALID_GPT_RESPONSE } }],
@@ -83,6 +91,7 @@ describe("runBehavioralAnalysis", () => {
 
     const result = await runBehavioralAnalysis(VALID_INPUT, {
       log: silentLogger,
+      tier: "free",
     });
 
     // Re-parse with the schema to prove every Zod constraint passes.
@@ -99,8 +108,48 @@ describe("runBehavioralAnalysis", () => {
     });
 
     await expect(
-      runBehavioralAnalysis(VALID_INPUT, { log: silentLogger }),
+      runBehavioralAnalysis(VALID_INPUT, { log: silentLogger, tier: "free" }),
     ).rejects.toThrow(OpenAIRetryError);
     expect(mockChatCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("free tier uses gpt-5.4-mini and Free system prompt", async () => {
+    mockChatCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: VALID_GPT_RESPONSE } }],
+    });
+
+    await runBehavioralAnalysis(VALID_INPUT, { log: silentLogger, tier: "free" });
+
+    expect(mockChatCreate).toHaveBeenCalledTimes(1);
+    const call = mockChatCreate.mock.calls[0][0];
+    expect(call.model).toBe("gpt-5.4-mini");
+    expect(call.messages[0].content).toBe(BEHAVIORAL_SYSTEM_PROMPT);
+  });
+
+  it("pro tier uses PRO_ANALYSIS_MODEL env override and Pro system prompt", async () => {
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
+    mockChatCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: VALID_GPT_RESPONSE } }],
+    });
+
+    await runBehavioralAnalysis(VALID_INPUT, { log: silentLogger, tier: "pro" });
+
+    expect(mockChatCreate).toHaveBeenCalledTimes(1);
+    const call = mockChatCreate.mock.calls[0][0];
+    expect(call.model).toBe("gpt-5-test-pro");
+    expect(call.messages[0].content).toBe(BEHAVIORAL_SYSTEM_PROMPT_PRO);
+  });
+
+  it("pro tier without env override defaults to gpt-5", async () => {
+    vi.stubEnv("PRO_ANALYSIS_MODEL", undefined as unknown as string);
+    mockChatCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: VALID_GPT_RESPONSE } }],
+    });
+
+    await runBehavioralAnalysis(VALID_INPUT, { log: silentLogger, tier: "pro" });
+
+    expect(mockChatCreate).toHaveBeenCalledTimes(1);
+    const call = mockChatCreate.mock.calls[0][0];
+    expect(call.model).toBe("gpt-5");
   });
 });

--- a/apps/web/lib/analysis-behavioral.ts
+++ b/apps/web/lib/analysis-behavioral.ts
@@ -13,7 +13,7 @@ import OpenAI from "openai";
 
 import {
   buildBehavioralPrompt,
-  BEHAVIORAL_SYSTEM_PROMPT,
+  systemPromptFor,
   type PreparedStarStory,
 } from "@/lib/analysis-prompts";
 import {
@@ -22,12 +22,15 @@ import {
   feedbackResponseSchema,
 } from "@/lib/analysis-schemas";
 import { OpenAIRetryError, withOpenAIRetry } from "@/lib/openai-retry";
+import { modelFor, type AnalysisTier } from "@/lib/analysis-model";
 
 export interface RunBehavioralAnalysisOptions {
   log: pino.Logger;
   userId?: string;
   /** Optional prepared STAR story for drift analysis */
   preparedStory?: PreparedStarStory;
+  /** User tier — determines model and system prompt depth */
+  tier: AnalysisTier;
 }
 
 /**
@@ -44,15 +47,17 @@ export async function runBehavioralAnalysis(
   opts: RunBehavioralAnalysisOptions,
 ): Promise<FeedbackResponse> {
   const { log } = opts;
+  const model = modelFor(opts.tier);
+  const systemPrompt = systemPromptFor("behavioral", opts.tier);
   const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
   const prompt = buildBehavioralPrompt(input.transcript, input.config, opts.preparedStory);
 
   return withOpenAIRetry(
     () =>
       openai.chat.completions.create({
-        model: "gpt-5.4-mini",
+        model,
         messages: [
-          { role: "system", content: BEHAVIORAL_SYSTEM_PROMPT },
+          { role: "system", content: systemPrompt },
           { role: "user", content: prompt },
         ],
         response_format: { type: "json_object" },
@@ -72,6 +77,6 @@ export async function runBehavioralAnalysis(
       }
       return validated.data;
     },
-    { service: "behavioral-analysis", log, userId: opts.userId, model: "gpt-5.4-mini" },
+    { service: "behavioral-analysis", log, userId: opts.userId, model },
   );
 }

--- a/apps/web/lib/analysis-model.test.ts
+++ b/apps/web/lib/analysis-model.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { modelFor, FREE_ANALYSIS_MODEL, DEFAULT_PRO_ANALYSIS_MODEL } from "./analysis-model";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("modelFor", () => {
+  it("modelFor('free') returns gpt-5.4-mini", () => {
+    expect(modelFor("free")).toBe(FREE_ANALYSIS_MODEL);
+    expect(modelFor("free")).toBe("gpt-5.4-mini");
+  });
+
+  it("modelFor('pro') returns PRO_ANALYSIS_MODEL when set", () => {
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
+    expect(modelFor("pro")).toBe("gpt-5-test-pro");
+  });
+
+  it("modelFor('pro') defaults to gpt-5 when env unset", () => {
+    vi.stubEnv("PRO_ANALYSIS_MODEL", undefined as unknown as string);
+    expect(modelFor("pro")).toBe(DEFAULT_PRO_ANALYSIS_MODEL);
+    expect(modelFor("pro")).toBe("gpt-5");
+  });
+
+  it("modelFor('pro') falls back to gpt-5 when env is empty string", () => {
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "");
+    expect(modelFor("pro")).toBe(DEFAULT_PRO_ANALYSIS_MODEL);
+    expect(modelFor("pro")).toBe("gpt-5");
+  });
+});

--- a/apps/web/lib/analysis-model.ts
+++ b/apps/web/lib/analysis-model.ts
@@ -1,0 +1,26 @@
+/**
+ * Model selection for analysis runs. Pro users get a stronger model;
+ * Free users get the default mini model.
+ *
+ * The model string is passed through to both the OpenAI chat.completions.create
+ * call and the withOpenAIRetry `model` option (for usage attribution).
+ */
+
+export const FREE_ANALYSIS_MODEL = "gpt-5.4-mini";
+export const DEFAULT_PRO_ANALYSIS_MODEL = "gpt-5";
+export type AnalysisTier = "free" | "pro";
+
+/**
+ * Return the OpenAI model string to use for an analysis run.
+ * Pro tier honours the `PRO_ANALYSIS_MODEL` env override (e.g. point at
+ * `gpt-4o` until `gpt-5` is GA). An empty-string env value is treated as
+ * unset and falls through to the default.
+ */
+export function modelFor(tier: AnalysisTier): string {
+  if (tier === "pro") {
+    const override = process.env.PRO_ANALYSIS_MODEL;
+    if (override && override.length > 0) return override;
+    return DEFAULT_PRO_ANALYSIS_MODEL;
+  }
+  return FREE_ANALYSIS_MODEL;
+}

--- a/apps/web/lib/analysis-prompts.test.ts
+++ b/apps/web/lib/analysis-prompts.test.ts
@@ -4,6 +4,11 @@ import { join } from "node:path";
 import {
   buildBehavioralPrompt,
   buildTechnicalPrompt,
+  BEHAVIORAL_SYSTEM_PROMPT,
+  BEHAVIORAL_SYSTEM_PROMPT_PRO,
+  TECHNICAL_SYSTEM_PROMPT,
+  TECHNICAL_SYSTEM_PROMPT_PRO,
+  systemPromptFor,
   type BehavioralPromptConfig,
   type TechnicalPromptConfig,
   type PreparedStarStory,
@@ -276,5 +281,69 @@ describe("buildTechnicalPrompt", () => {
     );
     const actual = buildTechnicalPrompt(TECH_TRANSCRIPT, TECH_SNAPSHOTS, TECH_CONFIG);
     expect(actual).toBe(expected);
+  });
+});
+
+// ---- System prompt tier selection (Pro vs Free) ----
+
+describe("Pro behavioral system prompt", () => {
+  it("Pro behavioral prompt contains filler_words_per_minute marker", () => {
+    expect(BEHAVIORAL_SYSTEM_PROMPT_PRO).toContain("filler_words_per_minute");
+  });
+
+  it("Pro behavioral prompt contains 'phrases to avoid' instruction", () => {
+    expect(BEHAVIORAL_SYSTEM_PROMPT_PRO.toLowerCase()).toContain("phrases to avoid");
+  });
+
+  it("Pro behavioral prompt contains 'phrases to add' instruction", () => {
+    expect(BEHAVIORAL_SYSTEM_PROMPT_PRO.toLowerCase()).toContain("phrases to add");
+  });
+
+  it("Pro behavioral prompt contains 'if you were me' rewrite instruction", () => {
+    expect(BEHAVIORAL_SYSTEM_PROMPT_PRO.toLowerCase()).toContain("if you were me");
+  });
+
+  it("Pro behavioral prompt contains 500-word summary requirement", () => {
+    expect(BEHAVIORAL_SYSTEM_PROMPT_PRO).toContain("500");
+  });
+
+  it("Free behavioral prompt does NOT contain Pro-only markers", () => {
+    expect(BEHAVIORAL_SYSTEM_PROMPT).not.toContain("filler_words_per_minute");
+    expect(BEHAVIORAL_SYSTEM_PROMPT.toLowerCase()).not.toContain("phrases to avoid");
+    expect(BEHAVIORAL_SYSTEM_PROMPT.toLowerCase()).not.toContain("phrases to add");
+    expect(BEHAVIORAL_SYSTEM_PROMPT.toLowerCase()).not.toContain("if you were me");
+  });
+});
+
+describe("Pro technical system prompt", () => {
+  it("Pro technical prompt contains 'if you were me' rewrite instruction", () => {
+    expect(TECHNICAL_SYSTEM_PROMPT_PRO.toLowerCase()).toContain("if you were me");
+  });
+
+  it("Pro technical prompt contains extended critique word count (500)", () => {
+    expect(TECHNICAL_SYSTEM_PROMPT_PRO).toContain("500");
+  });
+
+  it("Free technical prompt does NOT contain Pro-only markers", () => {
+    expect(TECHNICAL_SYSTEM_PROMPT).not.toContain("filler_words_per_minute");
+    expect(TECHNICAL_SYSTEM_PROMPT.toLowerCase()).not.toContain("if you were me");
+  });
+});
+
+describe("systemPromptFor", () => {
+  it("systemPromptFor('behavioral', 'free') returns BEHAVIORAL_SYSTEM_PROMPT", () => {
+    expect(systemPromptFor("behavioral", "free")).toBe(BEHAVIORAL_SYSTEM_PROMPT);
+  });
+
+  it("systemPromptFor('behavioral', 'pro') returns BEHAVIORAL_SYSTEM_PROMPT_PRO", () => {
+    expect(systemPromptFor("behavioral", "pro")).toBe(BEHAVIORAL_SYSTEM_PROMPT_PRO);
+  });
+
+  it("systemPromptFor('technical', 'free') returns TECHNICAL_SYSTEM_PROMPT", () => {
+    expect(systemPromptFor("technical", "free")).toBe(TECHNICAL_SYSTEM_PROMPT);
+  });
+
+  it("systemPromptFor('technical', 'pro') returns TECHNICAL_SYSTEM_PROMPT_PRO", () => {
+    expect(systemPromptFor("technical", "pro")).toBe(TECHNICAL_SYSTEM_PROMPT_PRO);
   });
 });

--- a/apps/web/lib/analysis-prompts.ts
+++ b/apps/web/lib/analysis-prompts.ts
@@ -15,6 +15,7 @@ import type {
   CodeSnapshotInput,
   TranscriptEntryInput,
 } from "./validations";
+import type { AnalysisTier } from "./analysis-model";
 
 // ---- System prompts (string-equal to Python module-level constants) ----
 
@@ -104,6 +105,126 @@ Respond ONLY with valid JSON matching this exact structure:
     }
   ]
 }`;
+
+// Pro extras are folded into existing string fields so feedbackResponseSchema stays unchanged.
+// Typed Pro fields + dedicated UI are a follow-up (see issue #177 PR description).
+
+export const BEHAVIORAL_SYSTEM_PROMPT_PRO = `You are an expert interview coach analyzing a behavioral interview transcript. You are providing DEEP, DETAILED feedback for a Pro-tier user.
+
+Your task is to evaluate the candidate's performance and provide structured, actionable feedback.
+
+For each question-answer pair you identify in the transcript:
+1. Extract the interviewer's question
+2. Summarize the candidate's answer in 1-2 sentences
+3. Score the answer from 0-10 based on:
+   - Use of STAR method (Situation, Task, Action, Result)
+   - Specificity and concrete examples
+   - Relevance to the question
+   - Communication clarity
+   - Depth and thoughtfulness
+4. Provide specific feedback on what was good and what could improve.
+   Inside the "feedback" string for each answer, include ALL of the following sections:
+   - A "filler_words_per_minute" number estimating how many filler words (um, uh, like, you know, sort of, basically) the candidate used per minute in this answer
+   - A "Phrases to avoid" list of 2-4 specific filler phrases or weak expressions the candidate used that undermine their credibility
+   - A "Phrases to add" list of 2-4 stronger alternative phrases or vocabulary the candidate should use instead
+   - An "If you were me, what would you say" paragraph: rewrite the candidate's answer in 3-5 sentences as a polished, high-impact version that a top candidate would deliver
+5. Give 1-3 actionable suggestions
+
+Then provide an overall assessment:
+- Overall score (weighted average of individual answers)
+- A detailed summary of 500-800 words covering: overall performance arc, communication patterns, STAR method mastery, specific strengths with examples, specific growth areas with concrete guidance, and what a top-quartile answer would look like for this role
+- Top 3 strengths
+- Top 3 areas for improvement
+
+Respond ONLY with valid JSON matching this exact structure:
+{
+  "overall_score": <float 0-10>,
+  "summary": "<500-800 word detailed overall assessment>",
+  "strengths": ["<strength 1>", "<strength 2>", "<strength 3>"],
+  "weaknesses": ["<weakness 1>", "<weakness 2>", "<weakness 3>"],
+  "answer_analyses": [
+    {
+      "question": "<the interviewer's question>",
+      "answer_summary": "<1-2 sentence summary of candidate's answer>",
+      "score": <float 0-10>,
+      "feedback": "<specific feedback including filler_words_per_minute count, phrases to avoid list, phrases to add list, and if you were me what would you say rewrite paragraph>",
+      "suggestions": ["<suggestion 1>", "<suggestion 2>"]
+    }
+  ]
+}`;
+
+export const TECHNICAL_SYSTEM_PROMPT_PRO = `You are an expert technical interview coach analyzing a coding interview session. You are providing DEEP, DETAILED feedback for a Pro-tier user.
+
+You will receive:
+- A full transcript of the candidate's verbal explanations
+- The candidate's code evolution (all snapshots from start to final submission)
+- Session configuration (problem type, focus areas, difficulty)
+
+Evaluate the candidate on two dimensions:
+
+1. **Code Quality (0-10)**: correctness, efficiency, readability,
+   edge case handling, time/space complexity awareness
+2. **Explanation Quality (0-10)**: clarity of thought process,
+   problem decomposition, trade-off discussion, communication
+
+Analyze distinct aspects of the candidate's performance.
+Use these categories for the answer_analyses array:
+- **Approach & Problem Decomposition**: How the candidate broke
+  down the problem and chose their strategy
+- **Implementation**: Code correctness, structure, and style —
+  reference specific lines or functions from the code snapshots
+- **Complexity Analysis**: Whether the candidate discussed
+  time/space complexity and if their analysis was correct
+- **Edge Cases & Testing**: Whether edge cases were considered in code or discussion
+- **Communication**: How well the candidate explained their thinking throughout
+
+For each analysis, reference specific code from the snapshots
+(e.g., "The loop on line 3 could use enumerate instead") and
+specific quotes from the transcript when relevant.
+
+In the "feedback" string for each analysis category, include ALL of the following:
+- A "filler_words_per_minute" number estimating filler words (um, uh, like, you know, sort of, basically) per minute in this portion of the session
+- A "Phrases to avoid" list of 2-4 weak or imprecise expressions the candidate used
+- A "Phrases to add" list of 2-4 stronger alternative phrases that signal technical mastery
+- An "If you were me, what would you say" paragraph: rewrite how the candidate should have explained this aspect in 3-5 polished sentences
+
+Provide an extended summary of 500-800 words covering: overall coding ability narrative, communication arc, specific code quality observations with line references, complexity analysis accuracy, edge-case thinking, and concrete next-step practice recommendations.
+
+Respond ONLY with valid JSON matching this exact structure:
+{
+  "overall_score": <float 0-10>,
+  "summary": "<500-800 word extended overall assessment referencing specific parts of the code>",
+  "strengths": ["<strength — cite code or transcript>", "<strength>", "<strength>"],
+  "weaknesses": ["<weakness — cite code or transcript>", "<weakness>", "<weakness>"],
+  "code_quality_score": <float 0-10>,
+  "explanation_quality_score": <float 0-10>,
+  "answer_analyses": [
+    {
+      "question": "<aspect being evaluated, e.g. 'Approach & Problem Decomposition'>",
+      "answer_summary": "<1-2 sentence summary of what the candidate did, referencing code>",
+      "score": <float 0-10>,
+      "feedback": "<specific feedback citing code lines and transcript quotes, including filler_words_per_minute, phrases to avoid, phrases to add, and if you were me what would you say rewrite>",
+      "suggestions": ["<actionable suggestion>", "<actionable suggestion>"]
+    }
+  ]
+}`;
+
+/**
+ * Return the correct system prompt for a given analysis kind and tier.
+ * Pro prompts extend the Free prompts with deeper critique sections
+ * (filler words, phrase coaching, "if you were me" rewrites, extended summary)
+ * while keeping the same top-level JSON keys so feedbackResponseSchema stays
+ * unchanged.
+ */
+export function systemPromptFor(
+  kind: "behavioral" | "technical",
+  tier: AnalysisTier,
+): string {
+  if (kind === "behavioral") {
+    return tier === "pro" ? BEHAVIORAL_SYSTEM_PROMPT_PRO : BEHAVIORAL_SYSTEM_PROMPT;
+  }
+  return tier === "pro" ? TECHNICAL_SYSTEM_PROMPT_PRO : TECHNICAL_SYSTEM_PROMPT;
+}
 
 // ---- Behavioral prompt config ----
 

--- a/apps/web/lib/analysis-technical.test.ts
+++ b/apps/web/lib/analysis-technical.test.ts
@@ -4,7 +4,7 @@
  * Mirrors the mock pattern used in
  * `app/api/analysis/technical/route.integration.test.ts`.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import pino from "pino";
@@ -25,6 +25,10 @@ import {
 } from "@/lib/analysis-schemas";
 import { buildTimeline } from "@/lib/timeline-correlator";
 import { OpenAIRetryError } from "@/lib/openai-retry";
+import {
+  TECHNICAL_SYSTEM_PROMPT,
+  TECHNICAL_SYSTEM_PROMPT_PRO,
+} from "@/lib/analysis-prompts";
 
 const VALID_GPT_RESPONSE_RAW = readFileSync(
   join(
@@ -83,6 +87,10 @@ describe("runTechnicalAnalysis", () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("happy path: returns a valid TechnicalFeedbackResponse from a fixture GPT reply", async () => {
     mockChatCreate.mockResolvedValueOnce({
       choices: [{ message: { content: VALID_GPT_RESPONSE_RAW } }],
@@ -90,6 +98,7 @@ describe("runTechnicalAnalysis", () => {
 
     const result = await runTechnicalAnalysis(VALID_INPUT, {
       log: silentLogger,
+      tier: "free",
     });
 
     const reparsed = technicalFeedbackResponseSchema.safeParse(result);
@@ -109,6 +118,7 @@ describe("runTechnicalAnalysis", () => {
 
     const result = await runTechnicalAnalysis(VALID_INPUT, {
       log: silentLogger,
+      tier: "free",
     });
 
     const expectedTimeline = buildTimeline(SAMPLE_TRANSCRIPT, SAMPLE_SNAPSHOTS);
@@ -130,8 +140,48 @@ describe("runTechnicalAnalysis", () => {
     });
 
     await expect(
-      runTechnicalAnalysis(VALID_INPUT, { log: silentLogger }),
+      runTechnicalAnalysis(VALID_INPUT, { log: silentLogger, tier: "free" }),
     ).rejects.toThrow(OpenAIRetryError);
     expect(mockChatCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("free tier uses gpt-5.4-mini and Free system prompt", async () => {
+    mockChatCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: VALID_GPT_RESPONSE_RAW } }],
+    });
+
+    await runTechnicalAnalysis(VALID_INPUT, { log: silentLogger, tier: "free" });
+
+    expect(mockChatCreate).toHaveBeenCalledTimes(1);
+    const call = mockChatCreate.mock.calls[0][0];
+    expect(call.model).toBe("gpt-5.4-mini");
+    expect(call.messages[0].content).toBe(TECHNICAL_SYSTEM_PROMPT);
+  });
+
+  it("pro tier uses PRO_ANALYSIS_MODEL env override and Pro system prompt", async () => {
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
+    mockChatCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: VALID_GPT_RESPONSE_RAW } }],
+    });
+
+    await runTechnicalAnalysis(VALID_INPUT, { log: silentLogger, tier: "pro" });
+
+    expect(mockChatCreate).toHaveBeenCalledTimes(1);
+    const call = mockChatCreate.mock.calls[0][0];
+    expect(call.model).toBe("gpt-5-test-pro");
+    expect(call.messages[0].content).toBe(TECHNICAL_SYSTEM_PROMPT_PRO);
+  });
+
+  it("pro tier without env override defaults to gpt-5", async () => {
+    vi.stubEnv("PRO_ANALYSIS_MODEL", undefined as unknown as string);
+    mockChatCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: VALID_GPT_RESPONSE_RAW } }],
+    });
+
+    await runTechnicalAnalysis(VALID_INPUT, { log: silentLogger, tier: "pro" });
+
+    expect(mockChatCreate).toHaveBeenCalledTimes(1);
+    const call = mockChatCreate.mock.calls[0][0];
+    expect(call.model).toBe("gpt-5");
   });
 });

--- a/apps/web/lib/analysis-technical.ts
+++ b/apps/web/lib/analysis-technical.ts
@@ -14,7 +14,7 @@ import OpenAI from "openai";
 
 import {
   buildTechnicalPrompt,
-  TECHNICAL_SYSTEM_PROMPT,
+  systemPromptFor,
 } from "@/lib/analysis-prompts";
 import {
   TechnicalFeedbackRequest,
@@ -23,10 +23,13 @@ import {
 } from "@/lib/analysis-schemas";
 import { OpenAIRetryError, withOpenAIRetry } from "@/lib/openai-retry";
 import { buildTimeline } from "@/lib/timeline-correlator";
+import { modelFor, type AnalysisTier } from "@/lib/analysis-model";
 
 export interface RunTechnicalAnalysisOptions {
   log: pino.Logger;
   userId?: string;
+  /** User tier — determines model and system prompt depth */
+  tier: AnalysisTier;
 }
 
 export async function runTechnicalAnalysis(
@@ -34,6 +37,8 @@ export async function runTechnicalAnalysis(
   opts: RunTechnicalAnalysisOptions,
 ): Promise<TechnicalFeedbackResponse> {
   const { log } = opts;
+  const model = modelFor(opts.tier);
+  const systemPrompt = systemPromptFor("technical", opts.tier);
   const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
   const prompt = buildTechnicalPrompt(
     input.transcript,
@@ -49,9 +54,9 @@ export async function runTechnicalAnalysis(
   return withOpenAIRetry(
     () =>
       openai.chat.completions.create({
-        model: "gpt-5.4-mini",
+        model,
         messages: [
-          { role: "system", content: TECHNICAL_SYSTEM_PROMPT },
+          { role: "system", content: systemPrompt },
           { role: "user", content: prompt },
         ],
         response_format: { type: "json_object" },
@@ -73,6 +78,6 @@ export async function runTechnicalAnalysis(
       }
       return validated.data;
     },
-    { service: "technical-analysis", log, userId: opts.userId, model: "gpt-5.4-mini" },
+    { service: "technical-analysis", log, userId: opts.userId, model },
   );
 }

--- a/apps/web/lib/openai-usage.test.ts
+++ b/apps/web/lib/openai-usage.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   computeCostMillis,
+  recordOpenAIUsage,
   OPENAI_MODEL_PRICING,
   OpenAICapError,
   getPerUserDailyCapMillis,
@@ -72,5 +73,44 @@ describe("cap constants", () => {
 
   it("default global cap is $50 = 50000 millidollars", () => {
     expect(getGlobalDailyCapMillis()).toBe(50000);
+  });
+});
+
+// Mock @/lib/db so recordOpenAIUsage tests don't need a real database
+const mockInsert = vi.fn().mockReturnValue({
+  values: vi.fn().mockReturnValue({
+    onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+  }),
+});
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return { insert: mockInsert };
+  },
+}));
+
+describe("recordOpenAIUsage — unknown model guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("recordOpenAIUsage skips silently with a warn when model is unknown", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await recordOpenAIUsage("user-1", "gpt-99-unknown-model", 1000, 500);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "recordOpenAIUsage: unknown model, skipping",
+      { model: "gpt-99-unknown-model" }
+    );
+    // No DB insert call should have happened
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("computeCostMillis still throws on unknown model (regression guard)", () => {
+    expect(() => computeCostMillis("gpt-99-unknown-model", 1000, 500)).toThrow(
+      /Unknown model.*gpt-99-unknown-model/
+    );
   });
 });

--- a/apps/web/lib/openai-usage.ts
+++ b/apps/web/lib/openai-usage.ts
@@ -30,6 +30,8 @@ export const OPENAI_MODEL_PRICING: Record<string, ModelPrice> = {
   "gpt-5.4-mini": { inputPer1MTokens: 0.75, outputPer1MTokens: 4.5 },
   "gpt-4o-mini": { inputPer1MTokens: 0.15, outputPer1MTokens: 0.6 },
   "gpt-4o": { inputPer1MTokens: 2.5, outputPer1MTokens: 10.0 },
+  // TODO: replace with official gpt-5 prices when OpenAI publishes.
+  "gpt-5": { inputPer1MTokens: 5.0, outputPer1MTokens: 30.0 },
   // Whisper is priced per minute, not per token — tracked separately.
   // Add new models here as they're adopted in the codebase.
 };
@@ -133,6 +135,10 @@ export async function recordOpenAIUsage(
   inputTokens: number,
   outputTokens: number
 ): Promise<void> {
+  if (!OPENAI_MODEL_PRICING[model]) {
+    console.warn("recordOpenAIUsage: unknown model, skipping", { model });
+    return;
+  }
   const cost = computeCostMillis(model, inputTokens, outputTokens);
   const today = todayUtcString();
   await db


### PR DESCRIPTION
## Summary
- Adds `PRO_ANALYSIS_MODEL` env var (default `gpt-5`) used for Pro-tier session feedback analysis across all three analysis entry points (`/api/sessions/[id]/feedback`, `/api/analysis/behavioral`, `/api/analysis/technical`).
- Extends both behavioral and technical system prompts for Pro users: per-answer filler-word rate, "phrases to avoid / phrases to add" coaching, "if you were me" rewrites, and 500-800 word overall summary.
- Pro extras fold into existing JSON string fields so `feedbackResponseSchema` is unchanged — zero frontend changes required.
- Adds `analysis-model.ts` utility (`modelFor`, `systemPromptFor`) and upgrades `recordOpenAIUsage` to log-and-skip on unknown models instead of silent-drop.

## Behavior

| Dimension | Free users | Pro users |
|---|---|---|
| Model | `gpt-5.4-mini` | `PRO_ANALYSIS_MODEL` env (default `gpt-5`) |
| System prompt depth | Current prompt | Extended prompt with filler-word count, phrase coaching, "if you were me" rewrite, 500-800 word summary |
| Response shape | Unchanged | Unchanged — same top-level JSON keys |
| Tier source | `getCurrentUserPlan(userId)` per request | Same |

**Downgrade semantics:** the plan is re-read from the DB on every POST. A user downgraded mid-session gets Free output on any subsequent POST that lands after the DB flip. No session-scoped or module-level plan cache.

**Response-shape invariant:** `feedbackResponseSchema` is unchanged. Integration test `POST persists the same response shape regardless of tier` asserts identical top-level JSON keys for Free and Pro responses.

## Operational notes
- `gpt-5` pricing in `OPENAI_MODEL_PRICING` is a placeholder (`$5.00 / $30.00 per 1M tokens`) pending OpenAI GA pricing. Update `apps/web/lib/openai-usage.ts` when official numbers are published.
- Until `gpt-5` is GA, set `PRO_ANALYSIS_MODEL=gpt-4o` in Vercel environment settings. The env var is read at runtime — update without redeploy.
- Cost attribution for `gpt-5` flows through the existing `recordOpenAIUsage` path; no schema change needed.
- `recordOpenAIUsage` previously threw on unknown model strings; the throw was swallowed by `.catch(() => {})` in the retry wrapper, so any typo'd `PRO_ANALYSIS_MODEL` would have silently dropped cost attribution. Now logs a warning and skips the insert — operators can spot the gap in logs.

## Test plan

Run in Vercel preview after this PR builds:

- [ ] Open a behavioral session as a Free user — verify feedback prose is unchanged from before this PR.
- [ ] Set `PRO_ANALYSIS_MODEL=gpt-4o` in preview environment (gpt-5 not yet GA), seed a Pro user in Supabase dev DB, run a behavioral session — verify feedback includes filler-word commentary, phrase suggestions, and an "if you were me" rewrite within the answer feedback text.
- [ ] Run a technical session as Pro user — verify same Pro extras appear in analysis category feedback strings, and summary is notably longer.
- [ ] Flip the Pro user's plan to `free` in the DB mid-test (before triggering a second feedback generation) — verify the second POST uses the Free model, confirming per-request tier lookup.
- [ ] Confirm response JSON keys are identical between Free and Pro responses (no new top-level fields).
- [x] Unit tests pass (938 tests)
- [x] Integration tests pass (361 tests)
- [x] Lint + typecheck clean

Closes #177

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>