### PR TITLE
fix(interview): cancel silence watchdog when AI audio.delta arrives

### DIFF
--- a/apps/web/hooks/useRealtimeVoice.test.ts
+++ b/apps/web/hooks/useRealtimeVoice.test.ts
@@ -355,4 +355,32 @@ describe("useRealtimeVoice silence watchdog (108-A / 108-B / 108-E)", () => {
     const itemCreate = sends[0];
     expect(itemCreate.type).toBe("conversation.item.create");
   });
+
+  /**
+   * Regression — the main reported bug. speech_stopped arms the watchdog.
+   * The AI then starts speaking via audio.delta. Without the fix, the timer
+   * armed by speech_stopped keeps ticking through the AI's TTS playback and
+   * nudges the user mid-speech.
+   */
+  it("clears the watchdog when audio.delta arrives after speech_stopped (mid-speech nudge fix)", async () => {
+    const { result } = renderHook(() =>
+      useRealtimeVoice({ systemPrompt: "Test" })
+    );
+    await openHook(result);
+    const countAfterSetup = mockWs.sends.length;
+
+    // User finishes speaking — watchdog arms.
+    deliver("input_audio_buffer.speech_stopped");
+
+    // 3s of silence (below nudge threshold) — watchdog still pending.
+    act(() => { vi.advanceTimersByTime(3_000); });
+
+    // AI starts responding. audio.delta must clear the watchdog.
+    deliver("response.output_audio.delta", { delta: "AAAA" });
+
+    // Advance well past the original threshold — with the fix, no nudge fires.
+    act(() => { vi.advanceTimersByTime(SILENCE_NUDGE_MS + 2_000); });
+
+    expect(mockWs.sends.length).toBe(countAfterSetup);
+  });
 });

--- a/apps/web/hooks/useRealtimeVoice.ts
+++ b/apps/web/hooks/useRealtimeVoice.ts
@@ -230,6 +230,13 @@ export function useRealtimeVoice(
           case "response.output_audio.delta":
           // Beta fallback
           case "response.audio.delta": {
+            // AI audio has started arriving — cancel any silence watchdog that was
+            // armed by the preceding speech_stopped event. Leaving it armed lets the
+            // 6s nudge timer fire mid-speech. A fresh watchdog arms after playback
+            // via drainQueue's speakingTimeout (and the response.done safety net
+            // further down).
+            clearSilenceWatchdog();
+
             // Decode base64 audio and queue for playback
             const binaryString = atob(msg.delta);
             const bytes = new Uint8Array(binaryString.length);


### PR DESCRIPTION
## Summary

The "nudge mid-speech" bug that was supposedly fixed in PR #191 still reproduces in production. This PR is the real fix.

## Root cause

The prior fixes (commit `16e8728` from months ago, and #191's commits `5d5f0c0` / `50e9a55`) addressed the `response.output_audio_transcript.done` arming race and added a `response.done` safety net. Both are correct but they missed the actual offender.

**The watchdog is armed earlier — by `input_audio_buffer.speech_stopped`** (line 322 in `useRealtimeVoice.ts`). That event fires when the user finishes speaking and unconditionally arms the 6-second nudge timer. When the AI then starts responding via `response.output_audio.delta` events, *nothing cancels the already-running watchdog*. The clock keeps ticking through the AI's TTS playback, and at 6 seconds the nudge fires — while the AI is still speaking its first sentence.

Full trace:

| Event | State after | Watchdog |
|---|---|---|
| user speaks → `speech_started` | `clearSilenceWatchdog` called | cleared |
| user done → `speech_stopped` | `armSilenceWatchdog` called | **ARMED** |
| AI starts → `audio.delta[0]` | `drainQueue` schedules audio, flips `isSpeakingRef = true` | **STILL ARMED** ← bug |
| ... more `audio.delta` ... | playback continues | still armed, ticking |
| 6s after speech_stopped | silenceTimerRef fires | **nudge sent while AI is speaking** |

## Fix

Single `clearSilenceWatchdog()` call at the top of the `audio.delta` handler. When the AI begins speaking, the user's silence is expected (they're listening), so the watchdog is stale and must die. A fresh watchdog arms correctly after the AI finishes — via `drainQueue`'s `speakingTimeout` callback, or via the `response.done` safety net for text-only responses.

## Tests

New regression test in `useRealtimeVoice.test.ts`:
- `clears the watchdog when audio.delta arrives after speech_stopped (mid-speech nudge fix)` — delivers speech_stopped, advances 3s (below threshold), delivers audio.delta, advances past the threshold, asserts no nudge was sent.

All 963 unit/component tests pass. Lint + typecheck clean.

## Test plan
- [ ] In Vercel preview, run a behavioral interview with a long agent response (ask "tell me about yourself" or similar that typically produces a 20+ second TTS response). The AI must NOT interrupt itself with "take your time" mid-speech.
- [ ] Sit fully silent after the AI finishes — confirm the nudge fires at ~6 seconds of silence (the re-arm path still works).
- [ ] Start speaking mid-nudge-period — confirm the watchdog clears and the cycle restarts cleanly.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>