### PR TITLE
fix(behavioral): forbid agent from answering its own question

### DIFF
--- a/apps/web/hooks/useRealtimeVoice.test.ts
+++ b/apps/web/hooks/useRealtimeVoice.test.ts
@@ -357,6 +357,32 @@ describe("useRealtimeVoice silence watchdog (108-A / 108-B / 108-E)", () => {
   });
 
   /**
+   * Regression guard — the nudge system message must explicitly tell the AI
+   * NOT to answer the question itself. "Gently nudge them" alone was
+   * interpreted as license to fill silence with a hypothetical answer.
+   */
+  it("nudge system message tells the AI not to answer the question itself", async () => {
+    const { result } = renderHook(() =>
+      useRealtimeVoice({ systemPrompt: "Test" })
+    );
+    await openHook(result);
+
+    deliver("input_audio_buffer.speech_stopped");
+    act(() => { vi.advanceTimersByTime(SILENCE_NUDGE_MS + 100); });
+
+    const sends = extraSends();
+    expect(sends.length).toBeGreaterThanOrEqual(2);
+
+    const itemCreate = sends[0];
+    expect(itemCreate.type).toBe("conversation.item.create");
+
+    const item = itemCreate.item as { content?: Array<{ text?: string }> };
+    const nudgeText = item?.content?.[0]?.text ?? "";
+    expect(nudgeText).toContain("Do NOT answer");
+    expect(nudgeText).toContain("Do NOT generate a sample answer");
+  });
+
+  /**
    * Regression — the main reported bug. speech_stopped arms the watchdog.
    * The AI then starts speaking via audio.delta. Without the fix, the timer
    * armed by speech_stopped keeps ticking through the AI's TTS playback and

--- a/apps/web/hooks/useRealtimeVoice.ts
+++ b/apps/web/hooks/useRealtimeVoice.ts
@@ -127,13 +127,13 @@ export function useRealtimeVoice(
 
     silenceTimerRef.current = setTimeout(() => {
       sendSilenceNudge(
-        "The candidate has been silent for ~10 seconds. Gently nudge them — for example, 'Take your time' or 'Want me to repeat the question?' Keep it to one sentence."
+        "The candidate has been silent. Gently nudge them with ONE short sentence — e.g. 'Take your time' or 'Want me to repeat the question?'. Do NOT answer the question yourself. Do NOT generate a sample answer. Do NOT continue past the nudge. Wait for the candidate to respond."
       );
     }, SILENCE_NUDGE_MS);
 
     handoffTimerRef.current = setTimeout(() => {
       sendSilenceNudge(
-        "The candidate has been silent for ~60 seconds. Acknowledge politely and move to the next question, e.g. 'Let\u2019s come back to this later \u2014 next\u2026'"
+        "The candidate has been silent for ~60 seconds. Acknowledge politely and move to the next question — e.g. 'Let\u2019s come back to this later \u2014 next\u2026'. Do NOT answer the previous question yourself. Do NOT give a sample answer. Just move on."
       );
       clearSilenceWatchdog();
     }, SILENCE_HANDOFF_MS);

--- a/apps/web/lib/prompts.test.ts
+++ b/apps/web/lib/prompts.test.ts
@@ -183,4 +183,34 @@ describe("buildBehavioralSystemPrompt", () => {
     const prompt = buildBehavioralSystemPrompt(DEFAULT_CONFIG);
     expect(prompt).not.toContain("RESUME");
   });
+
+  // Role-boundary regression tests — the "never speak as the candidate" rule
+  // must appear in EVERY behavioral prompt, not only when a resume is uploaded.
+  it("contains the 'never speak as the candidate' role boundary rule", () => {
+    const prompt = buildBehavioralSystemPrompt(DEFAULT_CONFIG);
+    expect(prompt).toContain("Never speak as the candidate");
+    expect(prompt).toContain("Never answer your own question");
+  });
+
+  it("contains filler-word guidance in every prompt", () => {
+    const prompt = buildBehavioralSystemPrompt(DEFAULT_CONFIG);
+    // The spec lists these concrete filler examples
+    expect(prompt).toContain("good question");
+    expect(prompt).toContain("hmm");
+  });
+
+  it("includes the role boundary even without a resume", () => {
+    const prompt = buildBehavioralSystemPrompt({
+      interview_style: 0.5,
+      difficulty: 0.5,
+      resume_text: undefined,
+    });
+    expect(prompt).toContain("Never speak as the candidate");
+    expect(prompt).toContain("Never answer your own question");
+  });
+
+  it("silence-handling section tells the AI not to answer its own question", () => {
+    const prompt = buildBehavioralSystemPrompt(DEFAULT_CONFIG);
+    expect(prompt).toContain("Do NOT answer your own question");
+  });
 });

--- a/apps/web/lib/prompts.ts
+++ b/apps/web/lib/prompts.ts
@@ -70,9 +70,16 @@ export function buildBehavioralSystemPrompt(
   // Resume context
   if (config.resume_text?.trim()) {
     sections.push(
-      `The candidate's resume is provided below for context ONLY. Use it to ask targeted follow-up questions about their experience. CRITICAL: You are the interviewer — NEVER answer questions on the candidate's behalf. NEVER speak as the candidate. NEVER paraphrase or recite the candidate's experience as if you lived it. Your ONLY role is to ask questions and probe deeper. If the candidate gives a vague answer, ask them to elaborate — do NOT fill in details from the resume yourself.\n\n--- RESUME (interviewer reference only) ---\n${config.resume_text.trim().slice(0, 3000)}\n--- END RESUME ---`
+      `The candidate's resume is provided below for context ONLY. Use it to ask targeted follow-up questions about their experience. Your ONLY role is to ask questions and probe deeper. If the candidate gives a vague answer, ask them to elaborate — do NOT fill in details from the resume yourself.\n\n--- RESUME (interviewer reference only) ---\n${config.resume_text.trim().slice(0, 3000)}\n--- END RESUME ---`
     );
   }
+
+  // Role boundary — CRITICAL; must appear in every behavioral prompt regardless
+  // of whether a resume is present. Prevents the AI from answering its own
+  // question when the candidate responds with filler or stays silent.
+  sections.push(
+    "CRITICAL — role boundary: You are the INTERVIEWER. Never speak as the candidate. Never produce what you imagine the candidate's answer would be, even as an example or to \"show what a good answer looks like.\" Never answer your own question.\n\nIf the candidate responds with filler or acknowledgement only (\"good question\", \"hmm\", \"let me think\", \"that's interesting\", \"um\", a nervous laugh, etc.) WITHOUT substantive content, treat it the same as silence: do NOT elaborate, do NOT answer, do NOT guess at what they might say. Wait briefly, then repeat or rephrase the question, or offer to clarify if they look stuck. A gentle \"take your time\" is fine — generating a hypothetical answer is not."
+  );
 
   // Warm-up — always present; must fire before any competency question (108-C)
   sections.push(
@@ -96,7 +103,7 @@ export function buildBehavioralSystemPrompt(
 
   // Silence-handling — AI must wait, not auto-advance (108-A / 108-B)
   sections.push(
-    "If the candidate is silent or pauses mid-answer, do NOT advance to a new question. Wait. The system may inject a gentle nudge (e.g. 'Take your time', 'Want me to repeat?', 'Should we move on?') as a system message — when you receive one, deliver it verbatim or near-verbatim, then wait again. Only move on after the candidate explicitly confirms or after the system instructs you to hand off."
+    "If the candidate is silent or pauses mid-answer, do NOT advance to a new question. Do NOT answer your own question. Wait. The system may inject a gentle nudge (e.g. 'Take your time', 'Want me to repeat?', 'Should we move on?') as a system message — when you receive one, deliver it verbatim or near-verbatim, then wait again. Only move on after the candidate explicitly confirms or after the system instructs you to hand off."
   );
 
   return sections.join("\n\n");


### PR DESCRIPTION
## Summary

Behavioral interview bug: the AI asks a question, the candidate says filler ("good question", "hmm") and goes quiet, and the AI — instead of waiting or nudging — **answers its own question as if it were the interviewee**. Unnatural and breaks the illusion of an interview.

## Root cause

Three gaps in the behavioral agent's instructions, all of them structural (not a model failure):

1. **"Never speak as the candidate" lived only in the resume-context conditional** (`lib/prompts.ts:73`). If the candidate hasn't uploaded a resume, the model never gets the rule. The base persona line "never confuse your identity with theirs" is too soft — an identity statement, not a behavioral rule.
2. **No explicit filler-word guidance.** When the candidate says "good question" or "hmm", the model reads that as engagement and thinks it's being asked to continue — which it does, by generating a sample answer.
3. **The silence-nudge system messages said "gently nudge them"** without any prohibition on self-answering. The model could read that as license to "nudge, and then helpfully fill in."

## Fix — prompt-only, no behavior changes

- **`lib/prompts.ts`** — new top-level `CRITICAL — role boundary` section is now in every behavioral prompt (not gated on resume). Lists filler words explicitly as silence-equivalents. Tells the model what to do instead (repeat, rephrase, or wait). Silence-handling section gains a hard `Do NOT answer your own question` line.
- **`hooks/useRealtimeVoice.ts`** — nudge and handoff system-message strings now carry `Do NOT answer the question yourself. Do NOT generate a sample answer.` constraints. Also removed the hardcoded "~10 seconds" duration since the constant is now 6s (drift fix).
- **Technical prompt untouched** — the technical interview is a candidate monologue, no conversational loop, bug can't manifest there.

## Tests

- 4 new assertions in `lib/prompts.test.ts`: role boundary present universally, filler-word guidance present, rule survives without resume, silence section forbids self-answering.
- 1 new assertion in `hooks/useRealtimeVoice.test.ts`: the nudge `conversation.item.create` payload contains `Do NOT answer` and `Do NOT generate a sample answer`.
- 968 total tests pass, lint + typecheck clean.

## Test plan (in Vercel preview)
- [ ] Start a behavioral interview without a resume, let the AI ask the first real question, say "good question" and stay silent. The AI must NOT produce a hypothetical candidate answer. It must wait, then (after ~6s) nudge with `"Take your time"` or `"Want me to repeat?"`.
- [ ] Repeat with a resume uploaded — same behavior expected.
- [ ] After the nudge, sit silent another 60s — handoff should fire and the AI should move to the next question without ever answering the previous one itself.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>