### PR TITLE
fix: TTS nudge race + tz-aware achievements + shorter Pro summary + 6s nudge

### DIFF
--- a/apps/web/app/api/users/badges/route.integration.test.ts
+++ b/apps/web/app/api/users/badges/route.integration.test.ts
@@ -34,10 +34,20 @@ const TEST_USER = {
   name: "Test User",
 };
 
+// Distinct user for timezone tests — separate ID avoids conflicts with
+// the beforeEach that deletes all sessions/achievements by TEST_USER.
+const NZ_USER = {
+  id: "00000000-0000-0000-0000-000000000201",
+  email: "nz-user-badges@example.com",
+  name: "NZ User",
+  timezone: "Pacific/Auckland", // UTC+12/+13
+};
+
 describe("POST /api/users/badges (integration)", () => {
   beforeAll(async () => {
     const db = getTestDb();
     await db.insert(users).values(TEST_USER).onConflictDoNothing();
+    await db.insert(users).values(NZ_USER).onConflictDoNothing();
   });
 
   beforeEach(async () => {
@@ -121,5 +131,81 @@ describe("POST /api/users/badges (integration)", () => {
     const res = await POST();
     const data = await res.json();
     expect(data.awarded).toEqual([]);
+  });
+
+  // ---- Timezone-aware achievement tests ----
+
+  it("early_bird is NOT awarded when the session is afternoon in the user's timezone", async () => {
+    // 2026-04-21T02:00:00Z → 14:00 NZST (UTC+12) — afternoon, not the 5-6am window
+    const db = getTestDb();
+    await db.insert(interviewSessions).values({
+      userId: NZ_USER.id,
+      type: "behavioral",
+      status: "completed",
+      startedAt: new Date("2026-04-21T02:00:00Z"),
+      createdAt: new Date("2026-04-21T02:00:00Z"),
+    });
+
+    mockAuth.mockResolvedValue({ user: { id: NZ_USER.id } });
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.awarded).not.toContain("early_bird");
+  });
+
+  it("early_bird IS awarded when the session is 6am in the user's timezone", async () => {
+    // 2026-04-20T18:00:00Z → 06:00 NZST (UTC+12) — falls in the 5-7am window
+    const db = getTestDb();
+    await db.insert(interviewSessions).values({
+      userId: NZ_USER.id,
+      type: "behavioral",
+      status: "completed",
+      startedAt: new Date("2026-04-20T18:00:00Z"),
+      createdAt: new Date("2026-04-20T18:00:00Z"),
+    });
+
+    mockAuth.mockResolvedValue({ user: { id: NZ_USER.id } });
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.awarded).toContain("early_bird");
+  });
+
+  it("marathon_runner uses the user's local calendar day, not UTC", async () => {
+    // NZ is UTC+12. Sessions that straddle the UTC midnight boundary but all
+    // land on April 21 in the NZ local calendar:
+    //   2026-04-20T12:00:00Z → April 21 00:00 NZST (midnight)
+    //   2026-04-20T23:00:00Z → April 21 11:00 NZST (mid-morning)
+    // All 5 sessions belong to April 21 NZ — marathon_runner should fire.
+    const db = getTestDb();
+    const utcTimestamps = [
+      "2026-04-20T12:00:00Z",
+      "2026-04-20T14:00:00Z",
+      "2026-04-20T16:00:00Z",
+      "2026-04-20T20:00:00Z",
+      "2026-04-20T23:00:00Z",
+    ];
+
+    for (const ts of utcTimestamps) {
+      await db.insert(interviewSessions).values({
+        userId: NZ_USER.id,
+        type: "behavioral",
+        status: "completed",
+        startedAt: new Date(ts),
+        createdAt: new Date(ts),
+      });
+    }
+
+    // Freeze "now" to a moment still on April 21 NZ so sessionsToday matches
+    vi.setSystemTime(new Date("2026-04-20T23:30:00Z")); // April 21 11:30 NZST
+
+    mockAuth.mockResolvedValue({ user: { id: NZ_USER.id } });
+    const res = await POST();
+
+    vi.useRealTimers();
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.awarded).toContain("marathon_runner");
   });
 });

--- a/apps/web/app/api/users/badges/route.ts
+++ b/apps/web/app/api/users/badges/route.ts
@@ -15,6 +15,10 @@ import { and, desc, eq, sql, count as countFn } from "drizzle-orm";
 import { calculateStreaks } from "@/lib/streaks";
 import { checkNewBadges } from "@/lib/badge-checker";
 import { createRequestLogger } from "@/lib/logger";
+import {
+  getHourInTimezone,
+  getDateStringInTimezone,
+} from "@/lib/timezone";
 
 // POST /api/users/badges — check and award new badges for the authenticated user
 export async function POST() {
@@ -106,28 +110,35 @@ export async function POST() {
     .from(interviewPlans)
     .where(eq(interviewPlans.userId, userId));
 
-  // Latest session hour (UTC)
-  const latestSession = sessions[0];
-  const latestSessionHour = latestSession?.startedAt
-    ? new Date(latestSession.startedAt).getUTCHours()
-    : latestSession?.createdAt
-      ? new Date(latestSession.createdAt).getUTCHours()
-      : null;
-
-  // Sessions today (UTC)
-  const today = new Date();
-  const todayStr = `${today.getUTCFullYear()}-${String(today.getUTCMonth() + 1).padStart(2, "0")}-${String(today.getUTCDate()).padStart(2, "0")}`;
-  const sessionsToday = sessions.filter((s) => {
-    const d = new Date(s.createdAt);
-    const ds = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
-    return ds === todayStr;
-  }).length;
-
-  // User plan
+  // User plan + timezone. Timezone is optional — null means the client
+  // hasn't synced yet; we fall back to UTC for achievement checks in that
+  // case (same as the pre-timezone behavior).
   const [userRow] = await db
-    .select({ plan: users.plan })
+    .select({ plan: users.plan, timezone: users.timezone })
     .from(users)
     .where(eq(users.id, userId));
+
+  const tz = userRow?.timezone ?? null;
+
+  // Latest session hour — evaluated in the user's local timezone so
+  // early_bird / night_owl fire at the right time of day. Previously this
+  // used UTC hours, which awarded "Early Bird" to a user in NZ running in
+  // the afternoon (2pm local = 2am UTC).
+  const latestSession = sessions[0];
+  const latestSessionHour = latestSession?.startedAt
+    ? getHourInTimezone(new Date(latestSession.startedAt), tz)
+    : latestSession?.createdAt
+      ? getHourInTimezone(new Date(latestSession.createdAt), tz)
+      : null;
+
+  // Sessions today — "today" is the user's local calendar day, not the
+  // server's UTC day. Same reason as above: marathon_runner should count
+  // sessions within the user's day, not sessions that happen to fall in
+  // the same UTC date.
+  const todayStr = getDateStringInTimezone(new Date(), tz);
+  const sessionsToday = sessions.filter((s) => {
+    return getDateStringInTimezone(new Date(s.createdAt), tz) === todayStr;
+  }).length;
 
   // Already earned
   const earned = await db

--- a/apps/web/app/api/users/me/route.integration.test.ts
+++ b/apps/web/app/api/users/me/route.integration.test.ts
@@ -392,4 +392,31 @@ describe("API /api/users/me (integration)", () => {
     );
     expect(res.status).toBe(400);
   });
+
+  // ---- Timezone PATCH (bug fix: TZ-aware achievements) ----
+
+  it("PATCH accepts timezone and persists it on the users row", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await PATCH(makePatchRequest({ timezone: "Pacific/Auckland" }));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.timezone).toBe("Pacific/Auckland");
+
+    const db = getTestDb();
+    const [row] = await db
+      .select({ timezone: users.timezone })
+      .from(users)
+      .where(eq(users.id, TEST_USER.id));
+    expect(row.timezone).toBe("Pacific/Auckland");
+
+    // Reset for other tests
+    await db.update(users).set({ timezone: null }).where(eq(users.id, TEST_USER.id));
+  });
+
+  it("PATCH rejects a timezone longer than 100 chars with 400", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const longTz = "America/" + "A".repeat(95); // > 100 chars total
+    const res = await PATCH(makePatchRequest({ timezone: longTz }));
+    expect(res.status).toBe(400);
+  });
 });

--- a/apps/web/app/api/users/me/route.ts
+++ b/apps/web/app/api/users/me/route.ts
@@ -43,6 +43,7 @@ export async function GET() {
       gazeTrackingEnabled: users.gazeTrackingEnabled,
       tourCompletedAt: users.tourCompletedAt,
       tourSkippedAt: users.tourSkippedAt,
+      timezone: users.timezone,
       createdAt: users.createdAt,
     })
     .from(users)
@@ -120,6 +121,10 @@ export async function PATCH(request: NextRequest) {
     updates.tourSkippedAt = body.tour_skipped_at;
   }
 
+  if (body.timezone !== undefined) {
+    updates.timezone = body.timezone;
+  }
+
   if (Object.keys(updates).length === 0) {
     return NextResponse.json(
       { error: "No valid fields to update" },
@@ -141,6 +146,7 @@ export async function PATCH(request: NextRequest) {
       gazeTrackingEnabled: users.gazeTrackingEnabled,
       tourCompletedAt: users.tourCompletedAt,
       tourSkippedAt: users.tourSkippedAt,
+      timezone: users.timezone,
     });
 
   return NextResponse.json(updated);

--- a/apps/web/components/shared/Header.test.tsx
+++ b/apps/web/components/shared/Header.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { Header } from "./Header";
 
@@ -39,6 +39,18 @@ vi.mock("next-themes", () => ({
 }));
 
 describe("Header", () => {
+  // useReportTimezone fires a PATCH on mount when session is authenticated.
+  // Stub fetch so tests don't see unexpected network calls or warnings.
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
   it("renders the app title", () => {
     usePlanMock.mockReturnValue({ plan: undefined });
     mockUseSession.mockReturnValue({ data: null, status: "unauthenticated" });

--- a/apps/web/components/shared/Header.tsx
+++ b/apps/web/components/shared/Header.tsx
@@ -19,6 +19,7 @@ import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { useTheme } from "next-themes";
 import { Sidebar } from "./Sidebar";
 import { usePlan, signOutAndClearPlan } from "@/hooks/usePlan";
+import { useReportTimezone } from "@/hooks/useReportTimezone";
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard" },
@@ -37,6 +38,7 @@ export function Header() {
   const { data: session, status } = useSession();
   const { theme, setTheme } = useTheme();
   const { plan } = usePlan();
+  useReportTimezone();
   const user = session?.user;
 
   const toggleTheme = () => {

--- a/apps/web/drizzle/0017_sharp_raider.sql
+++ b/apps/web/drizzle/0017_sharp_raider.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "timezone" text;

--- a/apps/web/drizzle/meta/0017_snapshot.json
+++ b/apps/web/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,1435 @@
+{
+  "id": "f35db051-b304-436b-890a-21d33739fd34",
+  "prevId": "816a3390-88c7-4f8d-82ee-2947f77b914b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.code_snapshots": {
+      "name": "code_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "code_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_result": {
+          "name": "execution_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "code_snapshots_session_id_interview_sessions_id_fk": {
+          "name": "code_snapshots_session_id_interview_sessions_id_fk",
+          "tableFrom": "code_snapshots",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_questions": {
+      "name": "company_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_questions_user_id_users_id_fk": {
+          "name": "company_questions_user_id_users_id_fk",
+          "tableFrom": "company_questions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deleted_usage": {
+      "name": "deleted_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deleted_usage_hash_month_unique": {
+          "name": "deleted_usage_hash_month_unique",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gaze_samples": {
+      "name": "gaze_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gaze_samples_session_id_interview_sessions_id_fk": {
+          "name": "gaze_samples_session_id_interview_sessions_id_fk",
+          "tableFrom": "gaze_samples",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_plans": {
+      "name": "interview_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interview_date": {
+          "name": "interview_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_data": {
+          "name": "plan_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_plans_user_id_users_id_fk": {
+          "name": "interview_plans_user_id_users_id_fk",
+          "tableFrom": "interview_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_sessions": {
+      "name": "interview_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'configuring'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_star_story_id": {
+          "name": "source_star_story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_sessions_user_id_users_id_fk": {
+          "name": "interview_sessions_user_id_users_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interview_sessions_source_star_story_id_star_stories_id_fk": {
+          "name": "interview_sessions_source_star_story_id_star_stories_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "source_star_story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_usage": {
+      "name": "interview_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "interview_usage_user_period_unique": {
+          "name": "interview_usage_user_period_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interview_usage_user_id_users_id_fk": {
+          "name": "interview_usage_user_id_users_id_fk",
+          "tableFrom": "interview_usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.openai_usage": {
+      "name": "openai_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd_millis": {
+          "name": "cost_usd_millis",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "openai_usage_user_date_model_unique": {
+          "name": "openai_usage_user_date_model_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_feedback": {
+      "name": "session_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_score": {
+          "name": "overall_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strengths": {
+          "name": "strengths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "weaknesses": {
+          "name": "weaknesses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "answer_analyses": {
+          "name": "answer_analyses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "code_quality_score": {
+          "name": "code_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation_quality_score": {
+          "name": "explanation_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeline_analysis": {
+          "name": "timeline_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_consistency_score": {
+          "name": "gaze_consistency_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_distribution": {
+          "name": "gaze_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_coverage": {
+          "name": "gaze_coverage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_timeline": {
+          "name": "gaze_timeline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drift_analysis": {
+          "name": "drift_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_tier": {
+          "name": "analysis_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_feedback_session_id_interview_sessions_id_fk": {
+          "name": "session_feedback_session_id_interview_sessions_id_fk",
+          "tableFrom": "session_feedback",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_templates": {
+      "name": "session_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_templates_user_id_users_id_fk": {
+          "name": "session_templates_user_id_users_id_fk",
+          "tableFrom": "session_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_stories": {
+      "name": "star_stories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_questions": {
+          "name": "expected_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "situation": {
+          "name": "situation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_stories_user_id_users_id_fk": {
+          "name": "star_stories_user_id_users_id_fk",
+          "tableFrom": "star_stories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_story_analyses": {
+      "name": "star_story_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scores": {
+          "name": "scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_story_analyses_story_id_star_stories_id_fk": {
+          "name": "star_story_analyses_story_id_star_stories_id_fk",
+          "tableFrom": "star_story_analyses",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcripts": {
+      "name": "transcripts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcripts_session_id_interview_sessions_id_fk": {
+          "name": "transcripts_session_id_interview_sessions_id_fk",
+          "tableFrom": "transcripts",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_badge_unique": {
+          "name": "user_badge_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "badge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_resumes": {
+      "name": "user_resumes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_resumes_user_id_users_id_fk": {
+          "name": "user_resumes_user_id_users_id_fk",
+          "tableFrom": "user_resumes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "user_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_start": {
+          "name": "plan_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_end": {
+          "name": "plan_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "past_due_at": {
+          "name": "past_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_tracking_enabled": {
+          "name": "gaze_tracking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tour_completed_at": {
+          "name": "tour_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tour_skipped_at": {
+          "name": "tour_skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.code_event_type": {
+      "name": "code_event_type",
+      "schema": "public",
+      "values": [
+        "edit",
+        "run",
+        "submit"
+      ]
+    },
+    "public.interview_type": {
+      "name": "interview_type",
+      "schema": "public",
+      "values": [
+        "behavioral",
+        "technical"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "configuring",
+        "in_progress",
+        "completed",
+        "cancelled",
+        "failed"
+      ]
+    },
+    "public.user_plan": {
+      "name": "user_plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "max"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1776743552291,
       "tag": "0016_rich_mandrill",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1776750968823,
+      "tag": "0017_sharp_raider",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/hooks/useRealtimeVoice.test.ts
+++ b/apps/web/hooks/useRealtimeVoice.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
+import { SILENCE_NUDGE_MS, SILENCE_HANDOFF_MS } from "@/lib/realtime-config";
 
 // ── MockWebSocket ────────────────────────────────────────────────────────────
 
@@ -173,9 +174,9 @@ function extraSends(): Record<string, unknown>[] {
 
 describe("useRealtimeVoice silence watchdog (108-A / 108-B / 108-E)", () => {
   /**
-   * 108-B / 108-F — No send within the first 9.9s after speech_stopped.
+   * 108-B / 108-F — No send within the first (SILENCE_NUDGE_MS - 100)ms after speech_stopped.
    */
-  it("produces no send before 10s after speech_stopped (108-B / 108-F)", async () => {
+  it("produces no send before the nudge threshold after speech_stopped (108-B / 108-F)", async () => {
     const { result } = renderHook(() =>
       useRealtimeVoice({ systemPrompt: "Test" })
     );
@@ -184,25 +185,25 @@ describe("useRealtimeVoice silence watchdog (108-A / 108-B / 108-E)", () => {
 
     deliver("input_audio_buffer.speech_stopped");
 
-    act(() => { vi.advanceTimersByTime(9_900); });
+    act(() => { vi.advanceTimersByTime(SILENCE_NUDGE_MS - 100); });
 
     // Watchdog must not have fired yet
     expect(mockWs.sends.length).toBe(countAfterSetup);
   });
 
   /**
-   * 108-A — At 10s+, nudge pair fires:
+   * 108-A — At SILENCE_NUDGE_MS+, nudge pair fires:
    *   [0] conversation.item.create (with nudge text)
    *   [1] response.create
    */
-  it("sends nudge pair at 10s mark after speech_stopped (108-A / 108-E)", async () => {
+  it("sends nudge pair at the nudge threshold after speech_stopped (108-A / 108-E)", async () => {
     const { result } = renderHook(() =>
       useRealtimeVoice({ systemPrompt: "Test" })
     );
     await openHook(result);
 
     deliver("input_audio_buffer.speech_stopped");
-    act(() => { vi.advanceTimersByTime(10_100); });
+    act(() => { vi.advanceTimersByTime(SILENCE_NUDGE_MS + 100); });
 
     const sends = extraSends();
     expect(sends.length).toBeGreaterThanOrEqual(2);
@@ -232,19 +233,21 @@ describe("useRealtimeVoice silence watchdog (108-A / 108-B / 108-E)", () => {
     const countAfterSetup = mockWs.sends.length;
 
     deliver("input_audio_buffer.speech_stopped");
-    act(() => { vi.advanceTimersByTime(5_000); }); // 5s — below nudge threshold
+    // Advance well below threshold (SILENCE_NUDGE_MS - 1000ms)
+    act(() => { vi.advanceTimersByTime(SILENCE_NUDGE_MS - 1000); });
 
     deliver("input_audio_buffer.speech_started"); // user resumes speaking
 
-    act(() => { vi.advanceTimersByTime(5_500); }); // 10.5s total — would cross threshold
+    // Advance 5500ms more — total now exceeds SILENCE_NUDGE_MS, proving cancellation
+    act(() => { vi.advanceTimersByTime(5_500); });
 
     expect(mockWs.sends.length).toBe(countAfterSetup);
   });
 
   /**
-   * 108-E — At 60s+, hand-off pair fires after the earlier nudge.
+   * 108-E — At SILENCE_HANDOFF_MS+, hand-off pair fires after the earlier nudge.
    */
-  it("sends hand-off pair at 60s mark after speech_stopped (108-E)", async () => {
+  it("sends hand-off pair at the handoff threshold after speech_stopped (108-E)", async () => {
     const { result } = renderHook(() =>
       useRealtimeVoice({ systemPrompt: "Test" })
     );
@@ -252,10 +255,10 @@ describe("useRealtimeVoice silence watchdog (108-A / 108-B / 108-E)", () => {
 
     deliver("input_audio_buffer.speech_stopped");
 
-    act(() => { vi.advanceTimersByTime(10_100); }); // cross the 10s nudge
+    act(() => { vi.advanceTimersByTime(SILENCE_NUDGE_MS + 100); }); // cross the nudge
     const countAfterNudge = mockWs.sends.length;
 
-    act(() => { vi.advanceTimersByTime(50_000); }); // 60.1s total — cross hand-off
+    act(() => { vi.advanceTimersByTime(SILENCE_HANDOFF_MS - SILENCE_NUDGE_MS + 100); }); // cross hand-off
 
     const handoffSends = mockWs.sends
       .slice(countAfterNudge)
@@ -285,17 +288,71 @@ describe("useRealtimeVoice silence watchdog (108-A / 108-B / 108-E)", () => {
     await openHook(result);
 
     deliver("input_audio_buffer.speech_stopped");
-    act(() => { vi.advanceTimersByTime(5_000); }); // 5s — below nudge
+    act(() => { vi.advanceTimersByTime(SILENCE_NUDGE_MS - 1000); }); // below nudge
 
     const countBeforeDisconnect = mockWs.sends.length;
 
     act(() => { result.current.disconnect(); });
 
-    // Advance well past both 10s and 60s thresholds
-    act(() => { vi.advanceTimersByTime(60_000); });
+    // Advance well past both nudge and handoff thresholds
+    act(() => { vi.advanceTimersByTime(SILENCE_HANDOFF_MS); });
 
     // WebSocket is CLOSED after disconnect so sendSilenceNudge returns early;
     // no new sends must appear
     expect(mockWs.sends.length).toBe(countBeforeDisconnect);
+  });
+
+  /**
+   * Regression — transcript.done arrived while TTS was still playing (or
+   * before any audio chunks were queued). The previous implementation gated
+   * arming on isSpeakingRef, which is false at that moment because
+   * drainQueue hasn't run yet. That armed the 10s timer mid-speech and the
+   * AI "nudged" the user while still talking.
+   *
+   * Fix contract: transcript.done must NOT arm the watchdog on its own. It
+   * must only set pendingWatchdogArmRef — arming happens later from
+   * drainQueue's speakingTimeout or from response.done.
+   */
+  it("does NOT arm the watchdog on transcript.done alone (race fix)", async () => {
+    const { result } = renderHook(() =>
+      useRealtimeVoice({ systemPrompt: "Test" })
+    );
+    await openHook(result);
+    const countAfterSetup = mockWs.sends.length;
+
+    // Transcript.done fires. isSpeakingRef is false (no audio deltas yet /
+    // drainQueue hasn't run in this test) — under the old code path the
+    // watchdog would arm and nudge at SILENCE_NUDGE_MS.
+    deliver("response.output_audio_transcript.done");
+
+    act(() => { vi.advanceTimersByTime(SILENCE_NUDGE_MS + 2000); });
+
+    expect(mockWs.sends.length).toBe(countAfterSetup);
+  });
+
+  /**
+   * Regression — response.done is the safety net. If no audio was ever
+   * queued (text-only response, or audio played and fully drained before
+   * response.done arrived), transcript.done sets pending but nothing clears
+   * it. response.done must arm the watchdog in that state.
+   */
+  it("arms the watchdog on response.done when nothing is speaking (safety net)", async () => {
+    const { result } = renderHook(() =>
+      useRealtimeVoice({ systemPrompt: "Test" })
+    );
+    await openHook(result);
+    const countAfterSetup = mockWs.sends.length;
+
+    // Full sequence for a text-only / already-finished response.
+    deliver("response.output_audio_transcript.done");
+    deliver("response.done");
+
+    // Now the watchdog should be armed — nudge fires after SILENCE_NUDGE_MS.
+    act(() => { vi.advanceTimersByTime(SILENCE_NUDGE_MS + 100); });
+
+    expect(mockWs.sends.length).toBeGreaterThan(countAfterSetup);
+    const sends = extraSends();
+    const itemCreate = sends[0];
+    expect(itemCreate.type).toBe("conversation.item.create");
   });
 });

--- a/apps/web/hooks/useRealtimeVoice.ts
+++ b/apps/web/hooks/useRealtimeVoice.ts
@@ -248,8 +248,16 @@ export function useRealtimeVoice(
             currentAssistantTextRef.current += msg.delta;
             break;
 
-          // GA event names — assistant finished speaking; arm watchdog if
-          // the user is not currently speaking (108-A)
+          // GA event names — assistant text transcript complete. Do NOT arm
+          // the watchdog here: transcript.done arrives when text streaming
+          // ends, which is typically BEFORE the first audio chunk has been
+          // queued (let alone finished playing). The previous implementation
+          // gated on isSpeakingRef.current, but that flag flips true only
+          // after drainQueue() runs — so when transcript.done wins the race
+          // the watchdog armed mid-speech and the AI nudged the user while
+          // still talking. Instead: always mark the arm pending. The watchdog
+          // actually arms either from drainQueue's speakingTimeout (when
+          // playback truly ends) or from the response.done safety net below.
           case "response.output_audio_transcript.done":
           // Beta fallback
           case "response.audio_transcript.done":
@@ -264,15 +272,26 @@ export function useRealtimeVoice(
               ]);
             }
             currentAssistantTextRef.current = "";
-            // Arm watchdog once the user is silent. If TTS is still playing,
-            // defer until playback finishes so the timer starts from actual
-            // silence — not from mid-speech.
             if (!isListening) {
-              if (isSpeakingRef.current) {
-                pendingWatchdogArmRef.current = true;
-              } else {
-                armSilenceWatchdog();
-              }
+              pendingWatchdogArmRef.current = true;
+            }
+            break;
+
+          // Safety net — response.done means the server has finished sending
+          // the entire response. If drainQueue never ran (text-only response
+          // or the audio arrived and fully played before this event), arm the
+          // watchdog now so we don't get stuck with pendingWatchdogArmRef
+          // true forever. If audio IS still playing, drainQueue's
+          // speakingTimeout will consume pendingWatchdogArmRef when playback
+          // ends — we leave it alone here.
+          case "response.done":
+            if (
+              pendingWatchdogArmRef.current &&
+              !isSpeakingRef.current &&
+              audioQueueRef.current.length === 0
+            ) {
+              pendingWatchdogArmRef.current = false;
+              armSilenceWatchdog();
             }
             break;
 

--- a/apps/web/hooks/useReportTimezone.test.ts
+++ b/apps/web/hooks/useReportTimezone.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const { useSessionMock } = vi.hoisted(() => ({
+  useSessionMock: vi.fn(() => ({
+    status: "authenticated" as const,
+    data: { user: { id: "u1" } },
+  })),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: useSessionMock,
+}));
+
+import { useReportTimezone } from "./useReportTimezone";
+
+const TZ_CACHE_KEY = "preploy:tz";
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+  useSessionMock.mockReturnValue({
+    status: "authenticated",
+    data: { user: { id: "u1" } },
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useReportTimezone", () => {
+  it("PATCHes /api/users/me with the detected timezone when cache is empty", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Force a deterministic timezone in the test environment.
+    vi.spyOn(
+      Intl.DateTimeFormat.prototype,
+      "resolvedOptions"
+    ).mockReturnValue({
+      timeZone: "Pacific/Auckland",
+    } as unknown as ReturnType<Intl.DateTimeFormat["resolvedOptions"]>);
+
+    renderHook(() => useReportTimezone());
+
+    // Wait a microtask for the effect to fire
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/users/me");
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body)).toEqual({ timezone: "Pacific/Auckland" });
+  });
+
+  it("skips the PATCH when sessionStorage already matches the detected timezone", async () => {
+    window.sessionStorage.setItem(TZ_CACHE_KEY, "America/New_York");
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.spyOn(
+      Intl.DateTimeFormat.prototype,
+      "resolvedOptions"
+    ).mockReturnValue({
+      timeZone: "America/New_York",
+    } as unknown as ReturnType<Intl.DateTimeFormat["resolvedOptions"]>);
+
+    renderHook(() => useReportTimezone());
+    await Promise.resolve();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not PATCH when unauthenticated", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useSessionMock.mockReturnValue({ status: "unauthenticated" as any, data: null as any });
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useReportTimezone());
+    await Promise.resolve();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not PATCH while session status is 'loading'", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    useSessionMock.mockReturnValue({ status: "loading" as any, data: null as any });
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderHook(() => useReportTimezone());
+    await Promise.resolve();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("stores the timezone in sessionStorage only after a successful PATCH", async () => {
+    // Fetch returns 500 — the hook must not cache on failure so a retry
+    // happens on the next mount.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.spyOn(
+      Intl.DateTimeFormat.prototype,
+      "resolvedOptions"
+    ).mockReturnValue({
+      timeZone: "Europe/London",
+    } as unknown as ReturnType<Intl.DateTimeFormat["resolvedOptions"]>);
+
+    renderHook(() => useReportTimezone());
+    // Two microtasks: one for fetch resolution, one for .then chain.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(window.sessionStorage.getItem(TZ_CACHE_KEY)).toBeNull();
+  });
+});

--- a/apps/web/hooks/useReportTimezone.ts
+++ b/apps/web/hooks/useReportTimezone.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSession } from "next-auth/react";
+
+const TZ_CACHE_KEY = "preploy:tz";
+
+/**
+ * Reports the user's IANA timezone to the server so time-of-day
+ * achievements (early_bird, night_owl, marathon_runner) use the user's
+ * local clock. The detected zone is cached in sessionStorage so we don't
+ * PATCH `/api/users/me` on every page navigation — only when it changes
+ * (user moved, VPN flip, etc.) or on first sign-in in this tab.
+ *
+ * Mount this hook once from a component that renders on every authenticated
+ * page (`Header` is the chosen site). It is a no-op for unauthenticated
+ * sessions and a no-op when `Intl.DateTimeFormat().resolvedOptions()` is
+ * unavailable (e.g. very old browsers).
+ */
+export function useReportTimezone(): void {
+  const { status } = useSession();
+
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    if (typeof window === "undefined") return;
+
+    let tz: string | undefined;
+    try {
+      tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    } catch {
+      return;
+    }
+    if (!tz) return;
+
+    const cached = window.sessionStorage.getItem(TZ_CACHE_KEY);
+    if (cached === tz) return;
+
+    // Fire-and-forget. A failed PATCH is not worth surfacing — achievement
+    // checks fall back to UTC until the next successful report.
+    fetch("/api/users/me", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ timezone: tz }),
+    })
+      .then((res) => {
+        if (res.ok) {
+          window.sessionStorage.setItem(TZ_CACHE_KEY, tz!);
+        }
+      })
+      .catch(() => {
+        /* ignore */
+      });
+  }, [status]);
+}

--- a/apps/web/lib/analysis-prompts.test.ts
+++ b/apps/web/lib/analysis-prompts.test.ts
@@ -303,8 +303,8 @@ describe("Pro behavioral system prompt", () => {
     expect(BEHAVIORAL_SYSTEM_PROMPT_PRO.toLowerCase()).toContain("if you were me");
   });
 
-  it("Pro behavioral prompt contains 500-word summary requirement", () => {
-    expect(BEHAVIORAL_SYSTEM_PROMPT_PRO).toContain("500");
+  it("Pro behavioral prompt contains 300-word summary requirement", () => {
+    expect(BEHAVIORAL_SYSTEM_PROMPT_PRO).toContain("300");
   });
 
   it("Free behavioral prompt does NOT contain Pro-only markers", () => {
@@ -320,8 +320,8 @@ describe("Pro technical system prompt", () => {
     expect(TECHNICAL_SYSTEM_PROMPT_PRO.toLowerCase()).toContain("if you were me");
   });
 
-  it("Pro technical prompt contains extended critique word count (500)", () => {
-    expect(TECHNICAL_SYSTEM_PROMPT_PRO).toContain("500");
+  it("Pro technical prompt contains extended critique word count (300)", () => {
+    expect(TECHNICAL_SYSTEM_PROMPT_PRO).toContain("300");
   });
 
   it("Free technical prompt does NOT contain Pro-only markers", () => {

--- a/apps/web/lib/analysis-prompts.ts
+++ b/apps/web/lib/analysis-prompts.ts
@@ -132,14 +132,14 @@ For each question-answer pair you identify in the transcript:
 
 Then provide an overall assessment:
 - Overall score (weighted average of individual answers)
-- A detailed summary of 500-800 words covering: overall performance arc, communication patterns, STAR method mastery, specific strengths with examples, specific growth areas with concrete guidance, and what a top-quartile answer would look like for this role
+- A detailed summary of 300-400 words covering: overall performance arc, communication patterns, STAR method mastery, specific strengths with examples, specific growth areas with concrete guidance, and what a top-quartile answer would look like for this role
 - Top 3 strengths
 - Top 3 areas for improvement
 
 Respond ONLY with valid JSON matching this exact structure:
 {
   "overall_score": <float 0-10>,
-  "summary": "<500-800 word detailed overall assessment>",
+  "summary": "<300-400 word detailed overall assessment>",
   "strengths": ["<strength 1>", "<strength 2>", "<strength 3>"],
   "weaknesses": ["<weakness 1>", "<weakness 2>", "<weakness 3>"],
   "answer_analyses": [
@@ -188,12 +188,12 @@ In the "feedback" string for each analysis category, include ALL of the followin
 - A "Phrases to add" list of 2-4 stronger alternative phrases that signal technical mastery
 - An "If you were me, what would you say" paragraph: rewrite how the candidate should have explained this aspect in 3-5 polished sentences
 
-Provide an extended summary of 500-800 words covering: overall coding ability narrative, communication arc, specific code quality observations with line references, complexity analysis accuracy, edge-case thinking, and concrete next-step practice recommendations.
+Provide an extended summary of 300-400 words covering: overall coding ability narrative, communication arc, specific code quality observations with line references, complexity analysis accuracy, edge-case thinking, and concrete next-step practice recommendations.
 
 Respond ONLY with valid JSON matching this exact structure:
 {
   "overall_score": <float 0-10>,
-  "summary": "<500-800 word extended overall assessment referencing specific parts of the code>",
+  "summary": "<300-400 word extended overall assessment referencing specific parts of the code>",
   "strengths": ["<strength — cite code or transcript>", "<strength>", "<strength>"],
   "weaknesses": ["<weakness — cite code or transcript>", "<weakness>", "<weakness>"],
   "code_quality_score": <float 0-10>,

--- a/apps/web/lib/realtime-config.ts
+++ b/apps/web/lib/realtime-config.ts
@@ -16,9 +16,8 @@ export const VAD_PREFIX_PADDING_MS = 300;
 export const VAD_SILENCE_DURATION_MS = 3000; // server waits 3s of silence before declaring user-turn end
 
 /** Wall-clock milliseconds from user-turn end to the first gentle nudge.
- *  At 10s the AI sends a one-sentence prompt ("Take your time…") injected
- *  as a system message so the candidate knows the session is still live. */
-export const SILENCE_NUDGE_MS = 10_000; // wall-clock from user-turn end → first gentle nudge
+ *  Reduced from 10s to 6s after user testing — 10s felt too slow mid-session. */
+export const SILENCE_NUDGE_MS = 6_000; // wall-clock from user-turn end → first gentle nudge
 
 /** Wall-clock milliseconds from user-turn end to the polite hand-off.
  *  At 60s the AI acknowledges the silence and moves to the next question.

--- a/apps/web/lib/schema.ts
+++ b/apps/web/lib/schema.ts
@@ -60,6 +60,7 @@ export const users = pgTable("users", {
   gazeTrackingEnabled: boolean("gaze_tracking_enabled").notNull().default(false),
   tourCompletedAt: timestamp("tour_completed_at", { withTimezone: true }),
   tourSkippedAt: timestamp("tour_skipped_at", { withTimezone: true }),
+  timezone: text("timezone"),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/apps/web/lib/timezone.test.ts
+++ b/apps/web/lib/timezone.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  getHourInTimezone,
+  getDateStringInTimezone,
+} from "./timezone";
+
+// 2026-04-21 02:00:00 UTC — mid-morning in Europe, mid-afternoon in
+// Pacific/Auckland (UTC+12 in NZST), evening-prior in US West.
+const UTC_MOMENT = new Date("2026-04-21T02:00:00Z");
+
+describe("getHourInTimezone", () => {
+  it("returns UTC hours when timezone is null", () => {
+    expect(getHourInTimezone(UTC_MOMENT, null)).toBe(2);
+  });
+
+  it("returns UTC hours when timezone is undefined", () => {
+    expect(getHourInTimezone(UTC_MOMENT, undefined)).toBe(2);
+  });
+
+  it("returns UTC hours when timezone is an empty string", () => {
+    expect(getHourInTimezone(UTC_MOMENT, "")).toBe(2);
+  });
+
+  it("returns local hour in Pacific/Auckland (UTC+12 standard)", () => {
+    // April is outside NZ daylight-saving; UTC+12. 02:00Z → 14:00 local.
+    expect(getHourInTimezone(UTC_MOMENT, "Pacific/Auckland")).toBe(14);
+  });
+
+  it("returns local hour in America/New_York (UTC-4 daylight)", () => {
+    // Late April is EDT (UTC-4). 02:00Z → 22:00 of the previous day local.
+    expect(getHourInTimezone(UTC_MOMENT, "America/New_York")).toBe(22);
+  });
+
+  it("returns local hour in Europe/London (UTC+1 daylight)", () => {
+    // Late April is BST (UTC+1). 02:00Z → 03:00 local.
+    expect(getHourInTimezone(UTC_MOMENT, "Europe/London")).toBe(3);
+  });
+
+  it("falls back to UTC hours when the timezone string is invalid", () => {
+    expect(getHourInTimezone(UTC_MOMENT, "Not/A_Real_Zone")).toBe(2);
+  });
+
+  it("normalizes a '24' hour reading to 0", () => {
+    // Midnight UTC → midnight local in UTC-0 zones. Some runtimes return
+    // "24" instead of "00" for the hour in `2-digit` mode; the helper must
+    // normalize to 0.
+    const midnight = new Date("2026-04-21T00:00:00Z");
+    expect(getHourInTimezone(midnight, "UTC")).toBe(0);
+  });
+});
+
+describe("getDateStringInTimezone", () => {
+  it("returns UTC date when timezone is null", () => {
+    expect(getDateStringInTimezone(UTC_MOMENT, null)).toBe("2026-04-21");
+  });
+
+  it("returns date for Pacific/Auckland (UTC+12 puts us later)", () => {
+    // 02:00Z on April 21 → 14:00 April 21 local. Same day.
+    expect(getDateStringInTimezone(UTC_MOMENT, "Pacific/Auckland")).toBe(
+      "2026-04-21"
+    );
+  });
+
+  it("returns previous-day date for America/Los_Angeles (UTC-7 puts us earlier)", () => {
+    // 02:00Z April 21 → 19:00 April 20 local (PDT).
+    expect(
+      getDateStringInTimezone(UTC_MOMENT, "America/Los_Angeles")
+    ).toBe("2026-04-20");
+  });
+
+  it("falls back to UTC date when the timezone string is invalid", () => {
+    expect(getDateStringInTimezone(UTC_MOMENT, "Not/A_Real_Zone")).toBe(
+      "2026-04-21"
+    );
+  });
+});

--- a/apps/web/lib/timezone.ts
+++ b/apps/web/lib/timezone.ts
@@ -1,0 +1,73 @@
+/**
+ * Timezone helpers for time-of-day and day-boundary achievement checks.
+ *
+ * The achievement check path (`/api/users/badges`) runs on the server, where
+ * the ambient timezone is UTC on Vercel. Previously we extracted hours via
+ * `.getUTCHours()` and day strings from `.getUTCDate()`, which fired
+ * `early_bird` / `night_owl` against UTC time regardless of where the user
+ * actually lives. A user in NZ (UTC+12/+13) running at 2pm local would
+ * register as 2am UTC — wrong.
+ *
+ * These helpers take an IANA timezone name (e.g. `"Pacific/Auckland"`) and
+ * return the hour (0-23) or the local calendar date ("YYYY-MM-DD") that the
+ * caller should use. When the timezone is null/undefined/invalid we fall
+ * back to UTC — same behavior as before, so the fix is strictly additive
+ * for users who haven't reported a timezone yet.
+ */
+
+/**
+ * Returns the hour (0-23) of `date` as observed in the given IANA timezone.
+ * Falls back to UTC when `timeZone` is null/undefined/empty or invalid.
+ */
+export function getHourInTimezone(
+  date: Date,
+  timeZone: string | null | undefined
+): number {
+  if (!timeZone) return date.getUTCHours();
+  try {
+    const fmt = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour: "2-digit",
+      hour12: false,
+    });
+    // `formatToParts` gives us the hour as a 0-23 string even with `2-digit`
+    // because `hour12: false` is set. `format()` would emit "24" at midnight
+    // in some locales, which is why we use `formatToParts`.
+    const parts = fmt.formatToParts(date);
+    const hourPart = parts.find((p) => p.type === "hour");
+    if (!hourPart) return date.getUTCHours();
+    const n = Number.parseInt(hourPart.value, 10);
+    if (Number.isNaN(n)) return date.getUTCHours();
+    // Normalize the midnight edge case some locales express as "24".
+    return n === 24 ? 0 : n;
+  } catch {
+    return date.getUTCHours();
+  }
+}
+
+/**
+ * Returns the calendar date ("YYYY-MM-DD") of `date` as observed in the
+ * given IANA timezone. Falls back to the UTC date when `timeZone` is
+ * null/undefined/empty or invalid.
+ */
+export function getDateStringInTimezone(
+  date: Date,
+  timeZone: string | null | undefined
+): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  if (!timeZone) {
+    return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`;
+  }
+  try {
+    const fmt = new Intl.DateTimeFormat("en-CA", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+    // en-CA formats as YYYY-MM-DD natively.
+    return fmt.format(date);
+  } catch {
+    return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`;
+  }
+}

--- a/apps/web/lib/validations.ts
+++ b/apps/web/lib/validations.ts
@@ -116,6 +116,11 @@ export const patchUserMeSchema = z.object({
   gaze_tracking_enabled: z.boolean().optional(),
   tour_completed_at: z.coerce.date().nullable().optional(),
   tour_skipped_at: z.coerce.date().nullable().optional(),
+  // IANA timezone name (e.g. "Pacific/Auckland"). The client syncs it on
+  // mount; the server uses it for time-of-day achievements (early_bird,
+  // night_owl, marathon_runner). Bounded length so we don't accept
+  // arbitrarily large strings.
+  timezone: z.string().trim().min(1).max(100).optional(),
 });
 export type PatchUserMeInput = z.infer<typeof patchUserMeSchema>;
 


### PR DESCRIPTION
## Summary

Two correctness bugs plus two small UX tweaks, bundled because they all came out of the same round of user testing.

- **TTS nudge race** (`useRealtimeVoice.ts`) — the silence watchdog was arming on `response.output_audio_transcript.done`, which fires when the *text* transcript finishes streaming. In that moment `isSpeakingRef.current` is still `false` because audio chunks haven't been queued yet, so the deferred-arm guard shipped in commit 16e8728 was being bypassed. The AI ended up nudging the user mid-speech on long responses. Fixed by always deferring at transcript.done, and adding a `response.done` handler as a safety net for text-only / already-drained responses.
- **Timezone-aware achievements** (`/api/users/badges`) — `early_bird`, `night_owl`, and `marathon_runner` were evaluated against `.getUTCHours()` and UTC calendar dates. A user in New Zealand (UTC+12/+13) completing a 2pm local session triggered Early Bird because 2pm NZ = 2am UTC. Added a nullable `timezone` column to `users`, a `useReportTimezone` client hook that detects via `Intl.DateTimeFormat` and PATCHes `/api/users/me` on first authenticated mount, and a `lib/timezone.ts` helper that the badges route now uses. UTC fallback preserved for users who haven't reported a tz yet.
- **Shorter nudge wait** — `SILENCE_NUDGE_MS` reduced from 10s to 6s after user testing (\"10s felt too slow mid-session\"). Hand-off stays at 60s.
- **Shorter Pro summary target** — `BEHAVIORAL_SYSTEM_PROMPT_PRO` and `TECHNICAL_SYSTEM_PROMPT_PRO` now ask GPT for a 300-400 word summary (was 500-800). User testing reported the 500-800 target was much too long to read on the feedback page.

## Schema change

Single additive nullable column on `users`:

\`\`\`sql
ALTER TABLE \"users\" ADD COLUMN \"timezone\" text;
\`\`\`

No backfill. Rows without a timezone fall back to UTC in the badge checker — same behavior as before this PR.

## Tests
- Unit / component (96 files, 962 tests): new `lib/timezone.test.ts` (12 tests), new `hooks/useReportTimezone.test.ts` (5 tests), 2 new regression tests in `useRealtimeVoice.test.ts` for the race + the response.done safety net. Prompt marker tests updated from 500→300.
- Integration (37 files, 369 tests): new `PATCH accepts timezone and persists it on the users row` and `PATCH rejects a timezone longer than 100 chars with 400` tests on `/api/users/me`. New `early_bird NOT awarded at 14:00 local`, `early_bird IS awarded at 06:00 local`, and `marathon_runner counts 5 sessions all on April 21 NZ despite UTC day boundary crossing` tests on `/api/users/badges`.
- All tests pass, lint + typecheck clean.

## Test plan (in Vercel preview)
- [ ] Run a long behavioral answer as a Pro user — confirm the AI does NOT say \"take your time\" while still speaking.
- [ ] Sit in silence after the AI finishes — confirm the nudge fires around the 6-second mark (previously 10s).
- [ ] Confirm `preploy:tz` appears in sessionStorage on first dashboard load after signing in.
- [ ] Confirm `users.timezone` is populated on the row (via Supabase dashboard) matching your real timezone.
- [ ] As a NZ user (or VPN simulated), complete a session at 2pm local time — confirm Early Bird is NOT awarded.
- [ ] As any user, complete a session at 6am local time — confirm Early Bird IS awarded.
- [ ] Open a Pro-generated feedback page — confirm the summary is noticeably shorter than before (~300-400 words, was ~500-800).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>