### PR TITLE
fix(ui): scroll ScoreCard summary instead of blowing out card height

### DIFF
--- a/apps/web/components/feedback/ScoreCard.test.tsx
+++ b/apps/web/components/feedback/ScoreCard.test.tsx
@@ -34,4 +34,15 @@ describe("ScoreCard", () => {
     expect(container.querySelector("[class*='text-blue']")).toBeTruthy();
     expect(screen.getByText("Excellent")).toBeInTheDocument();
   });
+
+  it("caps the summary height so Pro-tier 500-800 word summaries scroll inside the card", () => {
+    // Pro-tier prompts ask for a 500-800 word overall summary, which was
+    // blowing out the card height on the feedback dashboard. Guard against
+    // regression by asserting the summary stays bounded + scrollable.
+    const longSummary = "x".repeat(2000);
+    render(<ScoreCard score={5} summary={longSummary} />);
+    const summary = screen.getByText(longSummary);
+    expect(summary.className).toContain("max-h-40");
+    expect(summary.className).toContain("overflow-y-auto");
+  });
 });

--- a/apps/web/components/feedback/ScoreCard.tsx
+++ b/apps/web/components/feedback/ScoreCard.tsx
@@ -24,7 +24,12 @@ export function ScoreCard({ score, summary }: ScoreCardProps) {
           </div>
           <span className={`mt-1 text-sm font-medium ${text}`}>{label}</span>
         </div>
-        <p className="flex-1 text-sm text-muted-foreground leading-relaxed">{summary}</p>
+        {/* Pro-tier summaries can run 500–800 words — cap the visible height
+            so the card stays compact on the dashboard and the reader can
+            scroll within the widget instead of the whole page jumping. */}
+        <p className="flex-1 max-h-40 overflow-y-auto text-sm text-muted-foreground leading-relaxed">
+          {summary}
+        </p>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- Pro-tier feedback prompts (#177) ask for a 500-800 word overall summary, which was pushing the top-left ScoreCard widget on the feedback dashboard far too tall.
- Cap the summary `<p>` at `max-h-40` (160px, ~8 lines) with `overflow-y-auto` so the card stays compact and the reader scrolls within the widget.
- Updated `ScoreCard.test.tsx` with a regression guard that renders a 2000-character summary and asserts the scroll + max-height classes.

## Test plan
- [x] `npx turbo lint typecheck test --force` — 939 tests pass, lint + typecheck clean
- [ ] Smoke in Vercel preview — open a Pro user's feedback page; confirm the score card stays a normal height and the summary scrolls inside it; confirm the rest of the layout is not pushed down.
- [ ] Confirm a Free user's short summary still renders correctly (no empty scrollbar for short content — `overflow-y-auto` only shows a scrollbar when content overflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>