### PR TITLE
feat(pro): separate Pro-analysis quota + per-session opt-in (#190)

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -224,3 +224,5 @@ When editing an existing UI file, the self-check before opening a PR is:
 "does this look like every other shadcn+tailwind starter?" and "would a
 real user hit a dead end or confusion here?" If either answer is yes,
 push further.
+
+Pro-only UI affordances use the cedar accent (`text-[color:var(--primary)]`) with a `<Sparkles>` Lucide icon — first instance is `ProAnalysisToggle` (#190).

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -213,6 +213,7 @@ task definition / secrets manager.
 | `RESEND_API_KEY`             | RUNTIME_ONLY       | Resend API key for transactional email (welcome, feedback-ready, upgrade nudge). Create at [resend.com](https://resend.com). Emails silently skipped when unset. |
 | `RESEND_FROM_ADDRESS`        | RUNTIME_ONLY       | Override the FROM address for transactional emails. Defaults to `Preploy <onboarding@resend.dev>`. Switch to your verified domain (e.g. `Preploy <noreply@preploy.tech>`) after DNS verification in Resend. |
 | `PRO_ANALYSIS_MODEL`       | RUNTIME_ONLY       | Override model used for Pro users' session feedback analysis (default: `gpt-5`). Set per environment; point at an available model (e.g. `gpt-4o`) until `gpt-5` is GA. |
+| `PRO_ANALYSIS_MONTHLY_LIMIT` | RUNTIME_ONLY     | Monthly cap on Pro-tier analysis per user. Default `10`. Consumed by `/api/users/pro-analysis-usage` and the feedback tier resolver in `/api/sessions/[id]/feedback`. |
 
 Server-only secrets (`SUPABASE_DB_URL`, `OPENAI_API_KEY`, `GOOGLE_CLIENT_SECRET`,
 `SENTRY_DSN`) must never be referenced from a file marked `"use client"` and

--- a/apps/web/app/api/sessions/[id]/feedback/route.integration.test.ts
+++ b/apps/web/app/api/sessions/[id]/feedback/route.integration.test.ts
@@ -24,6 +24,7 @@ import {
   sessionFeedback,
   gazeSamples,
 } from "@/lib/schema";
+import { currentFreePeriodStart } from "@/lib/usage";
 import { eq } from "drizzle-orm";
 
 // Mock auth
@@ -636,13 +637,14 @@ describe("API /api/sessions/[id]/feedback (integration)", () => {
     const db = getTestDb();
     vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
 
-    // Create a behavioral session owned by the Pro user
+    // Create a behavioral session owned by the Pro user with useProAnalysis opted in
     const [proSession] = await db
       .insert(interviewSessions)
       .values({
         userId: PRO_USER.id,
         type: "behavioral",
         config: { interview_style: 0.5, difficulty: 0.5 },
+        useProAnalysis: true,
       })
       .returning();
 
@@ -690,13 +692,14 @@ describe("API /api/sessions/[id]/feedback (integration)", () => {
     const db = getTestDb();
     vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
 
-    // Create a technical session owned by the Pro user
+    // Create a technical session owned by the Pro user with useProAnalysis opted in
     const [proTechSession] = await db
       .insert(interviewSessions)
       .values({
         userId: PRO_USER.id,
         type: "technical",
         config: { interview_type: "leetcode", focus_areas: ["arrays"], language: "python", difficulty: "medium" },
+        useProAnalysis: true,
       })
       .returning();
 
@@ -735,13 +738,14 @@ describe("API /api/sessions/[id]/feedback (integration)", () => {
     const db = getTestDb();
     vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
 
-    // Create a behavioral session owned by Pro user
+    // Create a behavioral session owned by Pro user with useProAnalysis opted in
     const [proSession] = await db
       .insert(interviewSessions)
       .values({
         userId: PRO_USER.id,
         type: "behavioral",
         config: { interview_style: 0.5, difficulty: 0.5 },
+        useProAnalysis: true,
       })
       .returning();
 
@@ -800,13 +804,14 @@ describe("API /api/sessions/[id]/feedback (integration)", () => {
     const db = getTestDb();
     vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
 
-    // Create a Pro session
+    // Create a Pro session with useProAnalysis opted in
     const [proSession] = await db
       .insert(interviewSessions)
       .values({
         userId: PRO_USER.id,
         type: "behavioral",
         config: { interview_style: 0.5, difficulty: 0.5 },
+        useProAnalysis: true,
       })
       .returning();
 
@@ -882,12 +887,14 @@ describe("API /api/sessions/[id]/feedback (integration)", () => {
     const db = getTestDb();
     vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
 
+    // useProAnalysis: true is required for Pro tier (introduced in #190)
     const [proSession] = await db
       .insert(interviewSessions)
       .values({
         userId: PRO_USER.id,
         type: "behavioral",
         config: { interview_style: 0.5, difficulty: 0.5 },
+        useProAnalysis: true,
       })
       .returning();
 
@@ -934,5 +941,165 @@ describe("API /api/sessions/[id]/feedback (integration)", () => {
     expect(getRes.status).toBe(200);
     const body = await getRes.json();
     expect(body.analysisTier).toBe("free");
+  });
+
+  // ---- #190: 3-way AND tier resolution ----
+
+  it("POST writes analysisTier='pro' when user is Pro, session opted in, and quota has room", async () => {
+    const db = getTestDb();
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
+
+    // Pro session with useProAnalysis: true and no prior pro feedback rows
+    const [proSession] = await db
+      .insert(interviewSessions)
+      .values({
+        userId: PRO_USER.id,
+        type: "behavioral",
+        config: { interview_style: 0.5, difficulty: 0.5 },
+        useProAnalysis: true,
+      })
+      .returning();
+
+    await db.insert(transcripts).values({
+      sessionId: proSession.id,
+      entries: SAMPLE_TRANSCRIPT,
+    });
+
+    mockAuth.mockResolvedValue({ user: { id: PRO_USER.id } });
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: BEHAVIORAL_GPT_RESPONSE_RAW } }],
+    });
+
+    const res = await POST(makePostRequest(proSession.id), makeParams(proSession.id));
+    expect(res.status).toBe(201);
+
+    const [row] = await db
+      .select()
+      .from(sessionFeedback)
+      .where(eq(sessionFeedback.sessionId, proSession.id));
+    expect(row.analysisTier).toBe("pro");
+  });
+
+  it("POST falls back to analysisTier='free' (not 402) when Pro user opted in but is at 10/10", async () => {
+    const db = getTestDb();
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
+
+    const periodStart = currentFreePeriodStart();
+
+    // Seed 10 pro-tier feedback rows in the current period to exhaust the quota
+    for (let i = 0; i < 10; i++) {
+      const [s] = await db
+        .insert(interviewSessions)
+        .values({ userId: PRO_USER.id, type: "behavioral", config: {} })
+        .returning();
+      await db.insert(sessionFeedback).values({
+        sessionId: s.id,
+        analysisTier: "pro",
+        createdAt: new Date(periodStart.getTime() + i * 1000),
+      });
+    }
+
+    // Create the 11th session with useProAnalysis opted in
+    const [exhaustedSession] = await db
+      .insert(interviewSessions)
+      .values({
+        userId: PRO_USER.id,
+        type: "behavioral",
+        config: { interview_style: 0.5, difficulty: 0.5 },
+        useProAnalysis: true,
+      })
+      .returning();
+
+    await db.insert(transcripts).values({
+      sessionId: exhaustedSession.id,
+      entries: SAMPLE_TRANSCRIPT,
+    });
+
+    mockAuth.mockResolvedValue({ user: { id: PRO_USER.id } });
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: BEHAVIORAL_GPT_RESPONSE_RAW } }],
+    });
+
+    // Should NOT return 402 — must fall through to Free tier silently
+    const res = await POST(makePostRequest(exhaustedSession.id), makeParams(exhaustedSession.id));
+    expect(res.status).toBe(201);
+    expect(res.status).not.toBe(402);
+
+    const [row] = await db
+      .select()
+      .from(sessionFeedback)
+      .where(eq(sessionFeedback.sessionId, exhaustedSession.id));
+    expect(row.analysisTier).toBe("free");
+  });
+
+  it("POST writes analysisTier='free' for a Pro user whose session did not opt in", async () => {
+    const db = getTestDb();
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
+
+    // Pro session with useProAnalysis: false (default)
+    const [proSessionOff] = await db
+      .insert(interviewSessions)
+      .values({
+        userId: PRO_USER.id,
+        type: "behavioral",
+        config: { interview_style: 0.5, difficulty: 0.5 },
+        useProAnalysis: false,
+      })
+      .returning();
+
+    await db.insert(transcripts).values({
+      sessionId: proSessionOff.id,
+      entries: SAMPLE_TRANSCRIPT,
+    });
+
+    mockAuth.mockResolvedValue({ user: { id: PRO_USER.id } });
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: BEHAVIORAL_GPT_RESPONSE_RAW } }],
+    });
+
+    const res = await POST(makePostRequest(proSessionOff.id), makeParams(proSessionOff.id));
+    expect(res.status).toBe(201);
+
+    const [row] = await db
+      .select()
+      .from(sessionFeedback)
+      .where(eq(sessionFeedback.sessionId, proSessionOff.id));
+    expect(row.analysisTier).toBe("free");
+  });
+
+  it("POST writes analysisTier='free' for a Free user even if the session row somehow has useProAnalysis=true", async () => {
+    const db = getTestDb();
+    vi.stubEnv("PRO_ANALYSIS_MODEL", "gpt-5-test-pro");
+
+    // Forcibly insert a session with useProAnalysis=true for a Free user
+    // (simulates a state-leak scenario — the route should still produce Free tier)
+    const [freeSession] = await db
+      .insert(interviewSessions)
+      .values({
+        userId: TEST_USER.id,
+        type: "behavioral",
+        config: { interview_style: 0.5, difficulty: 0.5 },
+        useProAnalysis: true,
+      })
+      .returning();
+
+    await db.insert(transcripts).values({
+      sessionId: freeSession.id,
+      entries: SAMPLE_TRANSCRIPT,
+    });
+
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } }); // TEST_USER is Free plan
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: BEHAVIORAL_GPT_RESPONSE_RAW } }],
+    });
+
+    const res = await POST(makePostRequest(freeSession.id), makeParams(freeSession.id));
+    expect(res.status).toBe(201);
+
+    const [row] = await db
+      .select()
+      .from(sessionFeedback)
+      .where(eq(sessionFeedback.sessionId, freeSession.id));
+    expect(row.analysisTier).toBe("free");
   });
 });

--- a/apps/web/app/api/sessions/[id]/feedback/route.ts
+++ b/apps/web/app/api/sessions/[id]/feedback/route.ts
@@ -28,6 +28,7 @@ import type {
 } from "@/lib/analysis-schemas";
 import { OpenAIRetryError } from "@/lib/openai-retry";
 import { getCurrentUserPlan } from "@/lib/user-plan";
+import { getProAnalysisUsage } from "@/lib/usage";
 import type { AnalysisTier } from "@/lib/analysis-model";
 
 // POST /api/sessions/[id]/feedback — trigger feedback generation
@@ -69,8 +70,25 @@ export async function POST(
   // in-flight analyses finish at the tier the user has at the moment they hit
   // POST. Downgrade mid-session → Free output on this POST if the DB flip
   // landed first. Next session always uses the then-current tier.
+  //
+  // Tier is Pro iff ALL three conditions hold:
+  //   1. User's current plan is "pro"
+  //   2. Session was opted in to Pro analysis (useProAnalysis === true)
+  //   3. User still has Pro-analysis quota remaining this period
+  // Quota exhaustion falls through to Free silently — never 402.
   const plan = await getCurrentUserPlan(session.user.id);
-  const tier: AnalysisTier = plan === "pro" ? "pro" : "free";
+  let tier: AnalysisTier = "free";
+  if (plan === "pro" && found.useProAnalysis) {
+    const { used, limit } = await getProAnalysisUsage(session.user.id);
+    if (used < limit) {
+      tier = "pro";
+    } else {
+      log.info(
+        { userId: session.user.id, sessionId: id, proAnalysisFallback: true, used, limit },
+        "Pro user opted into Pro analysis but is at quota — falling back to Free tier"
+      );
+    }
+  }
   log.info({ tier, sessionId: id }, "feedback tier resolved");
 
   // Check if feedback already exists

--- a/apps/web/app/api/sessions/route.integration.test.ts
+++ b/apps/web/app/api/sessions/route.integration.test.ts
@@ -807,6 +807,59 @@ describe("API /api/sessions (integration)", () => {
     expect(res.status).toBe(400);
   });
 
+  // ---- #190: use_pro_analysis field ----
+
+  it("POST persists use_pro_analysis=true on the session row for a Pro user", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const db = getTestDb();
+    const { eq } = await import("drizzle-orm");
+    await db.update(users).set({ plan: "pro" }).where(eq(users.id, TEST_USER.id));
+
+    const res = await POST(
+      makePostRequest({ type: "behavioral", use_pro_analysis: true })
+    );
+    expect(res.status).toBe(201);
+    const data = await res.json();
+
+    // Verify the column was persisted
+    const { interviewSessions } = await import("@/lib/schema");
+    const [row] = await db
+      .select()
+      .from(interviewSessions)
+      .where(eq(interviewSessions.id, data.id));
+    expect(row.useProAnalysis).toBe(true);
+  });
+
+  it("POST returns 400 use_pro_analysis_requires_pro_plan for a Free user", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    // TEST_USER is reset to free plan by beforeEach
+
+    const res = await POST(
+      makePostRequest({ type: "behavioral", use_pro_analysis: true })
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("use_pro_analysis_requires_pro_plan");
+  });
+
+  it("POST defaults use_pro_analysis to false when the client omits the field", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const res = await POST(makePostRequest({ type: "behavioral" }));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+
+    const db = getTestDb();
+    const { interviewSessions } = await import("@/lib/schema");
+    const { eq } = await import("drizzle-orm");
+    const [row] = await db
+      .select()
+      .from(interviewSessions)
+      .where(eq(interviewSessions.id, data.id));
+    expect(row.useProAnalysis).toBe(false);
+  });
+
   // Regression: the parallel bypass path for the Resume feature. A free
   // user could previously POST a session config containing
   // `resume_text` or `resume_id` and land a resume-aware interviewer

--- a/apps/web/app/api/sessions/route.ts
+++ b/apps/web/app/api/sessions/route.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/validations";
 import { checkRateLimit, requireProFeature } from "@/lib/api-utils";
 import { tryConsumeInterviewSlot } from "@/lib/usage";
+import { getCurrentUserPlan } from "@/lib/user-plan";
 
 // GET /api/sessions — list sessions with pagination, type/score filters
 // Query params: page (1-based), limit, type, minScore, maxScore
@@ -149,7 +150,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const { type, config, source_star_story_id } = parsed.data;
+  const { type, config, source_star_story_id, use_pro_analysis } = parsed.data;
 
   // Validate config based on interview type
   if (config) {
@@ -159,6 +160,17 @@ export async function POST(request: NextRequest) {
     if (!configResult.success) {
       return NextResponse.json(
         { error: "Invalid session config", details: configResult.error.issues },
+        { status: 400 }
+      );
+    }
+  }
+
+  // Pro gate for use_pro_analysis flag. Free users sending true get 400.
+  if (use_pro_analysis === true) {
+    const userPlan = await getCurrentUserPlan(session.user.id);
+    if (userPlan !== "pro") {
+      return NextResponse.json(
+        { error: "use_pro_analysis_requires_pro_plan" },
         { status: 400 }
       );
     }
@@ -233,6 +245,7 @@ export async function POST(request: NextRequest) {
           type,
           config: config ?? {},
           sourceStarStoryId: source_star_story_id ?? null,
+          useProAnalysis: use_pro_analysis ?? false,
         })
         .returning();
       return row;

--- a/apps/web/app/api/users/pro-analysis-usage/route.integration.test.ts
+++ b/apps/web/app/api/users/pro-analysis-usage/route.integration.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
+import { NextRequest } from "next/server";
+import {
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../../tests/setup-db";
+import { users, interviewSessions, sessionFeedback } from "@/lib/schema";
+import { eq } from "drizzle-orm";
+
+const mockAuth = vi.fn();
+vi.mock("@/lib/auth", () => ({ auth: () => mockAuth() }));
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return getTestDb();
+  },
+}));
+
+import { GET } from "./route";
+
+const FREE_USER = {
+  id: "00000000-0000-0000-0000-000000000070",
+  email: "free-analysis@example.com",
+  name: "Free User",
+  plan: "free" as const,
+};
+
+const PRO_USER = {
+  id: "00000000-0000-0000-0000-000000000071",
+  email: "pro-analysis-route@example.com",
+  name: "Pro User",
+  plan: "pro" as const,
+};
+
+function makeGetRequest(): NextRequest {
+  return new NextRequest("http://localhost:3000/api/users/pro-analysis-usage", {
+    method: "GET",
+  });
+}
+
+describe("GET /api/users/pro-analysis-usage (integration)", () => {
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values(FREE_USER).onConflictDoNothing();
+    await db.insert(users).values(PRO_USER).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const db = getTestDb();
+    await db.delete(sessionFeedback);
+    await db.delete(interviewSessions).where(eq(interviewSessions.userId, PRO_USER.id));
+    await db.delete(interviewSessions).where(eq(interviewSessions.userId, FREE_USER.id));
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  it("GET returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("GET returns { plan: 'free', used: 0, limit: 0, periodEnd: null } for a Free user", async () => {
+    mockAuth.mockResolvedValue({ user: { id: FREE_USER.id } });
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      plan: "free",
+      used: 0,
+      limit: 0,
+      periodEnd: null,
+    });
+  });
+
+  it("GET returns matching used/limit/periodEnd for a Pro user with 3 pro feedback rows", async () => {
+    mockAuth.mockResolvedValue({ user: { id: PRO_USER.id } });
+
+    const db = getTestDb();
+    const periodStart = new Date(
+      Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1)
+    );
+
+    // Seed 3 pro-tier feedback rows
+    for (let i = 0; i < 3; i++) {
+      const [session] = await db
+        .insert(interviewSessions)
+        .values({ userId: PRO_USER.id, type: "behavioral", config: {} })
+        .returning();
+      await db.insert(sessionFeedback).values({
+        sessionId: session.id,
+        analysisTier: "pro",
+        createdAt: new Date(periodStart.getTime() + i * 1000),
+      });
+    }
+
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.plan).toBe("pro");
+    expect(body.used).toBe(3);
+    expect(body.limit).toBe(10);
+    // periodEnd is an ISO string or null
+    expect(typeof body.periodEnd === "string" || body.periodEnd === null).toBe(true);
+  });
+
+  it("GET returns used: 0 for a Pro user with no feedback rows", async () => {
+    mockAuth.mockResolvedValue({ user: { id: PRO_USER.id } });
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.plan).toBe("pro");
+    expect(body.used).toBe(0);
+    expect(body.limit).toBe(10);
+  });
+});

--- a/apps/web/app/api/users/pro-analysis-usage/route.ts
+++ b/apps/web/app/api/users/pro-analysis-usage/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { getCurrentUserPlan } from "@/lib/user-plan";
+import { getProAnalysisUsage } from "@/lib/usage";
+import { createRequestLogger } from "@/lib/logger";
+
+// GET /api/users/pro-analysis-usage — current Pro-analysis quota for the authenticated user
+export async function GET(_request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const log = createRequestLogger({
+    route: "GET /api/users/pro-analysis-usage",
+    userId: session.user.id,
+  });
+
+  const plan = await getCurrentUserPlan(session.user.id);
+
+  if (plan !== "pro") {
+    log.info({ plan }, "free user requested pro-analysis-usage — returning zero shape");
+    return NextResponse.json({
+      plan: "free",
+      used: 0,
+      limit: 0,
+      periodEnd: null,
+    });
+  }
+
+  const { used, limit, periodEnd } = await getProAnalysisUsage(session.user.id);
+
+  log.info({ used, limit }, "pro-analysis-usage fetched");
+
+  return NextResponse.json({
+    plan: "pro",
+    used,
+    limit,
+    periodEnd: periodEnd ? periodEnd.toISOString() : null,
+  });
+}

--- a/apps/web/components/interview/BehavioralSetupForm.test.tsx
+++ b/apps/web/components/interview/BehavioralSetupForm.test.tsx
@@ -8,6 +8,17 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush }),
 }));
 
+// ProAnalysisToggle calls usePlan — mock it to "free" so the toggle is
+// hidden and does not interfere with existing BehavioralSetupForm tests.
+vi.mock("@/hooks/usePlan", () => ({
+  usePlan: () => ({ plan: "free" }),
+}));
+
+// ProAnalysisToggle also uses next-auth/react session status.
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "authenticated" }),
+}));
+
 const { mockSetType, mockSetConfig, mockCreateSession } = vi.hoisted(() => ({
   mockSetType: vi.fn(),
   mockSetConfig: vi.fn(),
@@ -45,10 +56,13 @@ vi.mock("@/stores/prefillStore", () => ({
   }),
 }));
 
-// Mock fetch for question generation and user profile (gaze preference)
+// Mock fetch for question generation, user profile (gaze preference), and pro-analysis-usage
 const mockFetch = vi.fn().mockImplementation((url: string) => {
   if (typeof url === "string" && url.includes("/api/users/me")) {
     return Promise.resolve({ ok: true, json: async () => ({ gazeTrackingEnabled: false }) });
+  }
+  if (typeof url === "string" && url.includes("/api/users/pro-analysis-usage")) {
+    return Promise.resolve({ ok: true, json: async () => ({ plan: "free", used: 0, limit: 0, periodEnd: null }) });
   }
   return Promise.resolve({ ok: false, json: async () => ({}) });
 });

--- a/apps/web/components/interview/BehavioralSetupForm.tsx
+++ b/apps/web/components/interview/BehavioralSetupForm.tsx
@@ -15,6 +15,7 @@ import { TemplateControls } from "./TemplateControls";
 import { ResumeSelector } from "./ResumeSelector";
 import { UpgradePromptDialog } from "@/components/billing/UpgradePromptDialog";
 import { usePrefillStore } from "@/stores/prefillStore";
+import { ProAnalysisToggle } from "./ProAnalysisToggle";
 import type { BehavioralSessionConfig } from "@preploy/shared";
 
 interface CompanyQuestion {
@@ -49,6 +50,7 @@ export function BehavioralSetupForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [gazeTrackingEnabled, setGazeTrackingEnabled] = useState(false);
+  const [useProAnalysis, setUseProAnalysis] = useState(false);
 
   // Company question generation state
   const [generatedQuestions, setGeneratedQuestions] = useState<CompanyQuestion[]>([]);
@@ -164,9 +166,10 @@ export function BehavioralSetupForm() {
     setError(null);
     setIsSubmitting(true);
 
-    const sessionId = await createSession(
-      sourceStarStoryId ? { source_star_story_id: sourceStarStoryId } : undefined
-    );
+    const sessionId = await createSession({
+      ...(sourceStarStoryId ? { source_star_story_id: sourceStarStoryId } : {}),
+      use_pro_analysis: useProAnalysis,
+    });
     setIsSubmitting(false);
 
     if (sessionId) {
@@ -441,6 +444,9 @@ export function BehavioralSetupForm() {
           </Label>
         </div>
       )}
+
+      {/* Pro analysis toggle */}
+      <ProAnalysisToggle value={useProAnalysis} onChange={setUseProAnalysis} />
 
       {/* Error */}
       {error && (

--- a/apps/web/components/interview/ProAnalysisToggle.test.tsx
+++ b/apps/web/components/interview/ProAnalysisToggle.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — must be before any imports that use these modules
+// ---------------------------------------------------------------------------
+const { mockUsePlan } = vi.hoisted(() => ({
+  mockUsePlan: vi.fn(),
+}));
+
+vi.mock("@/hooks/usePlan", () => ({
+  usePlan: () => mockUsePlan(),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "authenticated" }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import component after mocks
+// ---------------------------------------------------------------------------
+import { ProAnalysisToggle } from "./ProAnalysisToggle";
+
+const FREE_USAGE = { plan: "free", used: 0, limit: 0, periodEnd: null };
+const PRO_USAGE_UNDER = { plan: "pro", used: 3, limit: 10, periodEnd: "2026-05-01T00:00:00.000Z" };
+const PRO_USAGE_EXHAUSTED = { plan: "pro", used: 10, limit: 10, periodEnd: "2026-05-01T00:00:00.000Z" };
+
+describe("ProAnalysisToggle", () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing for Free users", () => {
+    mockUsePlan.mockReturnValue({ plan: "free" });
+    const { container } = render(
+      <ProAnalysisToggle value={false} onChange={() => {}} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders Switch and '3 of 10 left' subline for Pro user under quota", async () => {
+    mockUsePlan.mockReturnValue({ plan: "pro" });
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => PRO_USAGE_UNDER,
+    });
+
+    render(<ProAnalysisToggle value={false} onChange={() => {}} />);
+
+    // Wait for fetch to resolve and loading skeleton to disappear
+    await waitFor(() => {
+      expect(screen.getAllByText(/3 of 10 left this month/i).length).toBeGreaterThan(0);
+    });
+
+    // Switch should be present and enabled
+    const switchEl = screen.getByRole("switch");
+    expect(switchEl).toBeInTheDocument();
+    expect(switchEl).not.toBeDisabled();
+
+    // Label text
+    expect(screen.getAllByText(/Use Pro analysis for this session/i).length).toBeGreaterThan(0);
+  });
+
+  it("renders disabled exhausted banner when used equals limit", async () => {
+    mockUsePlan.mockReturnValue({ plan: "pro" });
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => PRO_USAGE_EXHAUSTED,
+    });
+
+    render(<ProAnalysisToggle value={false} onChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/You've used all 10 Pro analyses this month/i).length
+      ).toBeGreaterThan(0);
+    });
+
+    // No switch should be rendered in exhausted state
+    expect(screen.queryByRole("switch")).toBeNull();
+  });
+
+  it("onChange fires when the Switch is clicked", async () => {
+    mockUsePlan.mockReturnValue({ plan: "pro" });
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => PRO_USAGE_UNDER,
+    });
+
+    const onChange = vi.fn();
+    render(<ProAnalysisToggle value={false} onChange={onChange} />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("switch")).toBeInTheDocument();
+    });
+
+    const switchEl = screen.getByRole("switch");
+    await userEvent.click(switchEl);
+    // shadcn Switch onCheckedChange passes (checked, event) — assert only the
+    // first argument (the new boolean value).
+    expect(onChange).toHaveBeenCalled();
+    expect(onChange.mock.calls[0][0]).toBe(true);
+  });
+});

--- a/apps/web/components/interview/ProAnalysisToggle.tsx
+++ b/apps/web/components/interview/ProAnalysisToggle.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState, useEffect, useId } from "react";
+import { Sparkles } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
+import { usePlan } from "@/hooks/usePlan";
+
+interface ProAnalysisToggleProps {
+  value: boolean;
+  onChange: (next: boolean) => void;
+}
+
+interface UsageData {
+  plan: "free" | "pro";
+  used: number;
+  limit: number;
+  periodEnd: string | null;
+}
+
+function formatDate(isoDate: string | null): string {
+  if (!isoDate) return "next month";
+  try {
+    return new Date(isoDate).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return "next month";
+  }
+}
+
+export function ProAnalysisToggle({ value, onChange }: ProAnalysisToggleProps) {
+  const { plan } = usePlan();
+  // null  = fetch not yet resolved (loading)
+  // false = fetch errored / non-Pro (show nothing or fallback)
+  // UsageData = fetched successfully
+  const [usage, setUsage] = useState<UsageData | null | false>(null);
+  const switchId = useId();
+  const sublineId = useId();
+
+  useEffect(() => {
+    // Only fetch for Pro users.
+    if (plan !== "pro") return;
+    let cancelled = false;
+    fetch("/api/users/pro-analysis-usage")
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to fetch pro analysis usage");
+        return res.json() as Promise<UsageData>;
+      })
+      .then((data) => {
+        if (!cancelled) setUsage(data);
+      })
+      .catch(() => {
+        if (!cancelled) setUsage(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [plan]);
+
+  // Derive loading: Pro plan but fetch hasn't resolved yet
+  const isLoading = plan === "pro" && usage === null;
+
+  // Hidden for Free users
+  if (plan !== "pro") return null;
+
+  // Skeleton while loading
+  if (isLoading) {
+    return (
+      <div
+        role="group"
+        aria-label="Pro analysis toggle loading"
+        className="flex items-start gap-3 rounded-lg border border-border px-4 py-3 animate-pulse"
+      >
+        <div className="mt-0.5 h-4 w-4 rounded bg-muted" />
+        <div className="flex-1 space-y-2">
+          <div className="h-4 w-48 rounded bg-muted" />
+          <div className="h-3 w-32 rounded bg-muted" />
+        </div>
+        <div className="h-5 w-9 rounded-full bg-muted" />
+      </div>
+    );
+  }
+
+  // usage === false means fetch errored — render nothing rather than a broken state.
+  if (usage === false) return null;
+
+  const usageData = usage as UsageData;
+  const used = usageData.used;
+  const limit = usageData.limit;
+  const periodEnd = usageData.periodEnd;
+  const isExhausted = limit > 0 && used >= limit;
+
+  if (isExhausted) {
+    return (
+      <div
+        role="group"
+        className="rounded-lg border border-[color:var(--primary)]/30 bg-[color:var(--primary)]/5 px-4 py-3 space-y-2"
+      >
+        <div className="flex items-center gap-2">
+          <Sparkles
+            className="h-4 w-4 shrink-0 text-[color:var(--primary)]"
+            aria-hidden="true"
+          />
+          <span className="text-sm font-medium">Pro analysis</span>
+        </div>
+        <p className="text-sm text-muted-foreground" id={sublineId}>
+          You&apos;ve used all {limit} Pro analyses this month. This session
+          will use standard analysis. Resets {formatDate(periodEnd)}.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="group"
+      className="flex items-start gap-3 rounded-lg border border-border px-4 py-3"
+    >
+      <Sparkles
+        className="mt-0.5 h-4 w-4 shrink-0 text-[color:var(--primary)]"
+        aria-hidden="true"
+      />
+      <div className="flex-1">
+        <label
+          htmlFor={switchId}
+          className="block cursor-pointer text-sm font-medium"
+        >
+          Use Pro analysis for this session
+        </label>
+        <p className="text-xs text-muted-foreground" id={sublineId}>
+          {used} of {limit} left this month
+        </p>
+      </div>
+      <Switch
+        id={switchId}
+        checked={value}
+        onCheckedChange={onChange}
+        aria-describedby={sublineId}
+        disabled={isExhausted}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/interview/TechnicalSetupForm.test.tsx
+++ b/apps/web/components/interview/TechnicalSetupForm.test.tsx
@@ -1,10 +1,21 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { TechnicalSetupForm } from "./TechnicalSetupForm";
 
 const mockPush = vi.fn();
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush }),
+}));
+
+// ProAnalysisToggle calls usePlan — mock it to "free" so the toggle is
+// hidden and does not interfere with existing TechnicalSetupForm tests.
+vi.mock("@/hooks/usePlan", () => ({
+  usePlan: () => ({ plan: "free" }),
+}));
+
+// ProAnalysisToggle also uses next-auth/react session status.
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ status: "authenticated" }),
 }));
 
 const { mockSetType, mockSetConfig, mockCreateSession, configOverride, prefillOverride } = vi.hoisted(() => ({
@@ -53,6 +64,13 @@ describe("TechnicalSetupForm", () => {
     vi.clearAllMocks();
     configOverride.value = {};
     prefillOverride.value = null;
+    // Stub fetch so ProAnalysisToggle (hidden for free plan) never makes a
+    // real network call during TechnicalSetupForm tests.
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("renders interview type options", () => {

--- a/apps/web/components/interview/TechnicalSetupForm.tsx
+++ b/apps/web/components/interview/TechnicalSetupForm.tsx
@@ -20,6 +20,7 @@ import { usePrefillStore } from "@/stores/prefillStore";
 import { TemplateControls } from "./TemplateControls";
 import { ResumeSelector } from "./ResumeSelector";
 import { UpgradePromptDialog } from "@/components/billing/UpgradePromptDialog";
+import { ProAnalysisToggle } from "./ProAnalysisToggle";
 import {
   SUPPORTED_LANGUAGES,
   FOCUS_AREAS_BY_TYPE,
@@ -70,6 +71,7 @@ export function TechnicalSetupForm() {
   const clearQuotaError = useInterviewStore((s) => s.clearQuotaError);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [useProAnalysis, setUseProAnalysis] = useState(false);
 
   const { technicalPrefill, clearPrefill } = usePrefillStore();
 
@@ -159,7 +161,7 @@ export function TechnicalSetupForm() {
     }
 
     setIsSubmitting(true);
-    const sessionId = await createSession();
+    const sessionId = await createSession({ use_pro_analysis: useProAnalysis });
     setIsSubmitting(false);
 
     if (sessionId) {
@@ -349,6 +351,9 @@ export function TechnicalSetupForm() {
           </Card>
         </div>
       </div>
+
+      {/* Pro analysis toggle */}
+      <ProAnalysisToggle value={useProAnalysis} onChange={setUseProAnalysis} />
 
       {/* Error */}
       {error && (

--- a/apps/web/drizzle/0018_lethal_taskmaster.sql
+++ b/apps/web/drizzle/0018_lethal_taskmaster.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "interview_sessions" ADD COLUMN "use_pro_analysis" boolean DEFAULT false NOT NULL;

--- a/apps/web/drizzle/meta/0018_snapshot.json
+++ b/apps/web/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,1442 @@
+{
+  "id": "fee6c15d-c879-4ada-b502-f4746664c4e3",
+  "prevId": "f35db051-b304-436b-890a-21d33739fd34",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.code_snapshots": {
+      "name": "code_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "code_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_result": {
+          "name": "execution_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "code_snapshots_session_id_interview_sessions_id_fk": {
+          "name": "code_snapshots_session_id_interview_sessions_id_fk",
+          "tableFrom": "code_snapshots",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_questions": {
+      "name": "company_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_questions_user_id_users_id_fk": {
+          "name": "company_questions_user_id_users_id_fk",
+          "tableFrom": "company_questions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deleted_usage": {
+      "name": "deleted_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deleted_usage_hash_month_unique": {
+          "name": "deleted_usage_hash_month_unique",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gaze_samples": {
+      "name": "gaze_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gaze_samples_session_id_interview_sessions_id_fk": {
+          "name": "gaze_samples_session_id_interview_sessions_id_fk",
+          "tableFrom": "gaze_samples",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_plans": {
+      "name": "interview_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interview_date": {
+          "name": "interview_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_data": {
+          "name": "plan_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_plans_user_id_users_id_fk": {
+          "name": "interview_plans_user_id_users_id_fk",
+          "tableFrom": "interview_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_sessions": {
+      "name": "interview_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'configuring'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_star_story_id": {
+          "name": "source_star_story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_pro_analysis": {
+          "name": "use_pro_analysis",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_sessions_user_id_users_id_fk": {
+          "name": "interview_sessions_user_id_users_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interview_sessions_source_star_story_id_star_stories_id_fk": {
+          "name": "interview_sessions_source_star_story_id_star_stories_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "source_star_story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_usage": {
+      "name": "interview_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "interview_usage_user_period_unique": {
+          "name": "interview_usage_user_period_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interview_usage_user_id_users_id_fk": {
+          "name": "interview_usage_user_id_users_id_fk",
+          "tableFrom": "interview_usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.openai_usage": {
+      "name": "openai_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd_millis": {
+          "name": "cost_usd_millis",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "openai_usage_user_date_model_unique": {
+          "name": "openai_usage_user_date_model_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_feedback": {
+      "name": "session_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_score": {
+          "name": "overall_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strengths": {
+          "name": "strengths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "weaknesses": {
+          "name": "weaknesses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "answer_analyses": {
+          "name": "answer_analyses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "code_quality_score": {
+          "name": "code_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation_quality_score": {
+          "name": "explanation_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeline_analysis": {
+          "name": "timeline_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_consistency_score": {
+          "name": "gaze_consistency_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_distribution": {
+          "name": "gaze_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_coverage": {
+          "name": "gaze_coverage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_timeline": {
+          "name": "gaze_timeline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drift_analysis": {
+          "name": "drift_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_tier": {
+          "name": "analysis_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_feedback_session_id_interview_sessions_id_fk": {
+          "name": "session_feedback_session_id_interview_sessions_id_fk",
+          "tableFrom": "session_feedback",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_templates": {
+      "name": "session_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_templates_user_id_users_id_fk": {
+          "name": "session_templates_user_id_users_id_fk",
+          "tableFrom": "session_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_stories": {
+      "name": "star_stories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_questions": {
+          "name": "expected_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "situation": {
+          "name": "situation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_stories_user_id_users_id_fk": {
+          "name": "star_stories_user_id_users_id_fk",
+          "tableFrom": "star_stories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_story_analyses": {
+      "name": "star_story_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scores": {
+          "name": "scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_story_analyses_story_id_star_stories_id_fk": {
+          "name": "star_story_analyses_story_id_star_stories_id_fk",
+          "tableFrom": "star_story_analyses",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcripts": {
+      "name": "transcripts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcripts_session_id_interview_sessions_id_fk": {
+          "name": "transcripts_session_id_interview_sessions_id_fk",
+          "tableFrom": "transcripts",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_badge_unique": {
+          "name": "user_badge_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "badge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_resumes": {
+      "name": "user_resumes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_resumes_user_id_users_id_fk": {
+          "name": "user_resumes_user_id_users_id_fk",
+          "tableFrom": "user_resumes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "user_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_start": {
+          "name": "plan_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_end": {
+          "name": "plan_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "past_due_at": {
+          "name": "past_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_tracking_enabled": {
+          "name": "gaze_tracking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tour_completed_at": {
+          "name": "tour_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tour_skipped_at": {
+          "name": "tour_skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.code_event_type": {
+      "name": "code_event_type",
+      "schema": "public",
+      "values": [
+        "edit",
+        "run",
+        "submit"
+      ]
+    },
+    "public.interview_type": {
+      "name": "interview_type",
+      "schema": "public",
+      "values": [
+        "behavioral",
+        "technical"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "configuring",
+        "in_progress",
+        "completed",
+        "cancelled",
+        "failed"
+      ]
+    },
+    "public.user_plan": {
+      "name": "user_plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "max"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1776750968823,
       "tag": "0017_sharp_raider",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1776780410797,
+      "tag": "0018_lethal_taskmaster",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/plans.ts
+++ b/apps/web/lib/plans.ts
@@ -59,6 +59,8 @@ export interface PlanLimits {
   monthlyInterviews: number | null;
   /** Maximum daily sessions (for in-app quota checks). */
   dailySessions: number;
+  /** Maximum Pro-tier analysis runs per billing period. 0 = not available on this plan. */
+  proAnalysisMonthly: number;
 }
 
 export interface PlanDefinition {
@@ -79,6 +81,7 @@ export interface PlanDefinition {
 
 export const FREE_PLAN_MONTHLY_INTERVIEW_LIMIT = 3;
 export const PRO_PLAN_MONTHLY_INTERVIEW_LIMIT = 40;
+export const PRO_ANALYSIS_MONTHLY_LIMIT = 10;
 
 export const PLAN_DEFINITIONS: Record<Plan, PlanDefinition> = {
   free: {
@@ -92,6 +95,7 @@ export const PLAN_DEFINITIONS: Record<Plan, PlanDefinition> = {
     limits: {
       monthlyInterviews: FREE_PLAN_MONTHLY_INTERVIEW_LIMIT,
       dailySessions: 3,
+      proAnalysisMonthly: 0,
     },
   },
   pro: {
@@ -109,6 +113,7 @@ export const PLAN_DEFINITIONS: Record<Plan, PlanDefinition> = {
     limits: {
       monthlyInterviews: PRO_PLAN_MONTHLY_INTERVIEW_LIMIT,
       dailySessions: 40,
+      proAnalysisMonthly: PRO_ANALYSIS_MONTHLY_LIMIT,
     },
   },
 };

--- a/apps/web/lib/schema.ts
+++ b/apps/web/lib/schema.ts
@@ -141,6 +141,7 @@ export const interviewSessions = pgTable("interview_sessions", {
     (): AnyPgColumn => starStories.id,
     { onDelete: "set null" }
   ),
+  useProAnalysis: boolean("use_pro_analysis").notNull().default(false),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/apps/web/lib/usage.integration.test.ts
+++ b/apps/web/lib/usage.integration.test.ts
@@ -12,7 +12,7 @@ import {
   teardownTestDb,
   getTestDb,
 } from "../tests/setup-db";
-import { users, interviewUsage, deletedUsage } from "@/lib/schema";
+import { users, interviewUsage, deletedUsage, interviewSessions, sessionFeedback } from "@/lib/schema";
 import { eq, and } from "drizzle-orm";
 
 vi.mock("@/lib/db", () => ({
@@ -27,6 +27,7 @@ import {
   hashEmailMonth,
   currentMonth,
   currentFreePeriodStart,
+  getProAnalysisUsage,
 } from "./usage";
 
 const TEST_USER = {
@@ -114,5 +115,102 @@ describe("usage carry-forward (integration)", () => {
       .where(and(eq(deletedUsage.emailHash, hash), eq(deletedUsage.month, month)));
     expect(row).toBeDefined();
     expect(row.usageCount).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getProAnalysisUsage (integration)
+// ---------------------------------------------------------------------------
+
+const PRO_ANALYSIS_USER = {
+  id: "00000000-0000-0000-0000-000000000060",
+  email: "pro-analysis@example.com",
+  name: "Pro Analysis Test",
+  plan: "pro" as const,
+};
+
+describe("getProAnalysisUsage (integration)", () => {
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values(PRO_ANALYSIS_USER).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    // Clean sessions and feedback between tests — keep the user row
+    const db = getTestDb();
+    await db.delete(sessionFeedback);
+    await db.delete(interviewSessions).where(eq(interviewSessions.userId, PRO_ANALYSIS_USER.id));
+  });
+
+  afterAll(async () => {
+    // cleanupTestDb and teardownTestDb are called by the carry-forward suite
+    // above — avoid double-teardown by only cleaning up if that suite hasn't
+    // run. In practice both suites share the same afterAll cleanupTestDb call
+    // from the carry-forward block, so we do nothing here to avoid a
+    // "already ended" error from postgres.js.
+  });
+
+  it("getProAnalysisUsage returns 0 when user has no pro feedback rows", async () => {
+    const { used, limit } = await getProAnalysisUsage(PRO_ANALYSIS_USER.id);
+    expect(used).toBe(0);
+    expect(limit).toBe(10); // PRO_ANALYSIS_MONTHLY_LIMIT
+  });
+
+  it("getProAnalysisUsage returns 3 after three pro feedback rows are inserted", async () => {
+    const db = getTestDb();
+    const periodStart = currentFreePeriodStart();
+
+    // Seed 3 sessions with pro-tier feedback
+    for (let i = 0; i < 3; i++) {
+      const [session] = await db
+        .insert(interviewSessions)
+        .values({ userId: PRO_ANALYSIS_USER.id, type: "behavioral", config: {} })
+        .returning();
+      await db.insert(sessionFeedback).values({
+        sessionId: session.id,
+        analysisTier: "pro",
+        createdAt: new Date(periodStart.getTime() + i * 1000), // within period
+      });
+    }
+
+    const { used, limit } = await getProAnalysisUsage(PRO_ANALYSIS_USER.id);
+    expect(used).toBe(3);
+    expect(limit).toBe(10);
+  });
+
+  it("getProAnalysisUsage excludes rows from a prior period", async () => {
+    const db = getTestDb();
+    const periodStart = currentFreePeriodStart();
+
+    // Seed 2 feedback rows in an old period (6 months ago)
+    const oldPeriodStart = new Date(
+      Date.UTC(periodStart.getUTCFullYear(), periodStart.getUTCMonth() - 6, 1)
+    );
+    for (let i = 0; i < 2; i++) {
+      const [session] = await db
+        .insert(interviewSessions)
+        .values({ userId: PRO_ANALYSIS_USER.id, type: "behavioral", config: {} })
+        .returning();
+      await db.insert(sessionFeedback).values({
+        sessionId: session.id,
+        analysisTier: "pro",
+        createdAt: new Date(oldPeriodStart.getTime() + i * 1000),
+      });
+    }
+
+    // Seed 1 row in the current period
+    const [currentSession] = await db
+      .insert(interviewSessions)
+      .values({ userId: PRO_ANALYSIS_USER.id, type: "behavioral", config: {} })
+      .returning();
+    await db.insert(sessionFeedback).values({
+      sessionId: currentSession.id,
+      analysisTier: "pro",
+      createdAt: new Date(periodStart.getTime() + 5000),
+    });
+
+    // Pass explicit periodStart = current month start → only count the 1 current row
+    const { used } = await getProAnalysisUsage(PRO_ANALYSIS_USER.id, periodStart);
+    expect(used).toBe(1);
   });
 });

--- a/apps/web/lib/usage.ts
+++ b/apps/web/lib/usage.ts
@@ -17,10 +17,10 @@
  * period_start key that doesn't match any existing row.
  */
 import { createHash } from "crypto";
-import { sql } from "drizzle-orm";
-import { eq, and } from "drizzle-orm";
+import { sql, count } from "drizzle-orm";
+import { eq, and, gte } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { interviewUsage, deletedUsage } from "@/lib/schema";
+import { interviewUsage, deletedUsage, users, interviewSessions, sessionFeedback } from "@/lib/schema";
 import { getPlanLimits } from "@/lib/plans";
 import { getCurrentUserPlan } from "@/lib/user-plan";
 
@@ -193,6 +193,72 @@ export async function tryConsumeInterviewSlot(
   }
 
   return { allowed: true, used: newCount, limit };
+}
+
+// ---------------------------------------------------------------------------
+// Pro-analysis quota
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns how many Pro-tier feedback rows the user has generated in the
+ * current billing period, plus the plan limit and period end.
+ *
+ * - `periodStart` defaults to `users.planPeriodStart` if set (Stripe billing
+ *   anchor), else falls back to `currentFreePeriodStart()` (calendar month).
+ * - `limit` comes from `getPlanLimits(plan).proAnalysisMonthly`:
+ *   0 for Free, 10 for Pro.
+ * - `used` = COUNT of session_feedback rows with analysis_tier = 'pro'
+ *   joined to sessions owned by this user within the period window.
+ * - `periodEnd` is `users.planPeriodEnd` when set, else the calendar-month end.
+ */
+export async function getProAnalysisUsage(
+  userId: string,
+  periodStart?: Date
+): Promise<{ used: number; limit: number; periodEnd: Date | null }> {
+  const plan = await getCurrentUserPlan(userId);
+  const limit = getPlanLimits(plan).proAnalysisMonthly;
+
+  // Derive period start: use the passed-in value, then the user's billing
+  // anchor from the DB, then fall back to calendar-month start.
+  let effectivePeriodStart: Date;
+  let periodEnd: Date | null = null;
+
+  if (periodStart) {
+    effectivePeriodStart = periodStart;
+  } else {
+    const [userRow] = await db
+      .select({ planPeriodStart: users.planPeriodStart, planPeriodEnd: users.planPeriodEnd })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+    effectivePeriodStart = userRow?.planPeriodStart ?? currentFreePeriodStart();
+    periodEnd = userRow?.planPeriodEnd ?? null;
+  }
+
+  if (!periodEnd && !periodStart) {
+    // Compute calendar-month end when no Stripe period end is set
+    const now = new Date();
+    const lastDay = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 0, 23, 59, 59, 999));
+    periodEnd = lastDay;
+  }
+
+  const [row] = await db
+    .select({ used: count() })
+    .from(sessionFeedback)
+    .innerJoin(interviewSessions, eq(sessionFeedback.sessionId, interviewSessions.id))
+    .where(
+      and(
+        eq(interviewSessions.userId, userId),
+        eq(sessionFeedback.analysisTier, "pro"),
+        gte(sessionFeedback.createdAt, effectivePeriodStart)
+      )
+    );
+
+  return {
+    used: row?.used ?? 0,
+    limit,
+    periodEnd,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/lib/validations.ts
+++ b/apps/web/lib/validations.ts
@@ -37,6 +37,7 @@ export const createSessionSchema = z.object({
   type: z.enum(["behavioral", "technical"]),
   config: z.record(z.string(), z.unknown()).optional(),
   source_star_story_id: z.string().uuid().optional(),
+  use_pro_analysis: z.boolean().optional(),
 });
 
 // ---- Timeline correlator schemas ----

--- a/apps/web/stores/interviewStore.ts
+++ b/apps/web/stores/interviewStore.ts
@@ -36,7 +36,7 @@ interface InterviewState {
   // Actions
   setType: (type: InterviewType) => void;
   setConfig: (partial: Partial<SessionConfig>) => void;
-  createSession: (extraFields?: { source_star_story_id?: string }) => Promise<string | null>;
+  createSession: (extraFields?: { source_star_story_id?: string; use_pro_analysis?: boolean }) => Promise<string | null>;
   clearQuotaError: () => void;
   startSession: () => Promise<void>;
   endSession: () => Promise<void>;
@@ -79,7 +79,7 @@ export const useInterviewStore = create<InterviewState>((set, get) => ({
       config: { ...state.config, ...partial } as SessionConfig,
     })),
 
-  createSession: async (extraFields?: { source_star_story_id?: string }) => {
+  createSession: async (extraFields?: { source_star_story_id?: string; use_pro_analysis?: boolean }) => {
     const { config, type } = get();
     const sessionType = type ?? "behavioral";
     set({ error: null, quotaError: null });


### PR DESCRIPTION
## Summary
- Adds a `use_pro_analysis` boolean column to `interview_sessions` (additive migration 0018, `DEFAULT false NOT NULL`) so each session carries an explicit opt-in rather than inheriting it from plan state at analysis time.
- Feedback tier resolver becomes a 3-way AND: Pro plan AND `session.useProAnalysis = true` AND `getProAnalysisUsage(userId).used < limit`. Quota exhaustion silently falls through to Free — never 402.
- New `GET /api/users/pro-analysis-usage` endpoint exposes live quota to the client; `ProAnalysisToggle` renders in both setup forms for Pro users with a live "N of 10 left" subline and an exhausted-state banner.
- `PRO_ANALYSIS_MONTHLY_LIMIT = 10` constant in `lib/plans.ts`; env-var row added to README env-audit table.

## Behavior

| Plan | `useProAnalysis` | Quota | `analysisTier` |
|------|-----------------|-------|----------------|
| free | any | N/A | `free` |
| pro | false (default) | N/A | `free` |
| pro | true | room remaining | `pro` |
| pro | true | exhausted (10/10) | `free` (silent fallback, logged as `proAnalysisFallback: true`) |

Toggle is hidden entirely for Free users (returns `null`, not a disabled state). Default is OFF — consistent with sibling fields (`gaze_enabled`, `resume_id`), avoids silently burning the 5-10× more expensive model on every warm-up.

Legacy Pro users with `users.planPeriodStart = NULL` fall back to `currentFreePeriodStart()` for the quota window so the derived count stays sane without requiring a data backfill.

## Schema
Migration `0018_lethal_taskmaster.sql` is additive-only:
```sql
ALTER TABLE "interview_sessions" ADD COLUMN "use_pro_analysis" boolean DEFAULT false NOT NULL;
```
No backfill required — existing sessions default to `false`, which means they resolve to Free tier on next feedback request (correct: they were created before the opt-in toggle existed). Usage is derived from `COUNT(*)` on `session_feedback.analysis_tier = 'pro'` (from #188) — no new counter column needed.

## Tests
- Unit / component (97 files, 972 tests): 4 new `ProAnalysisToggle` component tests + 3 new `getProAnalysisUsage` integration-style tests + toggle integration into both setup forms.
- Integration (38 files, 383 tests): 4 new tier-combination tests on feedback POST + 3 new tests on sessions POST + 4 new tests on the usage endpoint. 5 existing Pro-session test seeds updated with `useProAnalysis: true`.
- All tests pass, lint + typecheck clean. `readme-env-audit.test.ts` passes — `PRO_ANALYSIS_MONTHLY_LIMIT` registered.

## Test plan (Vercel preview)

Cover all four tier combinations manually:

- [ ] Sign in as a **Free** user: confirm `ProAnalysisToggle` is not rendered in either setup form
- [ ] Sign in as a **Pro** user with 0 of 10 used: confirm toggle renders with "0 of 10 left this month" subline, switch is enabled; start session with toggle OFF → feedback page shows Free-tier output; start session with toggle ON → feedback page shows Pro-tier output (banner reads "Pro analysis" from #187)
- [ ] Sign in as a **Pro** user with quota exhausted (seed 10 pro-tier rows in DB): confirm exhausted banner renders ("You've used all 10 Pro analyses this month"), no switch rendered; submit session → feedback generated with Free-tier output, no 402
- [ ] Confirm `ProAnalysisToggle` renders an `animate-pulse` skeleton briefly before the usage fetch resolves (throttle network in DevTools to Slow 3G)
- [ ] Confirm `POST /api/sessions` with `use_pro_analysis: true` from a Free-plan account returns `400 use_pro_analysis_requires_pro_plan` (via curl or Postman)
- [ ] Confirm `GET /api/users/pro-analysis-usage` returns `401` when unauthenticated

Closes #190

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>