### PR TITLE
feat(pro): add follow-up pressure slider for behavioral sessions (#178)

### DIFF
--- a/apps/web/app/api/sessions/route.integration.test.ts
+++ b/apps/web/app/api/sessions/route.integration.test.ts
@@ -137,13 +137,15 @@ describe("API /api/sessions (integration)", () => {
     });
   });
 
-  it("POST creates a session without config", async () => {
+  it("POST creates a session without config (free user gets probe_depth=0 default)", async () => {
     mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    // TEST_USER is free by beforeEach default
 
     const res = await POST(makePostRequest({ type: "behavioral" }));
     expect(res.status).toBe(201);
     const data = await res.json();
-    expect(data.config).toEqual({});
+    // probe_depth defaults to 0 for free users (#178)
+    expect(data.config).toEqual({ probe_depth: 0 });
   });
 
   // ---- POST validation errors ----
@@ -858,6 +860,199 @@ describe("API /api/sessions (integration)", () => {
       .from(interviewSessions)
       .where(eq(interviewSessions.id, data.id));
     expect(row.useProAnalysis).toBe(false);
+  });
+
+  // ---- #178: probe_depth gating ----
+
+  describe("probe_depth gating", () => {
+    it("Free + probe_depth: 3 → 402 pro_plan_required", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+      // Plan is "free" by beforeEach default
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: { interview_style: 0.5, difficulty: 0.5, probe_depth: 3 },
+        })
+      );
+      expect(res.status).toBe(402);
+      const data = await res.json();
+      expect(data).toEqual({
+        error: "pro_plan_required",
+        feature: "follow_up_probing",
+        currentPlan: "free",
+      });
+    });
+
+    it("Free + probe_depth: 1 → 402 pro_plan_required", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: { interview_style: 0.5, difficulty: 0.5, probe_depth: 1 },
+        })
+      );
+      expect(res.status).toBe(402);
+      const data = await res.json();
+      expect(data).toEqual({
+        error: "pro_plan_required",
+        feature: "follow_up_probing",
+        currentPlan: "free",
+      });
+    });
+
+    it("Pro + probe_depth: 3 → 201 and persists probe_depth=3 in config", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+      const db = getTestDb();
+      const { eq } = await import("drizzle-orm");
+      await db.update(users).set({ plan: "pro" }).where(eq(users.id, TEST_USER.id));
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: { interview_style: 0.5, difficulty: 0.5, probe_depth: 3 },
+        })
+      );
+      expect(res.status).toBe(201);
+      const data = await res.json();
+
+      const { interviewSessions } = await import("@/lib/schema");
+      const [row] = await db
+        .select()
+        .from(interviewSessions)
+        .where(eq(interviewSessions.id, data.id));
+      expect((row.config as Record<string, unknown>).probe_depth).toBe(3);
+    });
+
+    it("Free + probe_depth: 0 → 201 and persists probe_depth=0", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+      // Plan is "free" by beforeEach default
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: { interview_style: 0.5, difficulty: 0.5, probe_depth: 0 },
+        })
+      );
+      expect(res.status).toBe(201);
+      const data = await res.json();
+
+      const db = getTestDb();
+      const { interviewSessions } = await import("@/lib/schema");
+      const { eq } = await import("drizzle-orm");
+      const [row] = await db
+        .select()
+        .from(interviewSessions)
+        .where(eq(interviewSessions.id, data.id));
+      expect((row.config as Record<string, unknown>).probe_depth).toBe(0);
+    });
+
+    it("Free + no probe_depth → 201 and persisted probe_depth defaults to 0", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+      // Plan is "free" by beforeEach default
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: { interview_style: 0.5, difficulty: 0.5 },
+        })
+      );
+      expect(res.status).toBe(201);
+      const data = await res.json();
+
+      const db = getTestDb();
+      const { interviewSessions } = await import("@/lib/schema");
+      const { eq } = await import("drizzle-orm");
+      const [row] = await db
+        .select()
+        .from(interviewSessions)
+        .where(eq(interviewSessions.id, data.id));
+      expect((row.config as Record<string, unknown>).probe_depth).toBe(0);
+    });
+
+    it("Pro + no probe_depth → 201 and persisted probe_depth defaults to 2", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+      const db = getTestDb();
+      const { eq } = await import("drizzle-orm");
+      await db.update(users).set({ plan: "pro" }).where(eq(users.id, TEST_USER.id));
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: { interview_style: 0.5, difficulty: 0.5 },
+        })
+      );
+      expect(res.status).toBe(201);
+      const data = await res.json();
+
+      const { interviewSessions } = await import("@/lib/schema");
+      const [row] = await db
+        .select()
+        .from(interviewSessions)
+        .where(eq(interviewSessions.id, data.id));
+      expect((row.config as Record<string, unknown>).probe_depth).toBe(2);
+    });
+
+    it("probe_depth out of range (4) → 400 Invalid session config", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: { interview_style: 0.5, difficulty: 0.5, probe_depth: 4 },
+        })
+      );
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("Invalid session config");
+    });
+
+    it("probe_depth non-integer (1.5) → 400 Invalid session config", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: { interview_style: 0.5, difficulty: 0.5, probe_depth: 1.5 },
+        })
+      );
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("Invalid session config");
+    });
+
+    it("Technical sessions ignore probe_depth entirely (Pro user, technical config, no gate)", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+      const db = getTestDb();
+      const { eq } = await import("drizzle-orm");
+      await db.update(users).set({ plan: "pro" }).where(eq(users.id, TEST_USER.id));
+
+      const res = await POST(
+        makePostRequest({
+          type: "technical",
+          config: {
+            interview_type: "leetcode",
+            focus_areas: ["arrays"],
+            language: "python",
+            difficulty: "medium",
+          },
+        })
+      );
+      expect(res.status).toBe(201);
+      const data = await res.json();
+
+      const { interviewSessions } = await import("@/lib/schema");
+      const [row] = await db
+        .select()
+        .from(interviewSessions)
+        .where(eq(interviewSessions.id, data.id));
+      // Technical sessions must NOT have probe_depth written into their config
+      expect((row.config as Record<string, unknown>).probe_depth).toBeUndefined();
+    });
   });
 
   // Regression: the parallel bypass path for the Resume feature. A free

--- a/apps/web/app/api/sessions/route.ts
+++ b/apps/web/app/api/sessions/route.ts
@@ -192,6 +192,36 @@ export async function POST(request: NextRequest) {
     if (gated) return gated;
   }
 
+  // Resolve probe_depth for behavioral sessions. Technical sessions are
+  // explicitly untouched — follow-up pressure applies only to behavioral
+  // sessions. See #178.
+  // Technical sessions ignore probe_depth — follow-up pressure applies only
+  // to behavioral sessions. See #178.
+  let resolvedConfig = config ?? {};
+  if (type === "behavioral") {
+    const rawProbeDepth = config && typeof config === "object"
+      ? (config as Record<string, unknown>).probe_depth
+      : undefined;
+
+    if (typeof rawProbeDepth === "number" && rawProbeDepth > 0) {
+      // Non-zero probe_depth requires Pro
+      const gated = await requireProFeature(session.user.id, "follow_up_probing");
+      if (gated) return gated;
+      // Value already validated by Zod — keep as-is
+      resolvedConfig = { ...resolvedConfig, probe_depth: rawProbeDepth };
+    } else if (rawProbeDepth === 0) {
+      // Explicitly set to 0 — persist it (free users may send 0 explicitly)
+      resolvedConfig = { ...resolvedConfig, probe_depth: 0 };
+    } else {
+      // probe_depth was omitted — apply server-side default based on plan
+      const userPlan = await getCurrentUserPlan(session.user.id);
+      resolvedConfig = {
+        ...resolvedConfig,
+        probe_depth: userPlan === "pro" ? 2 : 0,
+      };
+    }
+  }
+
   // Capture once so the transaction callback closure has a narrowed string
   // (TypeScript loses the `session.user.id` non-null narrowing across the
   // async boundary).
@@ -243,7 +273,7 @@ export async function POST(request: NextRequest) {
         .values({
           userId,
           type,
-          config: config ?? {},
+          config: resolvedConfig,
           sourceStarStoryId: source_star_story_id ?? null,
           useProAnalysis: use_pro_analysis ?? false,
         })

--- a/apps/web/components/interview/BehavioralSetupForm.tsx
+++ b/apps/web/components/interview/BehavioralSetupForm.tsx
@@ -16,6 +16,8 @@ import { ResumeSelector } from "./ResumeSelector";
 import { UpgradePromptDialog } from "@/components/billing/UpgradePromptDialog";
 import { usePrefillStore } from "@/stores/prefillStore";
 import { ProAnalysisToggle } from "./ProAnalysisToggle";
+import { usePlan } from "@/hooks/usePlan";
+import { ProbeDepthControl } from "./ProbeDepthControl";
 import type { BehavioralSessionConfig } from "@preploy/shared";
 
 interface CompanyQuestion {
@@ -43,6 +45,7 @@ function difficultyLabel(v: number): string {
 
 export function BehavioralSetupForm() {
   const router = useRouter();
+  const { plan } = usePlan();
   const { config, setConfig, setType, createSession } = useInterviewStore();
   const quotaError = useInterviewStore((s) => s.quotaError);
   const clearQuotaError = useInterviewStore((s) => s.clearQuotaError);
@@ -342,6 +345,11 @@ export function BehavioralSetupForm() {
                   <span>Senior / Staff</span>
                 </div>
               </div>
+
+              <ProbeDepthControl
+                value={behavioralConfig.probe_depth ?? (plan === "pro" ? 2 : 0)}
+                onChange={(n) => setConfig({ probe_depth: n })}
+              />
             </CardContent>
           </Card>
 

--- a/apps/web/components/interview/ProbeDepthControl.test.tsx
+++ b/apps/web/components/interview/ProbeDepthControl.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — must be before any imports that use these modules
+// ---------------------------------------------------------------------------
+const { mockUsePlan } = vi.hoisted(() => ({
+  mockUsePlan: vi.fn(),
+}));
+
+vi.mock("@/hooks/usePlan", () => ({
+  usePlan: () => mockUsePlan(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import component after mocks
+// ---------------------------------------------------------------------------
+import { ProbeDepthControl } from "./ProbeDepthControl";
+
+describe("ProbeDepthControl", () => {
+  it("renders 3 toggle buttons for Pro users", () => {
+    mockUsePlan.mockReturnValue({ plan: "pro" });
+    render(<ProbeDepthControl value={2} onChange={() => {}} />);
+
+    expect(screen.getAllByText("Gentle").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Standard").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Intense").length).toBeGreaterThan(0);
+  });
+
+  it("clicking Standard calls onChange(2)", async () => {
+    mockUsePlan.mockReturnValue({ plan: "pro" });
+    const onChange = vi.fn();
+    render(<ProbeDepthControl value={1} onChange={onChange} />);
+
+    // Click the "Standard" button
+    const standardBtn = screen.getAllByText("Standard")[0];
+    await userEvent.click(standardBtn);
+
+    expect(onChange).toHaveBeenCalledWith(2);
+    // Ensure it's called with a number, not a string
+    expect(typeof onChange.mock.calls[0][0]).toBe("number");
+  });
+
+  it("renders the locked pill for Free users", () => {
+    mockUsePlan.mockReturnValue({ plan: "free" });
+    render(<ProbeDepthControl value={0} onChange={() => {}} />);
+
+    expect(screen.getAllByText(/Available on Pro/i).length).toBeGreaterThan(0);
+
+    // No toggle buttons in the DOM
+    expect(screen.queryByText("Gentle")).toBeNull();
+    expect(screen.queryByText("Standard")).toBeNull();
+    expect(screen.queryByText("Intense")).toBeNull();
+  });
+
+  it("renders nothing while plan is loading", () => {
+    mockUsePlan.mockReturnValue({ plan: undefined });
+    const { container } = render(<ProbeDepthControl value={0} onChange={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/web/components/interview/ProbeDepthControl.tsx
+++ b/apps/web/components/interview/ProbeDepthControl.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Sparkles } from "lucide-react";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { usePlan } from "@/hooks/usePlan";
+
+interface ProbeDepthControlProps {
+  value: 0 | 1 | 2 | 3;
+  onChange: (next: 0 | 1 | 2 | 3) => void;
+}
+
+const LEVELS: { value: "1" | "2" | "3"; label: string; sub: string }[] = [
+  { value: "1", label: "Gentle", sub: "(up to 1 follow-up)" },
+  { value: "2", label: "Standard", sub: "(up to 2)" },
+  { value: "3", label: "Intense", sub: "(up to 3)" },
+];
+
+export function ProbeDepthControl({ value, onChange }: ProbeDepthControlProps) {
+  const { plan } = usePlan();
+
+  // Render nothing while plan is loading (undefined)
+  if (plan === undefined) return null;
+
+  // Free users: locked cedar pill
+  if (plan === "free") {
+    return (
+      <a
+        href="/pricing#follow_up_probing"
+        className="block rounded-lg border border-[color:var(--primary)]/30 bg-[color:var(--primary)]/5 px-4 py-3 transition-colors hover:bg-[color:var(--primary)]/10"
+      >
+        <div className="flex items-center gap-2">
+          <Sparkles
+            className="h-4 w-4 shrink-0 text-[color:var(--primary)]"
+            aria-hidden="true"
+          />
+          <span className="text-sm font-medium">Follow-up pressure</span>
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Available on Pro — probe up to 3 layers deep per question.
+        </p>
+      </a>
+    );
+  }
+
+  // Pro users: ToggleGroup with three options.
+  // Base UI ToggleGroup uses value as readonly string[] (array, not single string).
+  // We enforce single-select by using multiple={false} and extracting the first
+  // element from the array in onValueChange.
+  const selectedValues: readonly string[] =
+    value > 0 ? [String(value)] : ["2"]; // default to "2" (Standard) for display
+
+  return (
+    <div
+      role="group"
+      aria-label="Follow-up pressure"
+      className="rounded-lg border border-border px-4 py-3 space-y-3"
+    >
+      <div>
+        <p className="text-sm font-medium">Follow-up pressure</p>
+        <p className="text-xs text-muted-foreground">
+          How hard should the interviewer push?
+        </p>
+      </div>
+      <ToggleGroup
+        value={selectedValues}
+        onValueChange={(groupValue: string[]) => {
+          // Guard: Base UI fires with [] when deselecting. Keep last selection.
+          if (!groupValue || groupValue.length === 0) return;
+          // Last pressed item wins (Base UI appends new values to the array)
+          const raw = groupValue[groupValue.length - 1];
+          const n = parseInt(raw, 10) as 1 | 2 | 3;
+          if (n === 1 || n === 2 || n === 3) {
+            onChange(n);
+          }
+        }}
+        className="grid grid-cols-3 gap-2"
+      >
+        {LEVELS.map(({ value: lvVal, label, sub }) => (
+          <ToggleGroupItem
+            key={lvVal}
+            value={lvVal}
+            className="flex h-auto flex-col gap-0.5 rounded-md border px-3 py-2 data-[pressed]:border-[color:var(--primary)] data-[pressed]:bg-[color:var(--primary)]/10 data-[pressed]:text-[color:var(--primary)]"
+          >
+            <span className="text-sm font-medium">{label}</span>
+            <span className="text-[10px] font-normal text-muted-foreground">
+              {sub}
+            </span>
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+    </div>
+  );
+}

--- a/apps/web/components/ui/toggle-group.tsx
+++ b/apps/web/components/ui/toggle-group.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import * as React from "react"
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle"
+import { ToggleGroup as ToggleGroupPrimitive } from "@base-ui/react/toggle-group"
+import { type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: "horizontal" | "vertical"
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 0,
+  orientation: "horizontal",
+})
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 0,
+  orientation = "horizontal",
+  children,
+  ...props
+}: ToggleGroupPrimitive.Props &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: "horizontal" | "vertical"
+  }) {
+  return (
+    <ToggleGroupPrimitive
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      data-orientation={orientation}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] rounded-lg data-[size=sm]:rounded-[min(var(--radius-md),10px)] data-vertical:flex-col data-vertical:items-stretch",
+        className
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider
+        value={{ variant, size, spacing, orientation }}
+      >
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive>
+  )
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant = "default",
+  size = "default",
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <TogglePrimitive
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        "shrink-0 group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-2 focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-lg group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-lg group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-lg group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-lg group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t",
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </TogglePrimitive>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }

--- a/apps/web/components/ui/toggle.tsx
+++ b/apps/web/components/ui/toggle.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-lg text-sm font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted data-[state=on]:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline: "border border-input bg-transparent hover:bg-muted",
+      },
+      size: {
+        default:
+          "h-8 min-w-8 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        sm: "h-7 min-w-7 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 min-w-9 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Toggle({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Toggle, toggleVariants }

--- a/apps/web/lib/features.test.ts
+++ b/apps/web/lib/features.test.ts
@@ -37,3 +37,13 @@ describe("FEATURE_MATRIX", () => {
     }
   });
 });
+
+describe("follow_up_probing feature (#178)", () => {
+  it("pro plan HAS follow_up_probing", () => {
+    expect(hasFeature("pro", "follow_up_probing")).toBe(true);
+  });
+
+  it("free plan does NOT have follow_up_probing", () => {
+    expect(hasFeature("free", "follow_up_probing")).toBe(false);
+  });
+});

--- a/apps/web/lib/features.ts
+++ b/apps/web/lib/features.ts
@@ -25,7 +25,10 @@ export type FeatureKey =
   | "planner"
   /** Resume upload + resume-tailored question generation (/resume, and the
    *  resume-selector dropdowns in the behavioral + technical setup pages). */
-  | "resume";
+  | "resume"
+  /** Interviewer follow-up pressure — probes up to 3 layers deep per question.
+   *  See #178. */
+  | "follow_up_probing";
 
 /**
  * Which plan tiers grant access to each feature. A feature is unlocked iff
@@ -34,6 +37,7 @@ export type FeatureKey =
 export const FEATURE_MATRIX: Record<FeatureKey, readonly Plan[]> = {
   planner: ["pro"],
   resume: ["pro"],
+  follow_up_probing: ["pro"],
 };
 
 /**
@@ -84,6 +88,17 @@ export const FEATURE_META: Record<
       "PDF + plain-text resume ingestion",
       "Company-specific questions referencing your real projects",
       "Attach the resume to any behavioral or technical session setup",
+    ],
+  },
+  follow_up_probing: {
+    label: "Follow-up pressure",
+    href: "/pricing#follow_up_probing",
+    tagline:
+      "Get an interviewer that probes up to three layers deep — impact, reasoning, counterfactual — just like a real panel.",
+    benefits: [
+      "Interviewer asks follow-ups per question before moving on",
+      "Gentle / Standard / Intense — pick how hard you want to be pushed",
+      "Trains you to go past surface-level STAR answers",
     ],
   },
 };

--- a/apps/web/lib/prompts.test.ts
+++ b/apps/web/lib/prompts.test.ts
@@ -213,4 +213,47 @@ describe("buildBehavioralSystemPrompt", () => {
     const prompt = buildBehavioralSystemPrompt(DEFAULT_CONFIG);
     expect(prompt).toContain("Do NOT answer your own question");
   });
+
+  // ---- #178: probe_depth / follow-up pressure ----
+
+  it("probe_depth > 0 injects the follow-up directive", () => {
+    const prompt = buildBehavioralSystemPrompt({
+      ...DEFAULT_CONFIG,
+      probe_depth: 2,
+    });
+    expect(prompt).toContain("Follow-up depth for this session: 2");
+    expect(prompt).toContain("business impact");
+  });
+
+  it("probe_depth: 0 omits the follow-up directive", () => {
+    const prompt = buildBehavioralSystemPrompt({
+      ...DEFAULT_CONFIG,
+      probe_depth: 0,
+    });
+    expect(prompt).not.toContain("Follow-up depth for this session");
+  });
+
+  it("missing probe_depth omits the follow-up directive", () => {
+    const prompt = buildBehavioralSystemPrompt(DEFAULT_CONFIG);
+    expect(prompt).not.toContain("Follow-up depth for this session");
+  });
+
+  it("probe_depth: 3 uses N=3 in the directive", () => {
+    const prompt = buildBehavioralSystemPrompt({
+      ...DEFAULT_CONFIG,
+      probe_depth: 3,
+    });
+    expect(prompt).toContain("Follow-up depth for this session: 3");
+  });
+
+  it("probe_depth directive overrides the 'ask one follow-up' default", () => {
+    const prompt = buildBehavioralSystemPrompt({
+      ...DEFAULT_CONFIG,
+      probe_depth: 2,
+    });
+    // The interview flow block contains the "ask one follow-up" line
+    expect(prompt).toContain("ask one follow-up");
+    // The probe_depth block explicitly overrides it
+    expect(prompt).toContain("This directive overrides any earlier");
+  });
 });

--- a/apps/web/lib/prompts.ts
+++ b/apps/web/lib/prompts.ts
@@ -96,6 +96,16 @@ export function buildBehavioralSystemPrompt(
 5. End with a polite closing.`
   );
 
+  // Follow-up pressure (probe_depth) — Pro-only. Injected AFTER "Interview flow"
+  // and BEFORE "Conciseness". When probe_depth is 0 or absent, this section is
+  // omitted entirely so Free-tier behavior is identical to today. See #178.
+  if (config.probe_depth && config.probe_depth > 0) {
+    const n = config.probe_depth;
+    sections.push(
+      `Follow-up depth for this session: ${n}. After the candidate's initial answer to each behavioral question, probe up to ${n} follow-up turns before moving on. Each probe must target a different dimension, in this order of preference: (1) business impact — "What was the measurable outcome? Numbers if you have them.", (2) reasoning — "Why that approach over the alternatives?", (3) counterfactual — "Knowing what you know now, what would you do differently?". Stop probing early if the candidate has already covered a dimension or is clearly out of material — do NOT repeat yourself and do NOT probe past ${n} turns. After the final probe, acknowledge briefly ("Got it — thanks.") and move to the next question. Probing is conversational, not adversarial: stay warm, one question at a time, never stack three questions in one turn. This directive overrides any earlier "ask one follow-up" instruction for this session.`
+    );
+  }
+
   // Conciseness — replaces the old "2-3 sentences maximum" constraint (108-D)
   sections.push(
     "Be conversational, not essayistic. Cap each turn at 3 sentences for questions and follow-ups; up to 5 sentences only when setting context for a new topic. This is a voice conversation — long monologues feel unnatural."

--- a/apps/web/lib/validations.ts
+++ b/apps/web/lib/validations.ts
@@ -9,6 +9,7 @@ export const behavioralConfigSchema = z.object({
     .optional(),
   interview_style: z.number().min(0).max(1),
   difficulty: z.number().min(0).max(1),
+  probe_depth: z.number().int().min(0).max(3).optional(),
 });
 
 export const technicalConfigSchema = z.object({

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -48,6 +48,10 @@ export interface BehavioralSessionConfig {
   resume_id?: string;
   resume_text?: string; // populated at session start, not stored in DB
   gaze_enabled?: boolean; // per-session opt-in (only shown when user has gaze_tracking_enabled)
+  // Pro-only. Number of interviewer follow-up layers per question during the
+  // behavioral session. 0 = no probing (Free default). 2 = Pro default
+  // (Standard). 3 = Intense. See #178.
+  probe_depth?: 0 | 1 | 2 | 3;
 }
 
 export interface TechnicalSessionConfig {


### PR DESCRIPTION
## Summary
- Adds a `probe_depth` (0–3) field to `BehavioralSessionConfig` that controls how many interviewer follow-up layers fire per behavioral question.
- Free users see a locked cedar pill linking to `/pricing#follow_up_probing`; Pro users see a Gentle / Standard / Intense ToggleGroup with Standard (2) pre-selected.
- Server enforces the gate: `probe_depth > 0` from a Free user returns 402 `pro_plan_required`; `probe_depth: 0` explicit or omitted passes through to set the plan-appropriate default (Pro → 2, Free → 0) stored in `interview_sessions.config` jsonb — no schema migration required.
- Prompt directive injected after the "Interview flow" block when `probe_depth > 0`, explicitly neutralizing the existing "ask one follow-up" instruction.

## Behavior

| User | Client sends | Result |
|------|-------------|--------|
| Free | `probe_depth` omitted | 201, `probe_depth: 0` persisted; no probing |
| Free | `probe_depth: 0` explicit | 201, `probe_depth: 0` persisted; no probing |
| Free | `probe_depth: 1–3` | 402 `pro_plan_required` |
| Pro | `probe_depth` omitted | 201, `probe_depth: 2` (Standard) persisted |
| Pro | `probe_depth: 1–3` explicit | 201, specified depth persisted |

Technical sessions explicitly excluded from `probe_depth` resolution in all code paths.

**Default of 2 (not 3) for Pro:** the middle of the range, so users can opt up to Intense or down to Gentle. Defaulting to max would leave no room to "go deeper than default."

## Prompt change
When `probe_depth > 0`, a "Follow-up depth for this session: N" directive is appended to the behavioral system prompt. It instructs the interviewer to probe up to N turns per question across three ordered dimensions — business impact, reasoning, counterfactual — and to stop early once the candidate has covered a dimension. The directive ends with "This directive overrides any earlier 'ask one follow-up' instruction for this session" to neutralize the pre-existing default probing line.

## Test plan
- [ ] Sign in as a **Pro user**, open Behavioral Setup — confirm the "Follow-up pressure" ToggleGroup appears with "Standard" visually selected (value 2)
- [ ] Toggle to "Intense" — start a session — confirm the live interviewer asks follow-up questions after each behavioral answer (up to 3 layers)
- [ ] Toggle to "Gentle" — start a session — confirm no more than 1 follow-up per question
- [ ] Sign in as a **Free user**, open Behavioral Setup — confirm the cedar locked pill appears ("Available on Pro") and the toggle buttons are absent
- [ ] As a Free user, attempt to start a session via the API with `probe_depth: 1` (curl or DevTools) — confirm 402 response with `{ "error": "pro_plan_required", "feature": "follow_up_probing" }`
- [ ] As a Free user, start a normal behavioral session — confirm it proceeds without probing (same experience as before #178)
- [ ] Start a Technical session as a Pro user — confirm no `probe_depth` key appears in the persisted config

Closes #178

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>