### PR TITLE
feat(ui): show Pro analysis banner on feedback page

### DIFF
--- a/apps/web/components/feedback/FeedbackDashboard.test.tsx
+++ b/apps/web/components/feedback/FeedbackDashboard.test.tsx
@@ -1,7 +1,22 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { FeedbackDashboard } from "./FeedbackDashboard";
 import type { GazeDistribution, GazeTimelineBucket } from "@/lib/gaze-metrics";
+
+const { usePlanMock } = vi.hoisted(() => ({
+  usePlanMock: vi.fn(() => ({ plan: "free" as "free" | "pro" | undefined })),
+}));
+
+vi.mock("@/hooks/usePlan", () => ({
+  usePlan: usePlanMock,
+  clearPlanCache: vi.fn(),
+  signOutAndClearPlan: vi.fn(),
+}));
+
+import { FeedbackDashboard } from "./FeedbackDashboard";
+
+beforeEach(() => {
+  usePlanMock.mockReturnValue({ plan: "free" });
+});
 
 const BEHAVIORAL_FEEDBACK = {
   overallScore: 7.5,
@@ -161,5 +176,31 @@ describe("FeedbackDashboard", () => {
       />
     );
     expect(screen.queryByText("Eye Contact")).toBeNull();
+  });
+
+  it("renders Pro analysis banner when plan is 'pro'", () => {
+    usePlanMock.mockReturnValue({ plan: "pro" });
+    render(
+      <FeedbackDashboard feedback={BEHAVIORAL_FEEDBACK} sessionId="test-id" />
+    );
+    const banner = screen.getByTestId("pro-analysis-banner");
+    expect(banner).toBeInTheDocument();
+    expect(banner.textContent).toContain("Pro analysis");
+  });
+
+  it("does not render Pro analysis banner when plan is 'free'", () => {
+    usePlanMock.mockReturnValue({ plan: "free" });
+    render(
+      <FeedbackDashboard feedback={BEHAVIORAL_FEEDBACK} sessionId="test-id" />
+    );
+    expect(screen.queryByTestId("pro-analysis-banner")).toBeNull();
+  });
+
+  it("does not render Pro analysis banner when plan is undefined (loading)", () => {
+    usePlanMock.mockReturnValue({ plan: undefined });
+    render(
+      <FeedbackDashboard feedback={BEHAVIORAL_FEEDBACK} sessionId="test-id" />
+    );
+    expect(screen.queryByTestId("pro-analysis-banner")).toBeNull();
   });
 });

--- a/apps/web/components/feedback/FeedbackDashboard.tsx
+++ b/apps/web/components/feedback/FeedbackDashboard.tsx
@@ -3,7 +3,8 @@
 import { useState, useCallback } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Download } from "lucide-react";
+import { Download, Sparkles } from "lucide-react";
+import { usePlan } from "@/hooks/usePlan";
 import { ScoreCard } from "./ScoreCard";
 import { StrengthsWeaknesses } from "./StrengthsWeaknesses";
 import { AnswerBreakdown } from "./AnswerBreakdown";
@@ -48,6 +49,7 @@ export function FeedbackDashboard({
   sessionType = "behavioral",
 }: FeedbackDashboardProps) {
   const [isExporting, setIsExporting] = useState(false);
+  const { plan } = usePlan();
   const isTechnical = sessionType === "technical";
   const setupLink = isTechnical
     ? "/interview/technical/setup"
@@ -112,6 +114,32 @@ export function FeedbackDashboard({
           </Link>
         </div>
       </div>
+
+      {/* Pro analysis banner — visible reinforcement that a Pro user's
+          feedback ran through the deeper model (shipped in #177). Gated
+          on the current user's plan via usePlan(); a user who upgraded
+          AFTER generating this feedback will still see the banner even
+          though this specific feedback was free-tier — accepted edge case
+          until tier is persisted on the feedback row. */}
+      {plan === "pro" && (
+        <div
+          className="flex items-start gap-3 rounded-lg border border-primary/20 bg-primary/5 px-4 py-3"
+          data-testid="pro-analysis-banner"
+        >
+          <Sparkles
+            className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+            aria-hidden="true"
+          />
+          <div className="space-y-0.5">
+            <p className="text-sm font-semibold text-primary">Pro analysis</p>
+            <p className="text-sm text-muted-foreground">
+              You&apos;re getting our deeper feedback mode — extended
+              per-answer critique, filler-word stats, phrase coaching, and
+              an &ldquo;if you were me&rdquo; rewrite on every answer.
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Scores row — ScoreCard + CodeQualityCard side-by-side on desktop */}
       {isTechnical &&


### PR DESCRIPTION
## Summary
- Adds a cedar-tinted "Pro analysis" banner above the score card on the feedback dashboard, visible only to Pro users. Gated on `usePlan()` from #175.
- Names what Pro analysis actually delivers (shipped in #177) so the subscription feels worth it: extended per-answer critique, filler-word stats, phrase coaching, and the "if you were me" rewrite.
- Free users see nothing — no change to their experience.

## Visual

Banner sits between the page title and the score card, with a `Sparkles` icon, cedar primary text for the header, and muted body text for the description. Uses semantic tokens (`bg-primary/5`, `border-primary/20`, `text-primary`) so it stays cohesive in both light and dark mode.

## Known edge case

This gates visibility on the *current* user's plan (via `usePlan()`), not on the plan that was active when the feedback was generated. Two consequences:

- **False positive:** a user who upgrades AFTER generating a Free-tier feedback will see the banner on that old Free feedback even though its content doesn't match what the banner promises. Minor — new Pro sessions generate quickly and the banner becomes accurate.
- **False negative:** a user who downgrades will stop seeing the banner on feedback that was genuinely Pro-generated. Minor — they no longer have the plan anyway.

A proper fix persists `analysis_tier` on the `session_feedback` row at generation time and drives the banner off that. That's a schema change + route write + route read + frontend, which didn't fit "quick UI fix." Will file as a follow-up issue.

## Test plan
- [x] Unit tests pass (941 total; 3 new tests cover Pro/Free/loading states of the banner)
- [x] Lint + typecheck clean
- [ ] Smoke in Vercel preview — sign in as a Pro user, open any feedback page, confirm the cedar banner reads well in both light and dark mode.
- [ ] Sign in as a Free user, confirm no banner appears.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>