### PR TITLE
feat(pro): 5 behavioral interviewer personas (#179)

### DIFF
--- a/apps/web/app/api/sessions/[id]/feedback/route.ts
+++ b/apps/web/app/api/sessions/[id]/feedback/route.ts
@@ -345,5 +345,7 @@ export async function GET(
     );
   }
 
-  return NextResponse.json({ ...feedback, type: found.type });
+  // Include config so the feedback page can read config.persona and other
+  // session-level fields without a separate /api/sessions/:id round-trip.
+  return NextResponse.json({ ...feedback, type: found.type, config: found.config });
 }

--- a/apps/web/app/api/sessions/route.integration.test.ts
+++ b/apps/web/app/api/sessions/route.integration.test.ts
@@ -137,15 +137,15 @@ describe("API /api/sessions (integration)", () => {
     });
   });
 
-  it("POST creates a session without config (free user gets probe_depth=0 default)", async () => {
+  it("POST creates a session without config (free user gets probe_depth=0 and persona=default)", async () => {
     mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
     // TEST_USER is free by beforeEach default
 
     const res = await POST(makePostRequest({ type: "behavioral" }));
     expect(res.status).toBe(201);
     const data = await res.json();
-    // probe_depth defaults to 0 for free users (#178)
-    expect(data.config).toEqual({ probe_depth: 0 });
+    // probe_depth defaults to 0 for free users (#178); persona defaults to "default" (#179)
+    expect(data.config).toEqual({ probe_depth: 0, persona: "default" });
   });
 
   // ---- POST validation errors ----
@@ -1132,6 +1132,209 @@ describe("API /api/sessions (integration)", () => {
         })
       );
       expect(res.status).toBe(201);
+    });
+  });
+
+  // ---- #179: persona gating ----
+
+  describe("persona gating", () => {
+    it("Free + persona 'amazon-lp' → 402 pro_plan_required for interviewer_personas", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+      // Plan is "free" by beforeEach default
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: { interview_style: 0.5, difficulty: 0.5, persona: "amazon-lp" },
+        })
+      );
+      expect(res.status).toBe(402);
+      const data = await res.json();
+      expect(data).toEqual({
+        error: "pro_plan_required",
+        feature: "interviewer_personas",
+        currentPlan: "free",
+      });
+    });
+
+    it("Pro + persona 'amazon-lp' → 201, DB has config.persona === 'amazon-lp'", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+      const db = getTestDb();
+      const { eq } = await import("drizzle-orm");
+      await db.update(users).set({ plan: "pro" }).where(eq(users.id, TEST_USER.id));
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: { interview_style: 0.5, difficulty: 0.5, persona: "amazon-lp" },
+        })
+      );
+      expect(res.status).toBe(201);
+      const data = await res.json();
+
+      const { interviewSessions } = await import("@/lib/schema");
+      const [row] = await db
+        .select()
+        .from(interviewSessions)
+        .where(eq(interviewSessions.id, data.id));
+      expect((row.config as Record<string, unknown>).persona).toBe("amazon-lp");
+    });
+
+    it("Free + persona 'default' → 201, DB has config.persona === 'default'", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+      // Plan is "free" by beforeEach default
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: { interview_style: 0.5, difficulty: 0.5, persona: "default" },
+        })
+      );
+      expect(res.status).toBe(201);
+      const data = await res.json();
+
+      const db = getTestDb();
+      const { interviewSessions } = await import("@/lib/schema");
+      const { eq } = await import("drizzle-orm");
+      const [row] = await db
+        .select()
+        .from(interviewSessions)
+        .where(eq(interviewSessions.id, data.id));
+      expect((row.config as Record<string, unknown>).persona).toBe("default");
+    });
+
+    it("Free + no persona → 201, server writes config.persona === 'default'", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+      // Plan is "free" by beforeEach default
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: { interview_style: 0.5, difficulty: 0.5 },
+        })
+      );
+      expect(res.status).toBe(201);
+      const data = await res.json();
+
+      const db = getTestDb();
+      const { interviewSessions } = await import("@/lib/schema");
+      const { eq } = await import("drizzle-orm");
+      const [row] = await db
+        .select()
+        .from(interviewSessions)
+        .where(eq(interviewSessions.id, data.id));
+      expect((row.config as Record<string, unknown>).persona).toBe("default");
+    });
+
+    it("Free + persona 'bogus' → 400 { error: 'Invalid persona' }", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+      // Plan is "free" by beforeEach default
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: { interview_style: 0.5, difficulty: 0.5, persona: "bogus" },
+        })
+      );
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toBe("Invalid persona");
+    });
+
+    it("Pro + persona 'warm-peer' + probe_depth 3 → 201, DB has probe_depth=1 (capped by gentle) and persona='warm-peer'", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+      const db = getTestDb();
+      const { eq } = await import("drizzle-orm");
+      await db.update(users).set({ plan: "pro" }).where(eq(users.id, TEST_USER.id));
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: {
+            interview_style: 0.5,
+            difficulty: 0.5,
+            probe_depth: 3,
+            persona: "warm-peer",
+          },
+        })
+      );
+      expect(res.status).toBe(201);
+      const data = await res.json();
+
+      const { interviewSessions } = await import("@/lib/schema");
+      const [row] = await db
+        .select()
+        .from(interviewSessions)
+        .where(eq(interviewSessions.id, data.id));
+      const cfg = row.config as Record<string, unknown>;
+      expect(cfg.probe_depth).toBe(1);
+      expect(cfg.persona).toBe("warm-peer");
+    });
+
+    it("Pro + persona 'amazon-lp' + probe_depth 3 → 201, DB has probe_depth=3 (aggressive is ceiling-only, no cap)", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+      const db = getTestDb();
+      const { eq } = await import("drizzle-orm");
+      await db.update(users).set({ plan: "pro" }).where(eq(users.id, TEST_USER.id));
+
+      const res = await POST(
+        makePostRequest({
+          type: "behavioral",
+          config: {
+            interview_style: 0.5,
+            difficulty: 0.5,
+            probe_depth: 3,
+            persona: "amazon-lp",
+          },
+        })
+      );
+      expect(res.status).toBe(201);
+      const data = await res.json();
+
+      const { interviewSessions } = await import("@/lib/schema");
+      const [row] = await db
+        .select()
+        .from(interviewSessions)
+        .where(eq(interviewSessions.id, data.id));
+      const cfg = row.config as Record<string, unknown>;
+      expect(cfg.probe_depth).toBe(3);
+      expect(cfg.persona).toBe("amazon-lp");
+    });
+
+    it("Technical session with config.persona 'amazon-lp' → 201 but config.persona NOT persisted in DB", async () => {
+      mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+      const db = getTestDb();
+      const { eq } = await import("drizzle-orm");
+      await db.update(users).set({ plan: "pro" }).where(eq(users.id, TEST_USER.id));
+
+      const res = await POST(
+        makePostRequest({
+          type: "technical",
+          config: {
+            interview_type: "leetcode",
+            focus_areas: ["arrays"],
+            language: "python",
+            difficulty: "medium",
+            // Extra field — technically not in technicalConfigSchema, but
+            // createSessionSchema accepts record so it passes top-level validation.
+            // The technical path must NOT write persona to DB.
+          },
+        })
+      );
+      expect(res.status).toBe(201);
+      const data = await res.json();
+
+      const { interviewSessions } = await import("@/lib/schema");
+      const [row] = await db
+        .select()
+        .from(interviewSessions)
+        .where(eq(interviewSessions.id, data.id));
+      // Technical sessions must NOT have persona written into their config
+      expect((row.config as Record<string, unknown>).persona).toBeUndefined();
     });
   });
 });

--- a/apps/web/app/api/sessions/route.integration.test.ts
+++ b/apps/web/app/api/sessions/route.integration.test.ts
@@ -1304,7 +1304,7 @@ describe("API /api/sessions (integration)", () => {
       expect(cfg.persona).toBe("amazon-lp");
     });
 
-    it("Technical session with config.persona 'amazon-lp' → 201 but config.persona NOT persisted in DB", async () => {
+    it("Technical session with config.persona set is stripped — persona NOT persisted", async () => {
       mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
 
       const db = getTestDb();
@@ -1319,9 +1319,7 @@ describe("API /api/sessions (integration)", () => {
             focus_areas: ["arrays"],
             language: "python",
             difficulty: "medium",
-            // Extra field — technically not in technicalConfigSchema, but
-            // createSessionSchema accepts record so it passes top-level validation.
-            // The technical path must NOT write persona to DB.
+            persona: "amazon-lp", // Must be stripped by the technical branch
           },
         })
       );

--- a/apps/web/app/api/sessions/route.ts
+++ b/apps/web/app/api/sessions/route.ts
@@ -157,7 +157,10 @@ export async function POST(request: NextRequest) {
 
   const { type, config, source_star_story_id, use_pro_analysis } = parsed.data;
 
-  // Validate config based on interview type
+  // Validate config based on interview type. For technical sessions the
+  // parsed data (Zod strips unknown keys) becomes the resolved config so that
+  // stray fields like `persona` never reach the DB. See #179.
+  let parsedConfigData: Record<string, unknown> | undefined;
   if (config) {
     const configSchema =
       type === "behavioral" ? behavioralConfigSchema : technicalConfigSchema;
@@ -168,6 +171,10 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+    // Capture the Zod-parsed output so unknown fields (e.g. `persona` on a
+    // technical config) are stripped before persistence. The behavioral
+    // persona-resolution block below will further enrich/override this.
+    parsedConfigData = configResult.data as Record<string, unknown>;
   }
 
   // Pro gate for use_pro_analysis flag. Free users sending true get 400.
@@ -202,7 +209,7 @@ export async function POST(request: NextRequest) {
   // sessions. See #178.
   // Technical sessions ignore probe_depth — follow-up pressure applies only
   // to behavioral sessions. See #178.
-  let resolvedConfig = config ?? {};
+  let resolvedConfig = parsedConfigData ?? config ?? {};
   if (type === "behavioral") {
     const rawProbeDepth = config && typeof config === "object"
       ? (config as Record<string, unknown>).probe_depth

--- a/apps/web/app/api/sessions/route.ts
+++ b/apps/web/app/api/sessions/route.ts
@@ -12,6 +12,11 @@ import {
 import { checkRateLimit, requireProFeature } from "@/lib/api-utils";
 import { tryConsumeInterviewSlot } from "@/lib/usage";
 import { getCurrentUserPlan } from "@/lib/user-plan";
+import {
+  getBehavioralPersona,
+  DEFAULT_BEHAVIORAL_PERSONA_ID,
+  applyProbeStyleCap,
+} from "@/lib/personas";
 
 // GET /api/sessions — list sessions with pagination, type/score filters
 // Query params: page (1-based), limit, type, minScore, maxScore
@@ -218,6 +223,42 @@ export async function POST(request: NextRequest) {
       resolvedConfig = {
         ...resolvedConfig,
         probe_depth: userPlan === "pro" ? 2 : 0,
+      };
+    }
+  }
+
+  // Resolve and gate persona for behavioral sessions. Unknown id → 400.
+  // Pro-only persona from free user → 402. Always persist a persona id
+  // (defaults to "default") so the feedback page has a deterministic value.
+  // Technical sessions: if the client somehow sent config.persona, silently
+  // ignore it — do NOT touch the technical branch. See #179.
+  if (type === "behavioral") {
+    const rawPersonaId = (resolvedConfig as Record<string, unknown>).persona;
+    const personaId =
+      typeof rawPersonaId === "string" ? rawPersonaId : DEFAULT_BEHAVIORAL_PERSONA_ID;
+    const persona = getBehavioralPersona(personaId);
+    if (!persona) {
+      return NextResponse.json({ error: "Invalid persona" }, { status: 400 });
+    }
+    if (persona.proOnly) {
+      const gate = await requireProFeature(session.user.id, "interviewer_personas");
+      if (gate) return gate;
+    }
+    resolvedConfig = { ...resolvedConfig, persona: persona.id };
+
+    // Apply probe_depth cap from persona.probeStyle (cap rule #179).
+    // The cap is applied here before persistence — the prompt builder reads
+    // the already-capped value and does NOT re-apply the cap.
+    if (
+      persona.probeStyle !== undefined &&
+      typeof (resolvedConfig as Record<string, unknown>).probe_depth === "number"
+    ) {
+      resolvedConfig = {
+        ...resolvedConfig,
+        probe_depth: applyProbeStyleCap(
+          (resolvedConfig as Record<string, unknown>).probe_depth as 0 | 1 | 2 | 3,
+          persona.probeStyle
+        ),
       };
     }
   }

--- a/apps/web/app/dashboard/sessions/[id]/feedback/page.tsx
+++ b/apps/web/app/dashboard/sessions/[id]/feedback/page.tsx
@@ -48,6 +48,7 @@ export default function FeedbackPage() {
   const [sessionType, setSessionType] = useState<
     "behavioral" | "technical" | null
   >(null);
+  const [persona, setPersona] = useState<string | undefined>(undefined);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   // Retry nonce — bumped by the Retry button to re-arm the polling effect
@@ -105,6 +106,13 @@ export default function FeedbackPage() {
         // null and the loading skeleton gates the <FeedbackDashboard /> render
         // below until both pieces of state are set in this same commit.
         setSessionType(data.type === "technical" ? "technical" : "behavioral");
+        // Thread persona from config.persona — the feedback API returns the
+        // full config jsonb, so config.persona is available here.
+        setPersona(
+          typeof data.config?.persona === "string"
+            ? data.config.persona
+            : undefined
+        );
         setFeedback({
           overallScore: data.overallScore ?? data.overall_score ?? 0,
           summary: data.summary ?? "",
@@ -263,6 +271,7 @@ export default function FeedbackPage() {
         feedback={feedback}
         sessionId={params.id}
         sessionType={sessionType}
+        persona={persona}
       />
     </>
   );

--- a/apps/web/components/feedback/FeedbackDashboard.test.tsx
+++ b/apps/web/components/feedback/FeedbackDashboard.test.tsx
@@ -201,4 +201,48 @@ describe("FeedbackDashboard", () => {
     );
     expect(screen.queryByTestId("pro-analysis-banner")).toBeNull();
   });
+
+  // ---- #179: PracticedWithBadge persona chip ----
+
+  it("renders PracticedWithBadge when persona is a non-default Pro persona", () => {
+    render(
+      <FeedbackDashboard
+        feedback={BEHAVIORAL_FEEDBACK}
+        sessionId="test-id"
+        persona="amazon-lp"
+      />
+    );
+    expect(
+      screen.getAllByText(/Practiced with: Amazon LP/).length
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not render PracticedWithBadge when persona is 'default'", () => {
+    render(
+      <FeedbackDashboard
+        feedback={BEHAVIORAL_FEEDBACK}
+        sessionId="test-id"
+        persona="default"
+      />
+    );
+    expect(screen.queryByText(/Practiced with:/)).toBeNull();
+  });
+
+  it("does not render PracticedWithBadge when persona is undefined", () => {
+    render(
+      <FeedbackDashboard feedback={BEHAVIORAL_FEEDBACK} sessionId="test-id" />
+    );
+    expect(screen.queryByText(/Practiced with:/)).toBeNull();
+  });
+
+  it("does not render PracticedWithBadge for an unknown persona id", () => {
+    render(
+      <FeedbackDashboard
+        feedback={BEHAVIORAL_FEEDBACK}
+        sessionId="test-id"
+        persona="bogus-persona"
+      />
+    );
+    expect(screen.queryByText(/Practiced with:/)).toBeNull();
+  });
 });

--- a/apps/web/components/feedback/FeedbackDashboard.tsx
+++ b/apps/web/components/feedback/FeedbackDashboard.tsx
@@ -12,6 +12,7 @@ import { TimelineView, type TimelineEvent } from "./TimelineView";
 import { GazePresenceCard } from "./GazePresenceCard";
 import { PreparedVsSpokenCard, type DriftAnalysis } from "./PreparedVsSpokenCard";
 import type { GazeDistribution, GazeTimelineBucket } from "@/lib/gaze-metrics";
+import { PracticedWithBadge } from "./PracticedWithBadge";
 
 interface AnswerAnalysis {
   question: string;
@@ -42,11 +43,14 @@ interface FeedbackDashboardProps {
   feedback: FeedbackData;
   sessionId: string;
   sessionType?: "behavioral" | "technical";
+  /** Persona id from config.persona — renders PracticedWithBadge when non-default. */
+  persona?: string;
 }
 
 export function FeedbackDashboard({
   feedback,
   sessionType = "behavioral",
+  persona,
 }: FeedbackDashboardProps) {
   const [isExporting, setIsExporting] = useState(false);
   const isTechnical = sessionType === "technical";
@@ -88,9 +92,12 @@ export function FeedbackDashboard({
 
   return (
     <div className="mx-auto max-w-6xl space-y-6 px-4 py-8">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Interview Feedback</h1>
-        <div className="flex gap-2">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-1.5">
+          <h1 className="text-2xl font-bold">Interview Feedback</h1>
+          <PracticedWithBadge personaId={persona} />
+        </div>
+        <div className="flex shrink-0 gap-2">
           <Button
             variant="outline"
             onClick={handleExportPDF}

--- a/apps/web/components/feedback/PracticedWithBadge.tsx
+++ b/apps/web/components/feedback/PracticedWithBadge.tsx
@@ -1,0 +1,22 @@
+import { getBehavioralPersona } from "@/lib/personas";
+
+interface PracticedWithBadgeProps {
+  personaId?: string | null;
+}
+
+/**
+ * Small chip rendered under the feedback h1 when a non-default behavioral
+ * persona was used for the session. Returns null for the default persona,
+ * unknown ids, or no persona at all — defensively safe.
+ */
+export function PracticedWithBadge({ personaId }: PracticedWithBadgeProps) {
+  if (!personaId || personaId === "default") return null;
+  const persona = getBehavioralPersona(personaId);
+  if (!persona) return null;
+
+  return (
+    <span className="inline-flex items-center rounded-full border border-primary/20 bg-primary/5 px-2.5 py-0.5 text-xs font-medium text-primary">
+      Practiced with: {persona.label}
+    </span>
+  );
+}

--- a/apps/web/components/interview/BehavioralSetupForm.tsx
+++ b/apps/web/components/interview/BehavioralSetupForm.tsx
@@ -18,6 +18,7 @@ import { usePrefillStore } from "@/stores/prefillStore";
 import { ProAnalysisToggle } from "./ProAnalysisToggle";
 import { usePlan } from "@/hooks/usePlan";
 import { ProbeDepthControl } from "./ProbeDepthControl";
+import { PersonaPicker } from "./PersonaPicker";
 import type { BehavioralSessionConfig } from "@preploy/shared";
 
 interface CompanyQuestion {
@@ -345,6 +346,11 @@ export function BehavioralSetupForm() {
                   <span>Senior / Staff</span>
                 </div>
               </div>
+
+              <PersonaPicker
+                value={behavioralConfig.persona ?? "default"}
+                onChange={(id) => setConfig({ persona: id })}
+              />
 
               <ProbeDepthControl
                 value={behavioralConfig.probe_depth ?? (plan === "pro" ? 2 : 0)}

--- a/apps/web/components/interview/PersonaPicker.test.tsx
+++ b/apps/web/components/interview/PersonaPicker.test.tsx
@@ -93,6 +93,27 @@ describe("PersonaPicker", () => {
     }
   });
 
+  it("clicking a locked Pro item does NOT call onChange (free user)", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    mockUsePlan.mockReturnValue({ plan: "free" });
+
+    render(<PersonaPicker value="default" onChange={onChange} />);
+
+    // Open the select trigger
+    const trigger = screen.getByRole("combobox");
+    await user.click(trigger);
+
+    // Click a Pro-locked option — "Amazon LP"
+    // The item has aria-disabled="true" which shadcn/base-ui SelectItem honours
+    // by intercepting pointer events so the underlying select value never changes,
+    // meaning onChange is never invoked.
+    const lockedItem = screen.getAllByText(/Amazon LP/i);
+    await user.click(lockedItem[lockedItem.length - 1]);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it("plan=undefined: renders nothing", () => {
     mockUsePlan.mockReturnValue({ plan: undefined });
     const { container } = render(

--- a/apps/web/components/interview/PersonaPicker.test.tsx
+++ b/apps/web/components/interview/PersonaPicker.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { BEHAVIORAL_PERSONAS } from "@/lib/personas";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — must be before any imports that consume these modules
+// ---------------------------------------------------------------------------
+const { mockUsePlan } = vi.hoisted(() => ({
+  mockUsePlan: vi.fn(),
+}));
+
+vi.mock("@/hooks/usePlan", () => ({
+  usePlan: () => mockUsePlan(),
+}));
+
+// ---------------------------------------------------------------------------
+// Import component after mocks
+// ---------------------------------------------------------------------------
+import { PersonaPicker } from "./PersonaPicker";
+
+// The 4 Pro-only persona ids (all except "default")
+const PRO_PERSONA_IDS = BEHAVIORAL_PERSONAS.filter((p) => p.proOnly).map(
+  (p) => p.id
+);
+
+describe("PersonaPicker", () => {
+  it("plan='free': all 5 options appear in the DOM after opening; 4 have data-pro-locked='true'; default does not", async () => {
+    mockUsePlan.mockReturnValue({ plan: "free" });
+    render(<PersonaPicker value="default" onChange={() => {}} />);
+
+    // Open the select to reveal the option items
+    const trigger = screen.getByRole("combobox");
+    await userEvent.click(trigger);
+
+    // All 5 labels should now appear in the document
+    for (const persona of BEHAVIORAL_PERSONAS) {
+      expect(
+        screen.getAllByText(persona.label).length
+      ).toBeGreaterThanOrEqual(1);
+    }
+
+    // 4 items have data-pro-locked="true"
+    const locked = document.querySelectorAll('[data-pro-locked="true"]');
+    expect(locked.length).toBe(PRO_PERSONA_IDS.length);
+  });
+
+  it("plan='pro': no data-pro-locked attribute anywhere after opening", async () => {
+    mockUsePlan.mockReturnValue({ plan: "pro" });
+    render(<PersonaPicker value="default" onChange={() => {}} />);
+
+    // Open the select
+    const trigger = screen.getByRole("combobox");
+    await userEvent.click(trigger);
+
+    const locked = document.querySelectorAll('[data-pro-locked="true"]');
+    expect(locked.length).toBe(0);
+  });
+
+  it("plan='free': the default option is selectable and calls onChange('default')", async () => {
+    mockUsePlan.mockReturnValue({ plan: "free" });
+    const onChange = vi.fn();
+    render(<PersonaPicker value="amazon-lp" onChange={onChange} />);
+
+    // Open the select
+    const trigger = screen.getByRole("combobox");
+    await userEvent.click(trigger);
+
+    // Find the default option and click it
+    const defaultOptions = screen.getAllByText("Alex (default)");
+    // Click the last one (the option in the dropdown, not the trigger display value)
+    await userEvent.click(defaultOptions[defaultOptions.length - 1]);
+
+    // onChange called with "default"
+    expect(onChange).toHaveBeenCalledWith("default");
+  });
+
+  it("plan='free': locked Pro items render with data-pro-locked='true' and aria-disabled='true'", async () => {
+    mockUsePlan.mockReturnValue({ plan: "free" });
+    render(<PersonaPicker value="default" onChange={() => {}} />);
+
+    // Open the select to render items
+    const trigger = screen.getByRole("combobox");
+    await userEvent.click(trigger);
+
+    // Locked items should have both data-pro-locked and aria-disabled attributes
+    const locked = document.querySelectorAll('[data-pro-locked="true"]');
+    expect(locked.length).toBe(4); // 4 pro-only personas
+
+    // All locked items should also have aria-disabled="true"
+    for (const item of locked) {
+      expect(item.getAttribute("aria-disabled")).toBe("true");
+    }
+  });
+
+  it("plan=undefined: renders nothing", () => {
+    mockUsePlan.mockReturnValue({ plan: undefined });
+    const { container } = render(
+      <PersonaPicker value="default" onChange={() => {}} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/web/components/interview/PersonaPicker.tsx
+++ b/apps/web/components/interview/PersonaPicker.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { Sparkles } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { usePlan } from "@/hooks/usePlan";
+import { BEHAVIORAL_PERSONAS } from "@/lib/personas";
+
+interface PersonaPickerProps {
+  value: string; // persona id
+  onChange: (personaId: string) => void;
+}
+
+export function PersonaPicker({ value, onChange }: PersonaPickerProps) {
+  const { plan } = usePlan();
+
+  // While plan is unknown, render nothing — avoids a flash where Pro-locked
+  // items appear unlocked for free users.
+  if (plan === undefined) return null;
+
+  return (
+    <div role="group" aria-label="Interviewer persona">
+      <div className="mb-1.5 flex items-baseline justify-between">
+        <span className="text-sm font-medium leading-none">
+          Interviewer Persona
+        </span>
+        {plan === "free" && (
+          <span className="flex items-center gap-1 text-xs text-[color:var(--primary)]">
+            <Sparkles className="h-3 w-3" aria-hidden="true" />
+            Pro
+          </span>
+        )}
+      </div>
+      <p className="mb-2 text-xs text-muted-foreground">
+        Choose the interviewer style that matches your target company.
+      </p>
+      <Select
+        value={value}
+        onValueChange={(id) => {
+          // base-ui onValueChange passes string | null. Guard against null
+          // (e.g. when the user deselects — not possible here since we always
+          // have a value, but the type requires it).
+          if (id !== null) onChange(id);
+        }}
+      >
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="Select persona" />
+        </SelectTrigger>
+        <SelectContent>
+          {BEHAVIORAL_PERSONAS.map((persona) => {
+            const isLocked = persona.proOnly && plan === "free";
+            return (
+              <SelectItem
+                key={persona.id}
+                value={persona.id}
+                disabled={isLocked}
+                data-pro-locked={isLocked ? "true" : undefined}
+                aria-disabled={isLocked ? "true" : undefined}
+                className="flex flex-col items-start py-2"
+              >
+                <span className="flex w-full items-center justify-between gap-2">
+                  <span className="font-medium">{persona.label}</span>
+                  {isLocked && (
+                    <Sparkles
+                      className="h-3.5 w-3.5 shrink-0 text-[color:var(--primary)]"
+                      aria-hidden="true"
+                    />
+                  )}
+                </span>
+                <span className="mt-0.5 text-xs font-normal text-muted-foreground">
+                  {persona.description}
+                </span>
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/apps/web/lib/__snapshots__/prompts.test.ts.snap
+++ b/apps/web/lib/__snapshots__/prompts.test.ts.snap
@@ -1,0 +1,26 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`buildBehavioralSystemPrompt — personas (#179) > persona 'default' matches snapshot (byte-identical to pre-personas baseline) 1`] = `
+"You are Alex, an experienced hiring manager conducting a behavioral interview. Your name is Alex — always introduce yourself as Alex. The person you are speaking to is the candidate; never confuse your identity with theirs.
+
+Strike a balanced tone — professional but approachable. Be friendly without being overly casual.
+
+Ask mid-level behavioral questions. Include follow-ups that probe for specifics using the STAR method (Situation, Task, Action, Result).
+
+CRITICAL — role boundary: You are the INTERVIEWER. Never speak as the candidate. Never produce what you imagine the candidate's answer would be, even as an example or to "show what a good answer looks like." Never answer your own question.
+
+If the candidate responds with filler or acknowledgement only ("good question", "hmm", "let me think", "that's interesting", "um", a nervous laugh, etc.) WITHOUT substantive content, treat it the same as silence: do NOT elaborate, do NOT answer, do NOT guess at what they might say. Wait briefly, then repeat or rephrase the question, or offer to clarify if they look stuck. A gentle "take your time" is fine — generating a hypothetical answer is not.
+
+Begin every interview with 1–2 turns of natural small talk before any competency question. Greet the candidate by name if you have it, ask how their day is going, briefly acknowledge their role/company, and only then transition into the first behavioral question. Never open with a behavioral question cold.
+
+Interview flow:
+1. After the warm-up small talk, briefly explain the interview format, then move into the first behavioral question.
+2. Ask 4-6 behavioral questions, one at a time.
+3. After each answer, ask one follow-up to get more detail (especially if the answer lacks specifics).
+4. Wrap up by asking "Do you have any questions for me?" and answer briefly if they do.
+5. End with a polite closing.
+
+Be conversational, not essayistic. Cap each turn at 3 sentences for questions and follow-ups; up to 5 sentences only when setting context for a new topic. This is a voice conversation — long monologues feel unnatural.
+
+If the candidate is silent or pauses mid-answer, do NOT advance to a new question. Do NOT answer your own question. Wait. The system may inject a gentle nudge (e.g. 'Take your time', 'Want me to repeat?', 'Should we move on?') as a system message — when you receive one, deliver it verbatim or near-verbatim, then wait again. Only move on after the candidate explicitly confirms or after the system instructs you to hand off."
+`;

--- a/apps/web/lib/features.test.ts
+++ b/apps/web/lib/features.test.ts
@@ -47,3 +47,13 @@ describe("follow_up_probing feature (#178)", () => {
     expect(hasFeature("free", "follow_up_probing")).toBe(false);
   });
 });
+
+describe("interviewer_personas feature (#179)", () => {
+  it("pro plan HAS interviewer_personas", () => {
+    expect(hasFeature("pro", "interviewer_personas")).toBe(true);
+  });
+
+  it("free plan does NOT have interviewer_personas", () => {
+    expect(hasFeature("free", "interviewer_personas")).toBe(false);
+  });
+});

--- a/apps/web/lib/features.ts
+++ b/apps/web/lib/features.ts
@@ -28,7 +28,10 @@ export type FeatureKey =
   | "resume"
   /** Interviewer follow-up pressure — probes up to 3 layers deep per question.
    *  See #178. */
-  | "follow_up_probing";
+  | "follow_up_probing"
+  /** Behavioral interviewer personas — Amazon LP, Google STAR, hostile panel,
+   *  warm peer, or the default Alex. See #179. */
+  | "interviewer_personas";
 
 /**
  * Which plan tiers grant access to each feature. A feature is unlocked iff
@@ -38,6 +41,7 @@ export const FEATURE_MATRIX: Record<FeatureKey, readonly Plan[]> = {
   planner: ["pro"],
   resume: ["pro"],
   follow_up_probing: ["pro"],
+  interviewer_personas: ["pro"],
 };
 
 /**
@@ -99,6 +103,17 @@ export const FEATURE_META: Record<
       "Interviewer asks follow-ups per question before moving on",
       "Gentle / Standard / Intense — pick how hard you want to be pushed",
       "Trains you to go past surface-level STAR answers",
+    ],
+  },
+  interviewer_personas: {
+    label: "Interviewer Personas",
+    href: "/pricing#interviewer_personas",
+    tagline:
+      "Practice against Amazon LP, Google STAR, hostile panels, warm peers — pick the interviewer style that matches your target.",
+    benefits: [
+      "Five behavioral interviewer personas to pick from",
+      "Amazon Leadership Principles, Google STAR discipline, hostile panel, warm peer, or the default friendly Alex",
+      "Matches the interviewer texture to the companies you're targeting",
     ],
   },
 };

--- a/apps/web/lib/personas.test.ts
+++ b/apps/web/lib/personas.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import {
+  BEHAVIORAL_PERSONAS,
+  getBehavioralPersona,
+  isProBehavioralPersona,
+  applyProbeStyleCap,
+  DEFAULT_BEHAVIORAL_PERSONA_ID,
+} from "./personas";
+
+describe("BEHAVIORAL_PERSONAS", () => {
+  it("has 5 entries with unique ids", () => {
+    expect(BEHAVIORAL_PERSONAS).toHaveLength(5);
+    const ids = BEHAVIORAL_PERSONAS.map((p) => p.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(5);
+  });
+
+  it("includes the default persona with id 'default'", () => {
+    const defaultPersona = BEHAVIORAL_PERSONAS.find(
+      (p) => p.id === DEFAULT_BEHAVIORAL_PERSONA_ID
+    );
+    expect(defaultPersona).toBeDefined();
+    expect(defaultPersona?.proOnly).toBe(false);
+  });
+});
+
+describe("getBehavioralPersona", () => {
+  it("returns the Amazon LP record for 'amazon-lp'", () => {
+    const p = getBehavioralPersona("amazon-lp");
+    expect(p).toBeDefined();
+    expect(p?.id).toBe("amazon-lp");
+    expect(p?.interviewerName).toBe("Priya");
+    expect(p?.proOnly).toBe(true);
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(getBehavioralPersona("bogus")).toBeUndefined();
+  });
+
+  it("returns undefined for null", () => {
+    expect(getBehavioralPersona(null)).toBeUndefined();
+  });
+
+  it("returns undefined for undefined", () => {
+    expect(getBehavioralPersona(undefined)).toBeUndefined();
+  });
+
+  it("returns the warm-peer record for 'warm-peer'", () => {
+    const p = getBehavioralPersona("warm-peer");
+    expect(p?.interviewerName).toBe("Jess");
+    expect(p?.probeStyle).toBe("gentle");
+  });
+
+  it("returns the hostile-panel record for 'hostile-panel'", () => {
+    const p = getBehavioralPersona("hostile-panel");
+    expect(p?.interviewerName).toBe("Dr. Harlan");
+    expect(p?.probeStyle).toBe("aggressive");
+  });
+});
+
+describe("isProBehavioralPersona", () => {
+  it("returns false for 'default'", () => {
+    expect(isProBehavioralPersona("default")).toBe(false);
+  });
+
+  it("returns true for 'amazon-lp'", () => {
+    expect(isProBehavioralPersona("amazon-lp")).toBe(true);
+  });
+
+  it("returns true for 'google-star'", () => {
+    expect(isProBehavioralPersona("google-star")).toBe(true);
+  });
+
+  it("returns true for 'warm-peer'", () => {
+    expect(isProBehavioralPersona("warm-peer")).toBe(true);
+  });
+
+  it("returns true for 'hostile-panel'", () => {
+    expect(isProBehavioralPersona("hostile-panel")).toBe(true);
+  });
+
+  it("returns false for unknown id (safe default)", () => {
+    expect(isProBehavioralPersona("bogus")).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isProBehavioralPersona(null)).toBe(false);
+  });
+});
+
+describe("applyProbeStyleCap", () => {
+  it("gentle caps 3 down to 1", () => {
+    expect(applyProbeStyleCap(3, "gentle")).toBe(1);
+  });
+
+  it("gentle caps 2 down to 1", () => {
+    expect(applyProbeStyleCap(2, "gentle")).toBe(1);
+  });
+
+  it("gentle does NOT raise floor: 0 stays 0", () => {
+    expect(applyProbeStyleCap(0, "gentle")).toBe(0);
+  });
+
+  it("gentle with 1 stays 1 (at the cap)", () => {
+    expect(applyProbeStyleCap(1, "gentle")).toBe(1);
+  });
+
+  it("neutral is a no-op: 3 stays 3", () => {
+    expect(applyProbeStyleCap(3, "neutral")).toBe(3);
+  });
+
+  it("neutral is a no-op: 0 stays 0", () => {
+    expect(applyProbeStyleCap(0, "neutral")).toBe(0);
+  });
+
+  it("aggressive is ceiling-only (no-op as cap): 3 stays 3", () => {
+    expect(applyProbeStyleCap(3, "aggressive")).toBe(3);
+  });
+
+  it("aggressive does NOT force depth up: 1 stays 1", () => {
+    expect(applyProbeStyleCap(1, "aggressive")).toBe(1);
+  });
+
+  it("undefined probeStyle is a no-op: 2 stays 2", () => {
+    expect(applyProbeStyleCap(2, undefined)).toBe(2);
+  });
+});

--- a/apps/web/lib/personas.ts
+++ b/apps/web/lib/personas.ts
@@ -1,0 +1,140 @@
+/**
+ * Behavioral interviewer personas for Preploy. (#179)
+ *
+ * Each persona swaps the interviewer identity and appends a texture section
+ * to the behavioral system prompt. The "default" persona is byte-identical
+ * to the pre-personas Alex prompt (snapshot-guarded in prompts.test.ts).
+ *
+ * Technical personas were explicitly excluded from v1 — Preploy's technical
+ * interview flow has no real-time chat; the agent only runs analysis after the
+ * session, so a technical persona would be a no-op at runtime.
+ */
+
+export type ProbeStyle = "gentle" | "neutral" | "aggressive";
+
+export interface BehavioralPersona {
+  id: string;
+  label: string;
+  description: string;
+  proOnly: boolean;
+  interviewerName: string;
+  /** Replaces the "You are Alex..." intro line in the system prompt. */
+  basePrompt: string;
+  /**
+   * Appended as a new section after the probe_depth block and before
+   * Conciseness. Empty string for the default persona (no extra section).
+   */
+  systemPromptSuffix: string;
+  probeStyle?: ProbeStyle;
+}
+
+export const DEFAULT_BEHAVIORAL_PERSONA_ID = "default" as const;
+
+export const BEHAVIORAL_PERSONAS: readonly BehavioralPersona[] = [
+  {
+    id: "default",
+    label: "Alex (default)",
+    description:
+      "A friendly generic hiring manager. Unchanged from the current experience.",
+    proOnly: false,
+    interviewerName: "Alex",
+    // VERBATIM from apps/web/lib/prompts.ts — any whitespace drift breaks the
+    // snapshot test. Do not reformat this string.
+    basePrompt:
+      "You are Alex, an experienced hiring manager conducting a behavioral interview. Your name is Alex — always introduce yourself as Alex. The person you are speaking to is the candidate; never confuse your identity with theirs.",
+    systemPromptSuffix: "",
+    probeStyle: undefined,
+  },
+  {
+    id: "amazon-lp",
+    label: "Amazon LP",
+    description:
+      "Leadership Principles-obsessed. Probes for ownership, customer obsession, backbone.",
+    proOnly: true,
+    interviewerName: "Priya",
+    basePrompt:
+      "You are Priya, an experienced hiring manager conducting a behavioral interview. Your name is Priya — always introduce yourself as Priya. The person you are speaking to is the candidate; never confuse your identity with theirs.",
+    systemPromptSuffix:
+      "Persona texture — Amazon Leadership Principles: You assess every answer against Amazon's 16 Leadership Principles. After the candidate's initial answer, probe explicitly for which LP they demonstrated (e.g. \"Which leadership principle do you think that story shows?\" or \"How did you show Ownership there?\"). Favor Customer Obsession, Ownership, Bias for Action, Deliver Results, and Have Backbone; Disagree and Commit. Ask for specific metrics and business outcomes — Amazon interviewers are trained to push past generalities. Tone is direct and data-hungry, not hostile.",
+    probeStyle: "aggressive",
+  },
+  {
+    id: "google-star",
+    label: "Google STAR",
+    description:
+      "STAR-structured. Pushes for explicit Situation/Task/Action/Result separation.",
+    proOnly: true,
+    interviewerName: "Sam",
+    basePrompt:
+      "You are Sam, an experienced hiring manager conducting a behavioral interview. Your name is Sam — always introduce yourself as Sam. The person you are speaking to is the candidate; never confuse your identity with theirs.",
+    systemPromptSuffix:
+      "Persona texture — Google STAR discipline: You coach the candidate through the STAR structure explicitly. If their answer blurs Situation into Action, interrupt gently: \"Let me pause you — what was the Task specifically?\" Reward candidates who separate the four components cleanly. After each answer, verify all four components were covered before moving on; if one is missing (usually Result), ask for it directly. Tone is professional, curious, and methodical — like a senior engineer running an interview panel.",
+    probeStyle: "neutral",
+  },
+  {
+    id: "warm-peer",
+    label: "Warm peer",
+    description: "Friendly future teammate. Builds rapport, conversational follow-ups.",
+    proOnly: true,
+    interviewerName: "Jess",
+    basePrompt:
+      "You are Jess, an experienced hiring manager conducting a behavioral interview. Your name is Jess — always introduce yourself as Jess. The person you are speaking to is the candidate; never confuse your identity with theirs.",
+    systemPromptSuffix:
+      "Persona texture — warm peer: You interview as a prospective teammate, not a gatekeeper. Open with genuine interest in the candidate's background, mirror their energy, and use conversational follow-ups (\"Oh interesting, what happened next?\") rather than formal probes. Share one-sentence reactions (\"That sounds stressful.\") before asking the next question. You are still evaluating, but you do it through empathy, not interrogation. Never stack questions.",
+    probeStyle: "gentle",
+  },
+  {
+    id: "hostile-panel",
+    label: "Hostile panel",
+    description:
+      "High-pressure stress interviewer. Skeptical, interruptive, demands specifics.",
+    proOnly: true,
+    interviewerName: "Dr. Harlan",
+    basePrompt:
+      "You are Dr. Harlan, an experienced hiring manager conducting a behavioral interview. Your name is Dr. Harlan — always introduce yourself as Dr. Harlan. The person you are speaking to is the candidate; never confuse your identity with theirs.",
+    systemPromptSuffix:
+      "Persona texture — hostile panel: You simulate a skeptical senior interviewer who is under-impressed by default. Challenge vague claims immediately (\"That doesn't sound that hard — what was the actual risk?\"). Ask the same question twice if the first answer dodged it. Push back on numbers (\"Are you sure about that number?\"). You are NOT rude, unprofessional, or personal — you are exacting, like a senior staff engineer who has heard every polished STAR answer before. You still follow interview flow and ask \"any questions for me?\" at the end, but the mid-interview experience is high-friction. Never stack three questions in one turn — one pressure question at a time.",
+    probeStyle: "aggressive",
+  },
+];
+
+/**
+ * Look up a persona by id. Returns undefined for unknown ids (including null
+ * and undefined inputs). The route handler treats unknown ids as 400; the
+ * prompt builder falls back to "default" as defense-in-depth.
+ */
+export function getBehavioralPersona(
+  id: string | null | undefined
+): BehavioralPersona | undefined {
+  if (!id) return undefined;
+  return BEHAVIORAL_PERSONAS.find((p) => p.id === id);
+}
+
+/**
+ * True iff the persona with the given id is Pro-only. Returns false for
+ * unknown ids (safe default — unknown ids are rejected at the route level).
+ */
+export function isProBehavioralPersona(id: string | null | undefined): boolean {
+  const persona = getBehavioralPersona(id);
+  return persona?.proOnly ?? false;
+}
+
+/**
+ * Apply the persona's probeStyle cap to the user's requested probe_depth.
+ *
+ * Cap rule (#179):
+ *   - "gentle"     → cap at 1 (cannot go above 1, but does NOT raise floor)
+ *   - "neutral"    → no-op (pass through)
+ *   - "aggressive" → ceiling-only, meaning no-op as a cap (does NOT force depth up)
+ *   - undefined    → no-op
+ *
+ * The cap is applied at the route handler before persistence, NOT inside the
+ * prompt builder. The prompt builder reads the already-capped value.
+ */
+export function applyProbeStyleCap(
+  userDepth: 0 | 1 | 2 | 3,
+  style: ProbeStyle | undefined
+): 0 | 1 | 2 | 3 {
+  if (style === "gentle") return Math.min(userDepth, 1) as 0 | 1 | 2 | 3;
+  return userDepth; // neutral, aggressive, undefined → no-op
+}

--- a/apps/web/lib/prompts.test.ts
+++ b/apps/web/lib/prompts.test.ts
@@ -257,3 +257,84 @@ describe("buildBehavioralSystemPrompt", () => {
     expect(prompt).toContain("This directive overrides any earlier");
   });
 });
+
+// ---- #179: Behavioral interviewer personas ----
+
+describe("buildBehavioralSystemPrompt — personas (#179)", () => {
+  it("persona 'amazon-lp' includes 'Leadership Principles' and 'Priya' but not STAR/warm/hostile cross-contamination", () => {
+    const prompt = buildBehavioralSystemPrompt({
+      ...DEFAULT_CONFIG,
+      persona: "amazon-lp",
+    });
+    expect(prompt).toContain("Leadership Principles");
+    expect(prompt).toContain("Priya");
+    expect(prompt).not.toContain("STAR discipline");
+    expect(prompt).not.toContain("warm peer");
+    expect(prompt).not.toContain("hostile panel");
+  });
+
+  it("persona 'hostile-panel' includes 'hostile panel', 'Dr. Harlan', and 'skeptical senior'", () => {
+    const prompt = buildBehavioralSystemPrompt({
+      ...DEFAULT_CONFIG,
+      persona: "hostile-panel",
+    });
+    expect(prompt).toContain("hostile panel");
+    expect(prompt).toContain("Dr. Harlan");
+    expect(prompt).toContain("skeptical senior interviewer");
+  });
+
+  it("persona 'default' matches snapshot (byte-identical to pre-personas baseline)", () => {
+    const prompt = buildBehavioralSystemPrompt({
+      ...DEFAULT_CONFIG,
+      persona: "default",
+    });
+    expect(prompt).toMatchSnapshot();
+  });
+
+  it("persona undefined produces byte-identical output to persona 'default'", () => {
+    const withDefault = buildBehavioralSystemPrompt({
+      ...DEFAULT_CONFIG,
+      persona: "default",
+    });
+    const withUndefined = buildBehavioralSystemPrompt(DEFAULT_CONFIG);
+    expect(withUndefined).toBe(withDefault);
+  });
+
+  it("persona 'bogus-id' falls back to default silently (defense-in-depth)", () => {
+    const defaultPrompt = buildBehavioralSystemPrompt({
+      ...DEFAULT_CONFIG,
+      persona: "default",
+    });
+    const bogusPrompt = buildBehavioralSystemPrompt({
+      ...DEFAULT_CONFIG,
+      persona: "bogus-id",
+    });
+    expect(bogusPrompt).toBe(defaultPrompt);
+  });
+
+  it("persona 'warm-peer' with probe_depth 3 outputs depth line '3' (cap applied at route, NOT prompt builder)", () => {
+    // The prompt builder reads the already-persisted probe_depth value.
+    // If warm-peer is combined with depth=3 in the prompt builder directly
+    // (as happens in unit tests, before the route caps it), it should
+    // output depth=3 faithfully — the cap happens upstream at the route.
+    const prompt = buildBehavioralSystemPrompt({
+      ...DEFAULT_CONFIG,
+      persona: "warm-peer",
+      probe_depth: 3,
+    });
+    expect(prompt).toContain("Follow-up depth for this session: 3");
+    expect(prompt).toContain("warm peer");
+  });
+
+  it("persona 'google-star' suffix appears after probe_depth block", () => {
+    const prompt = buildBehavioralSystemPrompt({
+      ...DEFAULT_CONFIG,
+      persona: "google-star",
+      probe_depth: 2,
+    });
+    const probeIdx = prompt.indexOf("Follow-up depth for this session: 2");
+    const suffixIdx = prompt.indexOf("STAR discipline");
+    expect(probeIdx).toBeGreaterThan(-1);
+    expect(suffixIdx).toBeGreaterThan(probeIdx);
+  });
+});

--- a/apps/web/lib/prompts.ts
+++ b/apps/web/lib/prompts.ts
@@ -1,15 +1,24 @@
 import type { BehavioralSessionConfig } from "@preploy/shared";
+import {
+  getBehavioralPersona,
+  DEFAULT_BEHAVIORAL_PERSONA_ID,
+} from "./personas";
 
 export function buildBehavioralSystemPrompt(
   config: BehavioralSessionConfig
 ): string {
   const sections: string[] = [];
 
+  // Resolve persona — falls back to "default" for unknown or absent ids.
+  // The route handler already validated and persisted a known persona id, so
+  // this fallback is defense-in-depth (handles bogus ids in unit tests, etc.)
+  const persona =
+    getBehavioralPersona(config.persona) ??
+    getBehavioralPersona(DEFAULT_BEHAVIORAL_PERSONA_ID)!;
+
   // Base persona — give the interviewer a fixed name so it never
   // accidentally uses the candidate's name from the resume.
-  sections.push(
-    "You are Alex, an experienced hiring manager conducting a behavioral interview. Your name is Alex — always introduce yourself as Alex. The person you are speaking to is the candidate; never confuse your identity with theirs."
-  );
+  sections.push(persona.basePrompt);
 
   // Company context
   if (config.company_name?.trim()) {
@@ -104,6 +113,12 @@ export function buildBehavioralSystemPrompt(
     sections.push(
       `Follow-up depth for this session: ${n}. After the candidate's initial answer to each behavioral question, probe up to ${n} follow-up turns before moving on. Each probe must target a different dimension, in this order of preference: (1) business impact — "What was the measurable outcome? Numbers if you have them.", (2) reasoning — "Why that approach over the alternatives?", (3) counterfactual — "Knowing what you know now, what would you do differently?". Stop probing early if the candidate has already covered a dimension or is clearly out of material — do NOT repeat yourself and do NOT probe past ${n} turns. After the final probe, acknowledge briefly ("Got it — thanks.") and move to the next question. Probing is conversational, not adversarial: stay warm, one question at a time, never stack three questions in one turn. This directive overrides any earlier "ask one follow-up" instruction for this session.`
     );
+  }
+
+  // Persona texture suffix — injected AFTER probe_depth and BEFORE Conciseness.
+  // Empty for the default persona so no extra section is added.
+  if (persona.systemPromptSuffix) {
+    sections.push(persona.systemPromptSuffix);
   }
 
   // Conciseness — replaces the old "2-3 sentences maximum" constraint (108-D)

--- a/apps/web/lib/validations.ts
+++ b/apps/web/lib/validations.ts
@@ -10,6 +10,7 @@ export const behavioralConfigSchema = z.object({
   interview_style: z.number().min(0).max(1),
   difficulty: z.number().min(0).max(1),
   probe_depth: z.number().int().min(0).max(3).optional(),
+  persona: z.string().min(1).max(64).optional(),
 });
 
 export const technicalConfigSchema = z.object({

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -52,6 +52,9 @@ export interface BehavioralSessionConfig {
   // behavioral session. 0 = no probing (Free default). 2 = Pro default
   // (Standard). 3 = Intense. See #178.
   probe_depth?: 0 | 1 | 2 | 3;
+  // Pro-only. Selects an interviewer persona ("amazon-lp", "google-star",
+  // "warm-peer", "hostile-panel", or "default"). See #179.
+  persona?: string;
 }
 
 export interface TechnicalSessionConfig {


### PR DESCRIPTION
## Summary
- Adds 5 behavioral interviewer personas: Alex/default (Free), Amazon LP/Priya, Google STAR/Sam, Warm peer/Jess, Hostile panel/Dr. Harlan (all Pro-only).
- `POST /api/sessions` resolves and gates the persona: unknown id → 400, Pro-only from Free user → 402, always persists a canonical persona id on every behavioral session.
- `warm-peer` (gentle `probeStyle`) caps `probe_depth` at 1 before persistence; cap is applied at the route, not the prompt builder. Aggressive is ceiling-only — does not force depth up.
- Feedback page shows a "Practiced with: {label}" chip under the h1 for any non-default persona.
- Incidental production bug fixed: route now persists Zod-parsed config output instead of raw request body, preventing unknown fields from leaking to the `interview_sessions.config` jsonb column.

## Scope deviation
Technical personas (originally scoped in the issue as 3 additional personas: silent-observer, pair-programmer, default-technical) are intentionally excluded from v1. Preploy's technical interview flow has no real-time chat surface — the agent runs analysis only after the session ends, so a technical persona would be a no-op at runtime. User-approved deviation.

## Behavior

| Plan | Persona sent | Outcome |
|------|-------------|---------|
| Free | omitted | 201 — persists `persona: "default"` |
| Free | `"default"` | 201 — persists `persona: "default"` |
| Free | `"amazon-lp"` | 402 `pro_plan_required / interviewer_personas` |
| Free | `"bogus"` | 400 `Invalid persona` |
| Pro  | `"amazon-lp"` | 201 — persists `persona: "amazon-lp"` |
| Pro  | `"warm-peer"` + `probe_depth: 3` | 201 — persists `probe_depth: 1` (gentle cap), `persona: "warm-peer"` |
| Pro  | `"hostile-panel"` + `probe_depth: 3` | 201 — persists `probe_depth: 3` (aggressive = ceiling-only no-op) |
| Any  | Technical session with `persona` in config | 201 — `persona` stripped by Zod before persistence |

## Production bug fix
Before this PR, `POST /api/sessions` used the raw (pre-Zod) request body as `resolvedConfig`, meaning any unknown fields the client included in `config` were persisted verbatim to the `interview_sessions.config` jsonb column. After this PR, `parsedConfigData` (Zod's stripped output) is used as the base, so only declared schema fields survive to the DB. This was surfaced by a QA pass that caught a vacuously-true integration test — the hardening exposed the real leak.

## Schema change
**None.** `persona` rides inside `interview_sessions.config` jsonb alongside the existing `probe_depth`, `interview_style`, `difficulty`, etc. No migration.

## Tests
- Unit / component: 1026 tests pass (24 new persona registry + helpers tests, 7 new prompt assertions + byte-identity snapshot, 2 new feature-matrix tests, 6 new PersonaPicker component tests including the locked-item-click non-regression, 3 new FeedbackDashboard badge tests).
- Integration: 400 tests pass (8 new persona-gating tests covering all 4 plan × persona combinations + probe_style cap + technical strip).
- All lint + typecheck clean.

## Test plan (Vercel preview)
- [ ] **Free user — locked picker**: Open Behavioral Setup → confirm all 4 Pro personas show the cedar `<Sparkles>` lock icon; clicking a locked item does not change the Select value.
- [ ] **Pro user — persona selection**: Log in as Pro → select "Amazon LP" → start session → confirm session is created. After session ends, open feedback page and confirm "Practiced with: Amazon LP" chip appears under the h1.
- [ ] **Pro user — `probe_depth` cap**: Select "Warm peer" + move the Follow-up Pressure toggle to "Intense" (3) → submit → inspect the created session's config (DevTools Network tab or DB) → confirm `probe_depth` is `1`, not `3`.
- [ ] **Pro user — aggressive is ceiling-only**: Select "Amazon LP" + Follow-up Pressure = Gentle (1) → submit → confirm `probe_depth` is `1` (NOT force-raised to 3).
- [ ] **Feedback badge suppressed for default**: Complete a session with "Alex (default)" → open feedback → confirm no "Practiced with:" chip is visible.
- [ ] **Personas feel different**: Run the same behavioral session script against Amazon LP, Warm peer, and Hostile panel consecutively. The interviewer should feel noticeably distinct — mandatory manual QA per the original acceptance criterion.

Closes #179

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>