### PR TITLE
feat(resume): structured parse + AI bullet rewrite (#176)

### DIFF
--- a/apps/web/app/api/resume/[id]/route.integration.test.ts
+++ b/apps/web/app/api/resume/[id]/route.integration.test.ts
@@ -7,8 +7,12 @@ import {
 } from "../../../../tests/setup-db";
 import { users, userResumes } from "@/lib/schema";
 
-// Mock auth
-const mockAuth = vi.fn();
+// Use vi.hoisted so mockParseResume is available when vi.mock factories run
+const { mockAuth, mockParseResume } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockParseResume: vi.fn(),
+}));
+
 vi.mock("@/lib/auth", () => ({
   auth: () => mockAuth(),
 }));
@@ -20,7 +24,12 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
-import { DELETE } from "./route";
+// Mock the resume parser for PATCH tests
+vi.mock("@/lib/resume-parser", () => ({
+  parseResume: mockParseResume,
+}));
+
+import { DELETE, PATCH } from "./route";
 
 const TEST_USER = {
   id: "00000000-0000-0000-0000-000000000011",
@@ -40,9 +49,29 @@ function makeDeleteRequest(id: string) {
   });
 }
 
+function makePatchRequest(id: string, body: unknown) {
+  return new NextRequest(`http://localhost:3000/api/resume/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
 function makeParams(id: string) {
   return { params: Promise.resolve({ id }) };
 }
+
+const MOCK_STRUCTURED = {
+  roles: [
+    {
+      company: "Acme",
+      title: "Engineer",
+      dates: "2020",
+      bullets: [{ text: "Did stuff", impact_score: 5, has_quantified_metric: false }],
+    },
+  ],
+  skills: ["TypeScript"],
+};
 
 describe("API DELETE /api/resume/[id] (integration)", () => {
   beforeAll(async () => {
@@ -53,6 +82,7 @@ describe("API DELETE /api/resume/[id] (integration)", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockParseResume.mockResolvedValue(MOCK_STRUCTURED);
     const db = getTestDb();
     await db.delete(userResumes);
   });
@@ -145,5 +175,152 @@ describe("API DELETE /api/resume/[id] (integration)", () => {
       .from(userResumes)
       .where(eq(userResumes.id, resume.id));
     expect(rows).toHaveLength(0);
+  });
+});
+
+describe("API PATCH /api/resume/[id] (integration)", () => {
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values(TEST_USER).onConflictDoNothing();
+    await db.insert(users).values(OTHER_USER).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockParseResume.mockResolvedValue(MOCK_STRUCTURED);
+    const db = getTestDb();
+    await db.delete(userResumes);
+  });
+
+  afterAll(async () => {
+    // shared teardown with DELETE suite — only teardown once at the very end
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await PATCH(
+      makePatchRequest("00000000-0000-0000-0000-000000000099", {
+        oldBullet: "old",
+        newBullet: "new",
+      }),
+      makeParams("00000000-0000-0000-0000-000000000099")
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when accessing another user's resume", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const db = getTestDb();
+    const [otherResume] = await db
+      .insert(userResumes)
+      .values({ userId: OTHER_USER.id, filename: "other.txt", content: "old bullet here" })
+      .returning();
+
+    const res = await PATCH(
+      makePatchRequest(otherResume.id, { oldBullet: "old bullet here", newBullet: "new bullet" }),
+      makeParams(otherResume.id)
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a nonexistent resume UUID", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await PATCH(
+      makePatchRequest("00000000-0000-0000-0000-000000009999", {
+        oldBullet: "old",
+        newBullet: "new",
+      }),
+      makeParams("00000000-0000-0000-0000-000000009999")
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when oldBullet is not found in resume content", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const db = getTestDb();
+    const [resume] = await db
+      .insert(userResumes)
+      .values({
+        userId: TEST_USER.id,
+        filename: "resume.txt",
+        content: "Led team of engineers to deliver product on time",
+      })
+      .returning();
+
+    const res = await PATCH(
+      makePatchRequest(resume.id, {
+        oldBullet: "this bullet does not exist in content",
+        newBullet: "new improved bullet",
+      }),
+      makeParams(resume.id)
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("Bullet not found");
+  });
+
+  it("happy path: replaces bullet and persists new content + structured_data", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const db = getTestDb();
+    const oldBullet = "Participated in team meetings and discussions";
+    const newBullet = "Led 12 cross-functional team meetings, cutting decision time by 30%";
+    const [resume] = await db
+      .insert(userResumes)
+      .values({
+        userId: TEST_USER.id,
+        filename: "resume.txt",
+        content: `Engineer at Acme\n${oldBullet}`,
+      })
+      .returning();
+
+    const res = await PATCH(
+      makePatchRequest(resume.id, { oldBullet, newBullet }),
+      makeParams(resume.id)
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.content).toContain(newBullet);
+    expect(data.content).not.toContain(oldBullet);
+    expect(data.structuredData).not.toBeNull();
+
+    // Verify persistence via SELECT
+    const { eq } = await import("drizzle-orm");
+    const [row] = await db.select().from(userResumes).where(eq(userResumes.id, resume.id));
+    expect(row.content).toContain(newBullet);
+    expect(row.structuredData).not.toBeNull();
+  });
+
+  it("graceful-fallback: persists new content with structuredData null when parser throws", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    mockParseResume.mockRejectedValue(new Error("Parse failure"));
+
+    const db = getTestDb();
+    const oldBullet = "Did some work at the company";
+    const [resume] = await db
+      .insert(userResumes)
+      .values({
+        userId: TEST_USER.id,
+        filename: "resume.txt",
+        content: `Jane Smith\n${oldBullet}`,
+      })
+      .returning();
+
+    const newBullet = "Delivered 3 product features reducing churn by 15%";
+    const res = await PATCH(
+      makePatchRequest(resume.id, { oldBullet, newBullet }),
+      makeParams(resume.id)
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.content).toContain(newBullet);
+    expect(data.structuredData).toBeNull();
+
+    // Verify persistence
+    const { eq } = await import("drizzle-orm");
+    const [row] = await db.select().from(userResumes).where(eq(userResumes.id, resume.id));
+    expect(row.content).toContain(newBullet);
+    expect(row.structuredData).toBeNull();
   });
 });

--- a/apps/web/app/api/resume/[id]/route.ts
+++ b/apps/web/app/api/resume/[id]/route.ts
@@ -4,6 +4,94 @@ import { db } from "@/lib/db";
 import { userResumes } from "@/lib/schema";
 import { eq } from "drizzle-orm";
 import { createRequestLogger } from "@/lib/logger";
+import { patchResumeBulletSchema } from "@/lib/validations";
+import { parseResume } from "@/lib/resume-parser";
+
+// PATCH /api/resume/[id] — replace a bullet in place + re-parse structured data
+export async function PATCH(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const { id } = await context.params;
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = session.user.id;
+  const log = createRequestLogger({ route: "PATCH /api/resume/[id]", userId });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = patchResumeBulletSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request", details: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  const { oldBullet, newBullet } = parsed.data;
+
+  let existing;
+  try {
+    [existing] = await db
+      .select()
+      .from(userResumes)
+      .where(eq(userResumes.id, id));
+  } catch {
+    return NextResponse.json({ error: "Resume not found" }, { status: 404 });
+  }
+
+  if (!existing) {
+    return NextResponse.json({ error: "Resume not found" }, { status: 404 });
+  }
+
+  if (existing.userId !== userId) {
+    return NextResponse.json({ error: "Resume not found" }, { status: 404 });
+  }
+
+  // Confirm the old bullet appears in content — replace first occurrence only.
+  // Note: indexOf / replace are literal string operations; no regex / fuzzy matching.
+  // If the bullet appears verbatim twice, only the first occurrence is replaced.
+  if (!existing.content.includes(oldBullet)) {
+    return NextResponse.json(
+      { error: "Bullet not found in resume content" },
+      { status: 400 }
+    );
+  }
+
+  const newContent = existing.content.replace(oldBullet, newBullet);
+
+  // Re-parse with new content — graceful fallback if parser fails
+  let structuredData: unknown = null;
+  try {
+    structuredData = await parseResume(newContent);
+  } catch (err) {
+    log.warn({ err }, "parseResume threw on PATCH; proceeding with structuredData: null");
+  }
+
+  const [updated] = await db
+    .update(userResumes)
+    .set({ content: newContent, structuredData })
+    .where(eq(userResumes.id, id))
+    .returning({
+      id: userResumes.id,
+      filename: userResumes.filename,
+      content: userResumes.content,
+      structuredData: userResumes.structuredData,
+      createdAt: userResumes.createdAt,
+    });
+
+  log.info({ resumeId: id }, "Resume bullet patched");
+
+  return NextResponse.json(updated, { status: 200 });
+}
 
 // DELETE /api/resume/[id] — delete a specific resume owned by the authenticated user
 export async function DELETE(

--- a/apps/web/app/api/resume/[id]/route.ts
+++ b/apps/web/app/api/resume/[id]/route.ts
@@ -38,8 +38,7 @@ export async function PATCH(
 
   const { oldBullet, newBullet } = parsed.data;
 
-  let existing;
-  [existing] = await db
+  const [existing] = await db
     .select()
     .from(userResumes)
     .where(eq(userResumes.id, id));

--- a/apps/web/app/api/resume/[id]/route.ts
+++ b/apps/web/app/api/resume/[id]/route.ts
@@ -39,14 +39,10 @@ export async function PATCH(
   const { oldBullet, newBullet } = parsed.data;
 
   let existing;
-  try {
-    [existing] = await db
-      .select()
-      .from(userResumes)
-      .where(eq(userResumes.id, id));
-  } catch {
-    return NextResponse.json({ error: "Resume not found" }, { status: 404 });
-  }
+  [existing] = await db
+    .select()
+    .from(userResumes)
+    .where(eq(userResumes.id, id));
 
   if (!existing) {
     return NextResponse.json({ error: "Resume not found" }, { status: 404 });

--- a/apps/web/app/api/resume/rewrite-bullet/route.integration.test.ts
+++ b/apps/web/app/api/resume/rewrite-bullet/route.integration.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
+import { NextRequest } from "next/server";
+import {
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../../tests/setup-db";
+import { users, userResumes } from "@/lib/schema";
+
+// Use vi.hoisted so mocks are available when vi.mock factories run
+const { mockAuth, mockCreate, mockCheckRateLimit } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockCreate: vi.fn(),
+  mockCheckRateLimit: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return getTestDb();
+  },
+}));
+
+// Mock OpenAI constructor — lazy-init in the route, so we mock the class
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    chat = {
+      completions: {
+        create: mockCreate,
+      },
+    };
+  },
+}));
+
+// Mock rate limiting — allow by default
+vi.mock("@/lib/api-utils", () => ({
+  checkRateLimit: mockCheckRateLimit,
+}));
+
+import { POST } from "./route";
+
+const TEST_USER = {
+  id: "00000000-0000-0000-0000-000000000021",
+  email: "test-rewrite@example.com",
+  name: "Rewrite Test User",
+};
+
+const OTHER_USER = {
+  id: "00000000-0000-0000-0000-000000000022",
+  email: "other-rewrite@example.com",
+  name: "Other Rewrite User",
+};
+
+let testResumeId: string;
+let otherResumeId: string;
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3000/api/resume/rewrite-bullet", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const MOCK_VARIANTS = [
+  "Led 15-person engineering team to deliver migration on time, reducing latency by 40%",
+  "Drove architecture migration, improving system throughput by 40% and eliminating 3 critical bottlenecks",
+  "Spearheaded monolith-to-microservices migration for 50k+ users, cutting P99 latency by 40%",
+];
+
+describe("API POST /api/resume/rewrite-bullet (integration)", () => {
+  beforeAll(async () => {
+    const db = getTestDb();
+    await db.insert(users).values(TEST_USER).onConflictDoNothing();
+    await db.insert(users).values(OTHER_USER).onConflictDoNothing();
+
+    const [resume] = await db
+      .insert(userResumes)
+      .values({
+        userId: TEST_USER.id,
+        filename: "test-resume.txt",
+        content: "Led migration of monolith to microservices, reducing latency",
+      })
+      .returning();
+    testResumeId = resume.id;
+
+    const [other] = await db
+      .insert(userResumes)
+      .values({
+        userId: OTHER_USER.id,
+        filename: "other-resume.txt",
+        content: "Other user resume content",
+      })
+      .returning();
+    otherResumeId = other.id;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Re-set default after clearAllMocks
+    mockCheckRateLimit.mockResolvedValue(null);
+
+    mockCreate.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({ variants: MOCK_VARIANTS }),
+          },
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest({ resumeId: testResumeId, bullet: "Did some work" })
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid body (missing bullet)", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(makeRequest({ resumeId: testResumeId }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("Invalid request");
+  });
+
+  it("returns 400 for invalid resumeId format (not uuid)", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(makeRequest({ resumeId: "not-a-uuid", bullet: "Did some work" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when resumeId belongs to another user (authorization)", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(
+      makeRequest({ resumeId: otherResumeId, bullet: "Did some work" })
+    );
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toContain("not found");
+  });
+
+  it("happy path: returns exactly 3 variants", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(
+      makeRequest({
+        resumeId: testResumeId,
+        bullet: "Participated in team meetings",
+        roleTitle: "Software Engineer",
+        roleCompany: "Acme Corp",
+      })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data.variants)).toBe(true);
+    expect(data.variants).toHaveLength(3);
+    data.variants.forEach((v: unknown) => expect(typeof v).toBe("string"));
+  });
+
+  it("DB row is unchanged after call (no write side-effect)", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const db = getTestDb();
+    const { eq } = await import("drizzle-orm");
+
+    // Snapshot the row before
+    const [before] = await db.select().from(userResumes).where(eq(userResumes.id, testResumeId));
+
+    await POST(makeRequest({ resumeId: testResumeId, bullet: "Did some work" }));
+
+    // Snapshot the row after
+    const [after] = await db.select().from(userResumes).where(eq(userResumes.id, testResumeId));
+    expect(after.content).toBe(before.content);
+    expect(after.structuredData).toEqual(before.structuredData);
+  });
+
+  it("returns 500 when OpenAI throws", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    mockCreate.mockRejectedValue(new Error("OpenAI error"));
+    const res = await POST(
+      makeRequest({ resumeId: testResumeId, bullet: "Did some work" })
+    );
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/web/app/api/resume/rewrite-bullet/route.ts
+++ b/apps/web/app/api/resume/rewrite-bullet/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { userResumes } from "@/lib/schema";
+import { and, eq } from "drizzle-orm";
+import { createRequestLogger } from "@/lib/logger";
+import { checkRateLimit } from "@/lib/api-utils";
+import { rewriteBulletSchema } from "@/lib/validations";
+import OpenAI from "openai";
+
+// POST /api/resume/rewrite-bullet — return 3 AI-rewritten variants of a weak bullet.
+// No DB write — the user must accept a variant via PATCH /api/resume/[id].
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = session.user.id;
+  const log = createRequestLogger({ route: "POST /api/resume/rewrite-bullet", userId });
+
+  const rateLimited = await checkRateLimit(userId, "openai");
+  if (rateLimited) return rateLimited;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = rewriteBulletSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request", details: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  const { resumeId, bullet, roleTitle, roleCompany } = parsed.data;
+
+  // Scope fetch to the authenticated user — foreign resumeId → 404
+  const [resume] = await db
+    .select({ id: userResumes.id })
+    .from(userResumes)
+    .where(and(eq(userResumes.id, resumeId), eq(userResumes.userId, userId)));
+
+  if (!resume) {
+    return NextResponse.json({ error: "Resume not found" }, { status: 404 });
+  }
+
+  const contextParts: string[] = [];
+  if (roleTitle) contextParts.push(`Role: ${roleTitle}`);
+  if (roleCompany) contextParts.push(`Company: ${roleCompany}`);
+  const contextStr = contextParts.length > 0 ? `\n${contextParts.join("\n")}` : "";
+
+  const userPrompt = `Bullet to rewrite:
+"${bullet}"${contextStr}
+
+Return exactly 3 stronger variants as JSON: { "variants": ["...", "...", "..."] }
+Each variant must use an action verb, add a quantifiable impact, and preserve the same facts. Do not invent numbers.`;
+
+  const responseJsonSchema = {
+    type: "object",
+    properties: {
+      variants: {
+        type: "array",
+        items: { type: "string" },
+      },
+    },
+    required: ["variants"],
+    additionalProperties: false,
+  };
+
+  try {
+    // Lazy-init: never construct at module load (next build safety — see CLAUDE.md)
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+    const completion = await openai.chat.completions.create({
+      model: "gpt-5.4-mini",
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are a professional resume coach. Rewrite weak resume bullets to add quantifiable impact, use strong action verbs, and keep the same facts. Do not invent numbers.",
+        },
+        { role: "user", content: userPrompt },
+      ],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "bullet_variants",
+          strict: true,
+          schema: responseJsonSchema,
+        },
+      },
+      max_completion_tokens: 600,
+    });
+
+    const rawContent = completion.choices[0]?.message?.content;
+    if (!rawContent) {
+      log.error({}, "OpenAI returned no content");
+      return NextResponse.json({ error: "Failed to generate rewrites" }, { status: 500 });
+    }
+
+    let data: { variants: string[] };
+    try {
+      data = JSON.parse(rawContent) as { variants: string[] };
+    } catch {
+      log.error({ rawContent }, "Failed to parse OpenAI response as JSON");
+      return NextResponse.json({ error: "Failed to generate rewrites" }, { status: 500 });
+    }
+
+    if (!Array.isArray(data.variants) || data.variants.length < 1) {
+      log.error({ data }, "OpenAI response missing variants array");
+      return NextResponse.json({ error: "Failed to generate rewrites" }, { status: 500 });
+    }
+
+    // Ensure exactly 3 — pad or trim if LLM misbehaved despite strict schema
+    const variants = data.variants.slice(0, 3);
+    while (variants.length < 3) {
+      variants.push(variants[variants.length - 1] ?? bullet);
+    }
+
+    log.info({ resumeId, variantCount: variants.length }, "Bullet rewrites generated");
+
+    return NextResponse.json({ variants });
+  } catch (err) {
+    log.error({ err }, "Failed to generate bullet rewrites");
+    return NextResponse.json({ error: "Failed to generate rewrites" }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/resume/route.ts
+++ b/apps/web/app/api/resume/route.ts
@@ -19,6 +19,7 @@ export async function GET() {
       id: userResumes.id,
       filename: userResumes.filename,
       content: userResumes.content,
+      structuredData: userResumes.structuredData,
       createdAt: userResumes.createdAt,
     })
     .from(userResumes)

--- a/apps/web/app/api/resume/upload/route.integration.test.ts
+++ b/apps/web/app/api/resume/upload/route.integration.test.ts
@@ -7,8 +7,12 @@ import {
 } from "../../../../tests/setup-db";
 import { users, userResumes } from "@/lib/schema";
 
-// Mock auth
-const mockAuth = vi.fn();
+// Use vi.hoisted so mockParseResume is available when vi.mock factories run
+const { mockAuth, mockParseResume } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockParseResume: vi.fn(),
+}));
+
 vi.mock("@/lib/auth", () => ({
   auth: () => mockAuth(),
 }));
@@ -18,6 +22,11 @@ vi.mock("@/lib/db", () => ({
   get db() {
     return getTestDb();
   },
+}));
+
+// Mock the resume parser
+vi.mock("@/lib/resume-parser", () => ({
+  parseResume: mockParseResume,
 }));
 
 import { POST } from "./route";
@@ -51,6 +60,18 @@ function makeUploadRequest(content: string | null, filename: string, mimeType: s
   return req;
 }
 
+const MOCK_STRUCTURED = {
+  roles: [
+    {
+      company: "Acme Corp",
+      title: "Engineer",
+      dates: "2020-2023",
+      bullets: [{ text: "Did stuff", impact_score: 5, has_quantified_metric: false }],
+    },
+  ],
+  skills: ["TypeScript"],
+};
+
 describe("API POST /api/resume/upload (integration)", () => {
   beforeAll(async () => {
     const db = getTestDb();
@@ -58,6 +79,8 @@ describe("API POST /api/resume/upload (integration)", () => {
   });
 
   beforeEach(async () => {
+    vi.clearAllMocks();
+    mockParseResume.mockResolvedValue(MOCK_STRUCTURED);
     const db = getTestDb();
     await db.delete(userResumes);
   });
@@ -71,6 +94,33 @@ describe("API POST /api/resume/upload (integration)", () => {
     mockAuth.mockResolvedValue(null);
     const res = await POST(makeUploadRequest("resume text", "resume.txt", "text/plain"));
     expect(res.status).toBe(401);
+  });
+
+  it("populates structured_data in DB when parser succeeds", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    mockParseResume.mockResolvedValue(MOCK_STRUCTURED);
+    const content = "John Doe\nSoftware Engineer\n5 years experience";
+    const res = await POST(makeUploadRequest(content, "resume.txt", "text/plain"));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.structuredData).not.toBeNull();
+    expect(data.structuredData.roles[0].company).toBe("Acme Corp");
+
+    // Verify persisted in DB
+    const db = getTestDb();
+    const { eq } = await import("drizzle-orm");
+    const [row] = await db.select().from(userResumes).where(eq(userResumes.id, data.id));
+    expect(row.structuredData).not.toBeNull();
+  });
+
+  it("succeeds with structured_data: null when parser throws", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    mockParseResume.mockRejectedValue(new Error("Parse failure"));
+    const content = "John Doe\nEngineer";
+    const res = await POST(makeUploadRequest(content, "resume2.txt", "text/plain"));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.structuredData).toBeNull();
   });
 
   it("returns 400 when no file is provided", async () => {

--- a/apps/web/app/api/resume/upload/route.ts
+++ b/apps/web/app/api/resume/upload/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { userResumes } from "@/lib/schema";
 import { createRequestLogger } from "@/lib/logger";
+import { parseResume } from "@/lib/resume-parser";
 import OpenAI from "openai";
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
@@ -124,16 +125,25 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Parse structured data — failure is non-fatal; we still store the resume
+  let structuredData = null;
+  try {
+    structuredData = await parseResume(content);
+  } catch (err) {
+    log.warn({ err }, "parseResume threw unexpectedly; proceeding with structuredData: null");
+  }
+
   const [resume] = await db
     .insert(userResumes)
     .values({
       userId: session.user.id,
       filename,
       content,
+      structuredData,
     })
     .returning();
 
-  log.info({ resumeId: resume.id, filename }, "Resume uploaded");
+  log.info({ resumeId: resume.id, filename, hasStructuredData: structuredData !== null }, "Resume uploaded");
 
   return NextResponse.json(resume, { status: 201 });
 }

--- a/apps/web/app/resume/components/ImproveBulletDrawer.test.tsx
+++ b/apps/web/app/resume/components/ImproveBulletDrawer.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ImproveBulletDrawer } from "./ImproveBulletDrawer";
+
+const MOCK_VARIANTS = [
+  "Led 15-person team, reducing latency by 40%",
+  "Drove migration delivering 40% throughput improvement",
+  "Spearheaded architecture overhaul cutting P99 latency by 40%",
+];
+
+function makeDefaultProps(overrides?: Partial<Parameters<typeof ImproveBulletDrawer>[0]>) {
+  return {
+    open: true,
+    onOpenChange: vi.fn(),
+    bullet: "Participated in team meetings",
+    roleTitle: "Software Engineer",
+    roleCompany: "Acme Corp",
+    resumeId: "resume-123",
+    onAccept: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("ImproveBulletDrawer", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ variants: MOCK_VARIANTS }),
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it("shows loading skeleton while fetching", () => {
+    // Make fetch hang so skeleton stays visible
+    global.fetch = vi.fn().mockReturnValue(new Promise(() => {})) as unknown as typeof fetch;
+    render(<ImproveBulletDrawer {...makeDefaultProps()} />);
+    // Skeleton blocks should be present (animate-pulse)
+    const skeleton = document.querySelectorAll(".animate-pulse");
+    expect(skeleton.length).toBeGreaterThan(0);
+  });
+
+  it("renders 3 variant choices after fetch resolves", async () => {
+    render(<ImproveBulletDrawer {...makeDefaultProps()} />);
+    await waitFor(() => {
+      expect(screen.getAllByText(MOCK_VARIANTS[0]).length).toBeGreaterThanOrEqual(1);
+    });
+    expect(screen.getAllByText(MOCK_VARIANTS[1]).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(MOCK_VARIANTS[2]).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("Accept button calls onAccept with the correct old and new bullet, then closes", async () => {
+    const onAccept = vi.fn().mockResolvedValue(undefined);
+    const onOpenChange = vi.fn();
+    render(
+      <ImproveBulletDrawer
+        {...makeDefaultProps({ onAccept, onOpenChange })}
+      />
+    );
+    await waitFor(() => {
+      expect(screen.getAllByText(MOCK_VARIANTS[0]).length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Click the first Accept button
+    const acceptButtons = screen.getAllByRole("button", { name: /accept/i });
+    fireEvent.click(acceptButtons[0]);
+
+    await waitFor(() => {
+      expect(onAccept).toHaveBeenCalledWith("Participated in team meetings", MOCK_VARIANTS[0]);
+    });
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("surfaces 429 rate-limit inline banner (not alert/dialog)", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: async () => ({ error: "Too many requests" }),
+    }) as unknown as typeof fetch;
+
+    render(<ImproveBulletDrawer {...makeDefaultProps()} />);
+
+    await waitFor(() => {
+      const banner = screen.getByRole("status");
+      expect(banner.textContent).toMatch(/hit the AI usage limit/i);
+    });
+  });
+
+  it("renders the original bullet text in the drawer", async () => {
+    render(<ImproveBulletDrawer {...makeDefaultProps()} />);
+    // Original bullet should be visible
+    await waitFor(() => {
+      expect(screen.getAllByText("Participated in team meetings").length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/apps/web/app/resume/components/ImproveBulletDrawer.tsx
+++ b/apps/web/app/resume/components/ImproveBulletDrawer.tsx
@@ -157,7 +157,7 @@ export function ImproveBulletDrawer({
                   variant="outline"
                   disabled={isAccepting}
                   onClick={() => handleAccept(variant)}
-                  className="gap-1.5"
+                  className="gap-1.5 min-h-[44px]"
                 >
                   <Check className="h-3.5 w-3.5" aria-hidden="true" />
                   Accept

--- a/apps/web/app/resume/components/ImproveBulletDrawer.tsx
+++ b/apps/web/app/resume/components/ImproveBulletDrawer.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Sparkles, Check } from "lucide-react";
+
+interface ImproveBulletDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  bullet: string;
+  roleTitle: string;
+  roleCompany: string;
+  resumeId: string;
+  /** Called when user accepts a variant — parent handles the PATCH and undo stack */
+  onAccept: (oldBullet: string, newBullet: string) => Promise<void>;
+}
+
+export function ImproveBulletDrawer({
+  open,
+  onOpenChange,
+  bullet,
+  roleTitle,
+  roleCompany,
+  resumeId,
+  onAccept,
+}: ImproveBulletDrawerProps) {
+  const [variants, setVariants] = useState<string[]>([]);
+  const [isFetching, setIsFetching] = useState(false);
+  const [isAccepting, setIsAccepting] = useState(false);
+  const [rateLimitError, setRateLimitError] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  // Fetch variants whenever the drawer opens with a new bullet
+  useEffect(() => {
+    if (!open || !bullet) return;
+
+    let cancelled = false;
+    setVariants([]);
+    setRateLimitError(false);
+    setFetchError(null);
+    setIsFetching(true);
+
+    fetch("/api/resume/rewrite-bullet", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ resumeId, bullet, roleTitle, roleCompany }),
+    })
+      .then(async (res) => {
+        if (cancelled) return;
+        if (res.status === 429) {
+          setRateLimitError(true);
+          return;
+        }
+        if (!res.ok) {
+          setFetchError("Failed to generate rewrites. Please try again.");
+          return;
+        }
+        const data = await res.json() as { variants: string[] };
+        if (!cancelled) setVariants(data.variants ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setFetchError("Network error. Please try again.");
+      })
+      .finally(() => {
+        if (!cancelled) setIsFetching(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, bullet, resumeId, roleTitle, roleCompany]);
+
+  async function handleAccept(variant: string) {
+    setIsAccepting(true);
+    try {
+      await onAccept(bullet, variant);
+      onOpenChange(false);
+    } finally {
+      setIsAccepting(false);
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="w-full sm:max-w-lg overflow-y-auto"
+      >
+        <SheetHeader className="mb-4">
+          <SheetTitle className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5 text-[color:var(--primary)]" aria-hidden="true" />
+            Improve This Bullet
+          </SheetTitle>
+          <SheetDescription>
+            Review AI-generated rewrites and accept one to update your resume.
+          </SheetDescription>
+        </SheetHeader>
+
+        {/* Original bullet */}
+        <div className="mb-4 rounded-md border bg-muted/40 p-3">
+          <p className="text-xs font-medium text-muted-foreground mb-1">Original</p>
+          <p className="text-sm">{bullet}</p>
+        </div>
+
+        {/* 429 rate-limit banner */}
+        {rateLimitError && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="mb-4 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+          >
+            You&apos;ve hit the AI usage limit. Please wait a minute and try again.
+          </div>
+        )}
+
+        {/* Generic error */}
+        {fetchError && !rateLimitError && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="mb-4 rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+          >
+            {fetchError}
+          </div>
+        )}
+
+        {/* Loading skeleton — 3 blocks mirroring the 3 variant cards */}
+        {isFetching && !rateLimitError && (
+          <div className="space-y-3" aria-label="Loading rewrites">
+            {[1, 2, 3].map((i) => (
+              <div
+                key={i}
+                className="animate-pulse rounded-md bg-muted h-20"
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Variants list */}
+        {!isFetching && variants.length > 0 && (
+          <div className="space-y-3">
+            {variants.map((variant, idx) => (
+              <div
+                key={idx}
+                className="rounded-md border p-3 space-y-2 motion-safe:transition-colors hover:border-primary/50"
+              >
+                <p className="text-sm">{variant}</p>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={isAccepting}
+                  onClick={() => handleAccept(variant)}
+                  className="gap-1.5"
+                >
+                  <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                  Accept
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/web/app/resume/components/StructuredResumeView.test.tsx
+++ b/apps/web/app/resume/components/StructuredResumeView.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { StructuredResumeView } from "./StructuredResumeView";
+import type { StructuredResume } from "@/lib/resume-parser";
+
+const MOCK_DATA: StructuredResume = {
+  roles: [
+    {
+      company: "Acme Corp",
+      title: "Senior Engineer",
+      dates: "2020-2023",
+      bullets: [
+        { text: "Led migration of monolith to microservices, reducing latency by 40%", impact_score: 9, has_quantified_metric: true },
+        { text: "Participated in team meetings", impact_score: 2, has_quantified_metric: false },
+        { text: "Wrote unit tests for core modules", impact_score: 6, has_quantified_metric: false },
+      ],
+    },
+    {
+      company: "Beta Inc",
+      title: "Junior Developer",
+      dates: "2018-2020",
+      bullets: [
+        { text: "Fixed bugs in the codebase", impact_score: 3, has_quantified_metric: false },
+      ],
+    },
+  ],
+  skills: ["TypeScript", "Node.js", "Postgres"],
+};
+
+describe("StructuredResumeView", () => {
+  const defaultProps = {
+    structuredData: MOCK_DATA,
+    resumeId: "resume-123",
+    onImprove: vi.fn(),
+    improvingBullet: null,
+  };
+
+  it("renders all roles in the navigation list", () => {
+    render(<StructuredResumeView {...defaultProps} />);
+    expect(screen.getAllByText("Acme Corp").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Beta Inc").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders the first role detail by default (company, title, dates, bullets)", () => {
+    render(<StructuredResumeView {...defaultProps} />);
+    // Role detail should show title and company
+    expect(screen.getAllByText("Senior Engineer").length).toBeGreaterThanOrEqual(1);
+    // Bullet text visible
+    expect(screen.getAllByText(/Led migration of monolith/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders skills chips", () => {
+    render(<StructuredResumeView {...defaultProps} />);
+    expect(screen.getAllByText("TypeScript").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Node.js").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Postgres").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders Improve button only for weak bullets (impact_score < 6)", () => {
+    render(<StructuredResumeView {...defaultProps} />);
+    // "Participated in team meetings" has score 2 → weak → Improve button
+    const improveButtons = screen.getAllByRole("button", { name: /rewrite bullet with ai/i });
+    // Score 9 (strong) and score 6 (moderate) should NOT have Improve
+    // Score 2 (weak) should have Improve
+    expect(improveButtons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not render Improve button for non-weak bullets (score >= 6)", () => {
+    const singleStrongBullet: StructuredResume = {
+      roles: [
+        {
+          company: "Co",
+          title: "Eng",
+          dates: "2020",
+          bullets: [{ text: "Strong bullet with 50% improvement", impact_score: 8, has_quantified_metric: true }],
+        },
+      ],
+      skills: [],
+    };
+    render(
+      <StructuredResumeView
+        structuredData={singleStrongBullet}
+        resumeId="r1"
+        onImprove={vi.fn()}
+        improvingBullet={null}
+      />
+    );
+    const improveButtons = screen.queryAllByRole("button", { name: /rewrite bullet with ai/i });
+    expect(improveButtons).toHaveLength(0);
+  });
+
+  it("switching role in nav updates the detail pane", () => {
+    render(<StructuredResumeView {...defaultProps} />);
+
+    // Click Beta Inc in the nav
+    const betaButtons = screen.getAllByText("Beta Inc");
+    fireEvent.click(betaButtons[0]);
+
+    // Should now show Beta Inc's bullet
+    expect(screen.getAllByText("Fixed bugs in the codebase").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("impact chip colour reflects the score band", () => {
+    const { container } = render(<StructuredResumeView {...defaultProps} />);
+    // High score (9) → cedar class
+    const cedarChips = container.querySelectorAll(".text-\\[color\\:var\\(--primary\\)\\]");
+    expect(cedarChips.length).toBeGreaterThanOrEqual(1);
+    // Low score (2) → destructive class
+    const destructiveChips = container.querySelectorAll(".text-destructive");
+    expect(destructiveChips.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("Improve button is disabled while that bullet is in-flight (improvingBullet set)", () => {
+    const weakBullet = "Participated in team meetings";
+    render(
+      <StructuredResumeView
+        {...defaultProps}
+        improvingBullet={weakBullet}
+      />
+    );
+    const btn = screen.getByRole("button", { name: /rewrite bullet with ai/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it("renders empty state message when no roles and no skills", () => {
+    render(
+      <StructuredResumeView
+        structuredData={{ roles: [], skills: [] }}
+        resumeId="r1"
+        onImprove={vi.fn()}
+        improvingBullet={null}
+      />
+    );
+    expect(screen.getAllByText(/No structured data was extracted/).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/app/resume/components/StructuredResumeView.tsx
+++ b/apps/web/app/resume/components/StructuredResumeView.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Sparkles } from "lucide-react";
+import type { StructuredResume } from "@/lib/resume-parser";
+
+interface StructuredResumeViewProps {
+  structuredData: StructuredResume;
+  /** resumeId reserved for future use (deep-link, analytics) */
+  resumeId?: string;
+  onImprove: (bullet: string, roleTitle: string, roleCompany: string) => void;
+  improvingBullet: string | null; // bullet text currently in-flight
+}
+
+/** Returns Tailwind class based on impact band. */
+function getImpactClass(score: number): string {
+  if (score >= 8) return "text-[color:var(--primary)]";
+  if (score >= 6) return "text-[color:var(--chart-2)]";
+  return "text-destructive";
+}
+
+export function StructuredResumeView({
+  structuredData,
+  onImprove,
+  improvingBullet,
+}: StructuredResumeViewProps) {
+  const [selectedRoleIndex, setSelectedRoleIndex] = useState(0);
+
+  const selectedRole = structuredData.roles[selectedRoleIndex] ?? null;
+
+  if (structuredData.roles.length === 0 && structuredData.skills.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground py-4">
+        No structured data was extracted from this resume.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {structuredData.roles.length > 0 ? (
+        <>
+          {/* Two-pane layout: role list left, detail right */}
+          <div className="flex flex-col gap-4 md:grid md:grid-cols-[200px_1fr]">
+            {/* Roles list */}
+            <nav
+              aria-label="Resume roles"
+              className="flex flex-row gap-1 overflow-x-auto md:flex-col md:overflow-x-visible"
+            >
+              {structuredData.roles.map((role, idx) => (
+                <button
+                  key={idx}
+                  onClick={() => setSelectedRoleIndex(idx)}
+                  className={`rounded-md px-3 py-2 text-left text-sm transition-colors min-w-[140px] md:min-w-0 ${
+                    selectedRoleIndex === idx
+                      ? "bg-primary/10 font-medium text-[color:var(--primary)]"
+                      : "hover:bg-accent text-muted-foreground"
+                  }`}
+                  aria-pressed={selectedRoleIndex === idx}
+                >
+                  <span className="block font-medium truncate">{role.company}</span>
+                  <span className="block text-xs truncate">{role.title}</span>
+                </button>
+              ))}
+            </nav>
+
+            {/* Role detail */}
+            {selectedRole && (
+              <div className="space-y-3">
+                <div>
+                  <p className="font-semibold text-base">{selectedRole.title}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {selectedRole.company}
+                    {selectedRole.dates ? ` · ${selectedRole.dates}` : ""}
+                  </p>
+                </div>
+
+                {selectedRole.bullets.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No bullets extracted for this role.</p>
+                ) : (
+                  <ul className="space-y-3">
+                    {selectedRole.bullets.map((bullet, bIdx) => {
+                      const isWeak = bullet.impact_score < 6;
+                      const isImproving = improvingBullet === bullet.text;
+                      return (
+                        <li key={bIdx} className="flex flex-col gap-1.5 rounded-md border p-3">
+                          <p className="text-sm">{bullet.text}</p>
+                          <div className="flex flex-wrap items-center gap-2">
+                            {/* Impact chip */}
+                            <Badge
+                              variant="outline"
+                              className={`text-xs font-medium ${getImpactClass(bullet.impact_score)}`}
+                            >
+                              Impact {bullet.impact_score}/10
+                            </Badge>
+
+                            {/* Quantified metric pill */}
+                            {bullet.has_quantified_metric && (
+                              <Badge variant="secondary" className="text-xs">
+                                Quantified
+                              </Badge>
+                            )}
+
+                            {/* Improve button for weak bullets */}
+                            {isWeak && (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                aria-label="Rewrite bullet with AI"
+                                aria-disabled={isImproving}
+                                disabled={isImproving}
+                                onClick={() =>
+                                  onImprove(bullet.text, selectedRole.title, selectedRole.company)
+                                }
+                                className="h-8 min-h-[44px] gap-1.5 motion-safe:transition-opacity"
+                              >
+                                <Sparkles
+                                  className="h-4 w-4 text-[color:var(--primary)]"
+                                  aria-hidden="true"
+                                />
+                                {isImproving ? "Improving..." : "Improve"}
+                              </Button>
+                            )}
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+        </>
+      ) : (
+        <p className="text-sm text-muted-foreground">No roles were extracted from this resume.</p>
+      )}
+
+      {/* Skills section */}
+      {structuredData.skills.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-muted-foreground">Skills</p>
+          <div className="flex flex-wrap gap-1.5">
+            {structuredData.skills.map((skill, idx) => (
+              <Badge key={idx} variant="secondary" className="text-xs">
+                {skill}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/resume/page.tsx
+++ b/apps/web/app/resume/page.tsx
@@ -16,13 +16,29 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { FileText, Upload, Loader2, Sparkles, Trash2 } from "lucide-react";
+import { FileText, Upload, Loader2, Sparkles, Trash2, Undo2 } from "lucide-react";
+import { StructuredResumeView } from "./components/StructuredResumeView";
+import { ImproveBulletDrawer } from "./components/ImproveBulletDrawer";
+import type { StructuredResume } from "@/lib/resume-parser";
 
 interface Resume {
   id: string;
   filename: string;
   content: string;
+  structuredData?: StructuredResume | null;
   createdAt: string;
+}
+
+interface UndoEntry {
+  oldBullet: string;
+  newBullet: string;
+}
+
+interface DrawerState {
+  open: boolean;
+  bullet: string;
+  roleTitle: string;
+  roleCompany: string;
 }
 
 interface GeneratedQuestion {
@@ -48,6 +64,16 @@ export default function ResumePage() {
   // Delete state
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  // Structured view: bullet rewrite drawer + session-local undo stack
+  const [drawerState, setDrawerState] = useState<DrawerState>({
+    open: false,
+    bullet: "",
+    roleTitle: "",
+    roleCompany: "",
+  });
+  const [undoStack, setUndoStack] = useState<UndoEntry[]>([]);
+  const [improvingBullet, setImprovingBullet] = useState<string | null>(null);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -169,6 +195,60 @@ export default function ResumePage() {
     } finally {
       setIsDeleting(false);
     }
+  };
+
+  const handleImprove = (bullet: string, roleTitle: string, roleCompany: string) => {
+    setImprovingBullet(bullet);
+    setDrawerState({ open: true, bullet, roleTitle, roleCompany });
+  };
+
+  const handleDrawerOpenChange = (open: boolean) => {
+    setDrawerState((prev) => ({ ...prev, open }));
+    if (!open) setImprovingBullet(null);
+  };
+
+  /**
+   * Accept a bullet variant — PATCH the resume, update local state, push undo entry.
+   */
+  const handleAcceptVariant = async (oldBullet: string, newBullet: string) => {
+    if (!selectedResumeId) return;
+    const res = await fetch(`/api/resume/${selectedResumeId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ oldBullet, newBullet }),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      showMessage("error", (err as { error?: string }).error ?? "Failed to update bullet");
+      return;
+    }
+    const updated = await res.json() as Resume;
+    setResumes((prev) => prev.map((r) => (r.id === updated.id ? updated : r)));
+    setUndoStack((prev) => [{ oldBullet, newBullet }, ...prev]);
+    setImprovingBullet(null);
+    showMessage("success", "Bullet updated. Use Undo to revert.");
+  };
+
+  /**
+   * Undo the last rewrite — issues a reverse PATCH (new→old).
+   * In-memory only; dies on navigation (per spec).
+   */
+  const handleUndo = async () => {
+    if (undoStack.length === 0 || !selectedResumeId) return;
+    const [{ oldBullet, newBullet }, ...rest] = undoStack;
+    const res = await fetch(`/api/resume/${selectedResumeId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ oldBullet: newBullet, newBullet: oldBullet }),
+    });
+    if (!res.ok) {
+      showMessage("error", "Failed to undo rewrite");
+      return;
+    }
+    const updated = await res.json() as Resume;
+    setResumes((prev) => prev.map((r) => (r.id === updated.id ? updated : r)));
+    setUndoStack(rest);
+    showMessage("success", "Rewrite undone.");
   };
 
   const handleGenerateQuestions = async () => {
@@ -435,6 +515,36 @@ export default function ResumePage() {
               </CardContent>
             </Card>
           )}
+
+          {/* Structured view — only when structuredData present */}
+          {selectedResume?.structuredData && (
+            <Card>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <CardTitle>Structured View</CardTitle>
+                  {undoStack.length > 0 && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleUndo}
+                      className="gap-1.5 text-sm"
+                    >
+                      <Undo2 className="h-4 w-4" aria-hidden="true" />
+                      Undo last rewrite
+                    </Button>
+                  )}
+                </div>
+              </CardHeader>
+              <CardContent>
+                <StructuredResumeView
+                  structuredData={selectedResume.structuredData}
+                  resumeId={selectedResume.id}
+                  onImprove={handleImprove}
+                  improvingBullet={improvingBullet}
+                />
+              </CardContent>
+            </Card>
+          )}
         </div>
 
         {/* Right column — Generate Questions */}
@@ -578,6 +688,19 @@ export default function ResumePage() {
           )}
         </div>
       </div>
+
+      {/* Improve bullet drawer — right sheet on desktop, bottom on mobile */}
+      {selectedResume && (
+        <ImproveBulletDrawer
+          open={drawerState.open}
+          onOpenChange={handleDrawerOpenChange}
+          bullet={drawerState.bullet}
+          roleTitle={drawerState.roleTitle}
+          roleCompany={drawerState.roleCompany}
+          resumeId={selectedResume.id}
+          onAccept={handleAcceptVariant}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/app/resume/resume.test.tsx
+++ b/apps/web/app/resume/resume.test.tsx
@@ -12,6 +12,38 @@ const mockResumes = [
     filename: "my_resume.pdf",
     content: "John Doe\nSoftware Engineer\n5 years experience",
     createdAt: "2026-01-15T00:00:00Z",
+    structuredData: null,
+  },
+];
+
+const mockResumesWithStructured = [
+  {
+    id: "resume-2",
+    filename: "structured_resume.pdf",
+    content: "John Doe\nSoftware Engineer at Acme Corp",
+    createdAt: "2026-01-15T00:00:00Z",
+    structuredData: {
+      roles: [
+        {
+          company: "Acme Corp",
+          title: "Senior Engineer",
+          dates: "2020-2023",
+          bullets: [
+            {
+              text: "Led migration of monolith to microservices, reducing latency by 40%",
+              impact_score: 9,
+              has_quantified_metric: true,
+            },
+            {
+              text: "Participated in team meetings",
+              impact_score: 2,
+              has_quantified_metric: false,
+            },
+          ],
+        },
+      ],
+      skills: ["TypeScript", "Node.js"],
+    },
   },
 ];
 
@@ -108,5 +140,34 @@ describe("ResumePage", () => {
     // Skeleton should show while loading
     const pulseElements = document.querySelectorAll(".animate-pulse");
     expect(pulseElements.length).toBeGreaterThan(0);
+  });
+
+  it("renders Structured View card when structuredData is present", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ resumes: mockResumesWithStructured }),
+    }) as unknown as typeof fetch;
+
+    render(<ResumePage />);
+    await vi.waitFor(() => {
+      expect(screen.getAllByText("Structured View").length).toBeGreaterThanOrEqual(1);
+    });
+    // Role name should be visible inside the structured view
+    expect(screen.getAllByText("Acme Corp").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not render Structured View card when structuredData is null (plaintext-only fallback)", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ resumes: mockResumes }),
+    }) as unknown as typeof fetch;
+
+    render(<ResumePage />);
+    await vi.waitFor(() => {
+      // The resume list should render
+      expect(screen.getAllByText("my_resume.pdf").length).toBeGreaterThanOrEqual(1);
+    });
+    // Structured View card should NOT be present
+    expect(screen.queryByText("Structured View")).toBeNull();
   });
 });

--- a/apps/web/drizzle/0019_public_shatterstar.sql
+++ b/apps/web/drizzle/0019_public_shatterstar.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user_resumes" ADD COLUMN "structured_data" jsonb;

--- a/apps/web/drizzle/meta/0019_snapshot.json
+++ b/apps/web/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,1448 @@
+{
+  "id": "d1a487eb-d77c-4317-a346-6b3a56c87a52",
+  "prevId": "fee6c15d-c879-4ada-b502-f4746664c4e3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.code_snapshots": {
+      "name": "code_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "code_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_result": {
+          "name": "execution_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "code_snapshots_session_id_interview_sessions_id_fk": {
+          "name": "code_snapshots_session_id_interview_sessions_id_fk",
+          "tableFrom": "code_snapshots",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_questions": {
+      "name": "company_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_questions_user_id_users_id_fk": {
+          "name": "company_questions_user_id_users_id_fk",
+          "tableFrom": "company_questions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deleted_usage": {
+      "name": "deleted_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deleted_usage_hash_month_unique": {
+          "name": "deleted_usage_hash_month_unique",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gaze_samples": {
+      "name": "gaze_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gaze_samples_session_id_interview_sessions_id_fk": {
+          "name": "gaze_samples_session_id_interview_sessions_id_fk",
+          "tableFrom": "gaze_samples",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_plans": {
+      "name": "interview_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interview_date": {
+          "name": "interview_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_data": {
+          "name": "plan_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_plans_user_id_users_id_fk": {
+          "name": "interview_plans_user_id_users_id_fk",
+          "tableFrom": "interview_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_sessions": {
+      "name": "interview_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'configuring'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_star_story_id": {
+          "name": "source_star_story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_pro_analysis": {
+          "name": "use_pro_analysis",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_sessions_user_id_users_id_fk": {
+          "name": "interview_sessions_user_id_users_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interview_sessions_source_star_story_id_star_stories_id_fk": {
+          "name": "interview_sessions_source_star_story_id_star_stories_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "source_star_story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_usage": {
+      "name": "interview_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "interview_usage_user_period_unique": {
+          "name": "interview_usage_user_period_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interview_usage_user_id_users_id_fk": {
+          "name": "interview_usage_user_id_users_id_fk",
+          "tableFrom": "interview_usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.openai_usage": {
+      "name": "openai_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd_millis": {
+          "name": "cost_usd_millis",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "openai_usage_user_date_model_unique": {
+          "name": "openai_usage_user_date_model_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_feedback": {
+      "name": "session_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_score": {
+          "name": "overall_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strengths": {
+          "name": "strengths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "weaknesses": {
+          "name": "weaknesses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "answer_analyses": {
+          "name": "answer_analyses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "code_quality_score": {
+          "name": "code_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation_quality_score": {
+          "name": "explanation_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeline_analysis": {
+          "name": "timeline_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_consistency_score": {
+          "name": "gaze_consistency_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_distribution": {
+          "name": "gaze_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_coverage": {
+          "name": "gaze_coverage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_timeline": {
+          "name": "gaze_timeline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drift_analysis": {
+          "name": "drift_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_tier": {
+          "name": "analysis_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_feedback_session_id_interview_sessions_id_fk": {
+          "name": "session_feedback_session_id_interview_sessions_id_fk",
+          "tableFrom": "session_feedback",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_templates": {
+      "name": "session_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_templates_user_id_users_id_fk": {
+          "name": "session_templates_user_id_users_id_fk",
+          "tableFrom": "session_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_stories": {
+      "name": "star_stories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_questions": {
+          "name": "expected_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "situation": {
+          "name": "situation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_stories_user_id_users_id_fk": {
+          "name": "star_stories_user_id_users_id_fk",
+          "tableFrom": "star_stories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_story_analyses": {
+      "name": "star_story_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scores": {
+          "name": "scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_story_analyses_story_id_star_stories_id_fk": {
+          "name": "star_story_analyses_story_id_star_stories_id_fk",
+          "tableFrom": "star_story_analyses",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcripts": {
+      "name": "transcripts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcripts_session_id_interview_sessions_id_fk": {
+          "name": "transcripts_session_id_interview_sessions_id_fk",
+          "tableFrom": "transcripts",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_badge_unique": {
+          "name": "user_badge_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "badge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_resumes": {
+      "name": "user_resumes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structured_data": {
+          "name": "structured_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_resumes_user_id_users_id_fk": {
+          "name": "user_resumes_user_id_users_id_fk",
+          "tableFrom": "user_resumes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "user_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_start": {
+          "name": "plan_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_end": {
+          "name": "plan_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "past_due_at": {
+          "name": "past_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_tracking_enabled": {
+          "name": "gaze_tracking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tour_completed_at": {
+          "name": "tour_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tour_skipped_at": {
+          "name": "tour_skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.code_event_type": {
+      "name": "code_event_type",
+      "schema": "public",
+      "values": [
+        "edit",
+        "run",
+        "submit"
+      ]
+    },
+    "public.interview_type": {
+      "name": "interview_type",
+      "schema": "public",
+      "values": [
+        "behavioral",
+        "technical"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "configuring",
+        "in_progress",
+        "completed",
+        "cancelled",
+        "failed"
+      ]
+    },
+    "public.user_plan": {
+      "name": "user_plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "max"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1776780410797,
       "tag": "0018_lethal_taskmaster",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1776900010028,
+      "tag": "0019_public_shatterstar",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/resume-parser.test.ts
+++ b/apps/web/lib/resume-parser.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Unit tests for resume-parser.ts
+ *
+ * We mock OpenAI so these tests never touch the network. All tests exercise
+ * the schema validation and parseResume() logic branches.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---- Mock OpenAI before importing the module under test ----
+const mockCreate = vi.hoisted(() => vi.fn());
+
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    chat = {
+      completions: {
+        create: mockCreate,
+      },
+    };
+  },
+}));
+
+import {
+  parseResume,
+  structuredResumeSchema,
+  bulletSchema,
+  roleSchema,
+} from "./resume-parser";
+
+// Helper to build a mock OpenAI response
+function mockOpenAIResponse(content: string) {
+  mockCreate.mockResolvedValueOnce({
+    choices: [{ message: { content } }],
+  });
+}
+
+// A well-formed structured resume payload
+const VALID_PAYLOAD = {
+  roles: [
+    {
+      company: "Acme Corp",
+      title: "Software Engineer",
+      dates: "2020-2023",
+      bullets: [
+        {
+          text: "Led migration of monolith to microservices, reducing latency by 40%",
+          impact_score: 9,
+          has_quantified_metric: true,
+        },
+        {
+          text: "Participated in team meetings",
+          impact_score: 2,
+          has_quantified_metric: false,
+        },
+      ],
+    },
+  ],
+  skills: ["TypeScript", "Node.js", "Postgres"],
+};
+
+describe("structuredResumeSchema", () => {
+  it("accepts a valid payload with roles and skills", () => {
+    const result = structuredResumeSchema.safeParse(VALID_PAYLOAD);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an empty roles array (resume with no detected roles)", () => {
+    const result = structuredResumeSchema.safeParse({ roles: [], skills: [] });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a non-integer impact_score", () => {
+    const payload = {
+      roles: [
+        {
+          company: "Co",
+          title: "Eng",
+          dates: "2020",
+          bullets: [{ text: "Did stuff", impact_score: 7.5, has_quantified_metric: false }],
+        },
+      ],
+      skills: [],
+    };
+    const result = structuredResumeSchema.safeParse(payload);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects impact_score out of range (> 10)", () => {
+    const payload = {
+      roles: [
+        {
+          company: "Co",
+          title: "Eng",
+          dates: "2020",
+          bullets: [{ text: "Did stuff", impact_score: 11, has_quantified_metric: false }],
+        },
+      ],
+      skills: [],
+    };
+    const result = structuredResumeSchema.safeParse(payload);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects impact_score below 0", () => {
+    const payload = {
+      roles: [
+        {
+          company: "Co",
+          title: "Eng",
+          dates: "2020",
+          bullets: [{ text: "Did stuff", impact_score: -1, has_quantified_metric: false }],
+        },
+      ],
+      skills: [],
+    };
+    const result = structuredResumeSchema.safeParse(payload);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-boolean has_quantified_metric", () => {
+    const payload = {
+      roles: [
+        {
+          company: "Co",
+          title: "Eng",
+          dates: "2020",
+          bullets: [{ text: "Did stuff", impact_score: 5, has_quantified_metric: "yes" }],
+        },
+      ],
+      skills: [],
+    };
+    const result = structuredResumeSchema.safeParse(payload);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("bulletSchema", () => {
+  it("accepts a valid bullet", () => {
+    const result = bulletSchema.safeParse({ text: "Did stuff", impact_score: 5, has_quantified_metric: false });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty text", () => {
+    const result = bulletSchema.safeParse({ text: "", impact_score: 5, has_quantified_metric: false });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("roleSchema", () => {
+  it("accepts a role with empty bullets array", () => {
+    const result = roleSchema.safeParse({ company: "Co", title: "Eng", dates: "2020", bullets: [] });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("parseResume()", () => {
+  beforeEach(() => {
+    mockCreate.mockReset();
+  });
+
+  it("returns null for empty input without calling OpenAI", async () => {
+    const result = await parseResume("");
+    expect(result).toBeNull();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns null for whitespace-only input without calling OpenAI", async () => {
+    const result = await parseResume("   \n\t  ");
+    expect(result).toBeNull();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns parsed data on a valid LLM response", async () => {
+    mockOpenAIResponse(JSON.stringify(VALID_PAYLOAD));
+    const result = await parseResume("Some resume text");
+    expect(result).not.toBeNull();
+    expect(result!.roles).toHaveLength(1);
+    expect(result!.roles[0].company).toBe("Acme Corp");
+    expect(result!.skills).toContain("TypeScript");
+  });
+
+  it("returns null when LLM returns non-JSON string", async () => {
+    mockOpenAIResponse("I cannot parse this resume, please try again.");
+    const result = await parseResume("Some resume text");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when LLM returns JSON that fails schema validation (invalid impact_score)", async () => {
+    const badPayload = {
+      roles: [
+        {
+          company: "Co",
+          title: "Eng",
+          dates: "2020",
+          bullets: [{ text: "Did stuff", impact_score: 15, has_quantified_metric: false }],
+        },
+      ],
+      skills: [],
+    };
+    mockOpenAIResponse(JSON.stringify(badPayload));
+    const result = await parseResume("Some resume text");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when OpenAI throws an error", async () => {
+    mockCreate.mockRejectedValueOnce(new Error("OpenAI API error"));
+    const result = await parseResume("Some resume text");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when OpenAI returns no content", async () => {
+    mockCreate.mockResolvedValueOnce({ choices: [{ message: { content: null } }] });
+    const result = await parseResume("Some resume text");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when OpenAI returns empty choices", async () => {
+    mockCreate.mockResolvedValueOnce({ choices: [] });
+    const result = await parseResume("Some resume text");
+    expect(result).toBeNull();
+  });
+
+  it("accepts a payload with empty roles (no roles detected in resume)", async () => {
+    mockOpenAIResponse(JSON.stringify({ roles: [], skills: ["JavaScript"] }));
+    const result = await parseResume("John Doe, skills: JavaScript");
+    expect(result).not.toBeNull();
+    expect(result!.roles).toHaveLength(0);
+    expect(result!.skills).toContain("JavaScript");
+  });
+});

--- a/apps/web/lib/resume-parser.ts
+++ b/apps/web/lib/resume-parser.ts
@@ -1,0 +1,138 @@
+/**
+ * Resume parser: uses OpenAI structured output to convert raw resume text
+ * into a typed payload (roles + bullets with impact scores, skills).
+ *
+ * Returns null on any failure so callers can gracefully fall back to
+ * the unstructured plaintext view.
+ *
+ * Lazy-init OpenAI client: never constructed at module load so that
+ * `next build` can import this module without OPENAI_API_KEY present.
+ */
+import { z } from "zod/v4";
+
+// ---- Zod schemas (also used by the DB column type) ----
+
+export const bulletSchema = z.object({
+  text: z.string().min(1).max(800),
+  impact_score: z.number().int().min(0).max(10),
+  has_quantified_metric: z.boolean(),
+});
+
+export const roleSchema = z.object({
+  company: z.string().min(1).max(200),
+  title: z.string().min(1).max(200),
+  dates: z.string().max(120),
+  bullets: z.array(bulletSchema).max(20),
+});
+
+export const structuredResumeSchema = z.object({
+  roles: z.array(roleSchema).max(20),
+  skills: z.array(z.string().min(1).max(80)).max(100),
+});
+
+export type StructuredResume = z.infer<typeof structuredResumeSchema>;
+
+// ---- JSON schema for OpenAI structured output ----
+// Mirrors the Zod schema above but expressed as JSON Schema strict mode
+// requires. All fields must be listed in `required`; no `additionalProperties`.
+
+const RESPONSE_JSON_SCHEMA = {
+  type: "object",
+  properties: {
+    roles: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          company: { type: "string" },
+          title: { type: "string" },
+          dates: { type: "string" },
+          bullets: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                text: { type: "string" },
+                impact_score: { type: "integer" },
+                has_quantified_metric: { type: "boolean" },
+              },
+              required: ["text", "impact_score", "has_quantified_metric"],
+              additionalProperties: false,
+            },
+          },
+        },
+        required: ["company", "title", "dates", "bullets"],
+        additionalProperties: false,
+      },
+    },
+    skills: {
+      type: "array",
+      items: { type: "string" },
+    },
+  },
+  required: ["roles", "skills"],
+  additionalProperties: false,
+};
+
+const SYSTEM_PROMPT = `You are a resume analysis expert. Parse the provided resume text into structured JSON.
+
+For each role/position:
+- Extract company name, job title, and date range
+- Extract each bullet point as-is
+- Score each bullet's impact on a scale of 0-10:
+  * 0-5: weak (vague, generic, no measurable outcome)
+  * 6-7: moderate (some specificity but missing metrics or action clarity)
+  * 8-10: strong (clear action verb, quantified impact, specific outcome)
+- Set has_quantified_metric=true only if the bullet contains a number/percentage/dollar amount
+
+For skills: extract all technical skills, tools, languages, and frameworks mentioned.
+
+Return ONLY valid JSON matching the specified schema. No markdown, no commentary.`;
+
+/**
+ * Parse raw resume text into structured data.
+ * Returns null if parsing fails for any reason (network error, invalid JSON,
+ * schema mismatch, empty input) — callers must handle null gracefully.
+ */
+export async function parseResume(text: string): Promise<StructuredResume | null> {
+  if (!text || text.trim().length === 0) return null;
+
+  try {
+    const OpenAI = (await import("openai")).default;
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+    const response = await openai.chat.completions.create({
+      model: "gpt-5.4-mini",
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: text.slice(0, 15000) }, // guard against enormous resumes
+      ],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "structured_resume",
+          strict: true,
+          schema: RESPONSE_JSON_SCHEMA,
+        },
+      },
+      max_completion_tokens: 4000,
+    });
+
+    const rawContent = response.choices[0]?.message?.content;
+    if (!rawContent) return null;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawContent);
+    } catch {
+      return null;
+    }
+
+    const result = structuredResumeSchema.safeParse(parsed);
+    if (!result.success) return null;
+
+    return result.data;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/lib/schema.ts
+++ b/apps/web/lib/schema.ts
@@ -228,6 +228,7 @@ export const userResumes = pgTable("user_resumes", {
     .references(() => users.id, { onDelete: "cascade" }),
   filename: text("filename").notNull(),
   content: text("content").notNull(),
+  structuredData: jsonb("structured_data"),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/apps/web/lib/validations.ts
+++ b/apps/web/lib/validations.ts
@@ -143,3 +143,19 @@ export const gazeSamplesBodySchema = z.object({
   samples: z.array(gazeSampleSchema).min(1).max(3600),
 });
 export type GazeSamplesBody = z.infer<typeof gazeSamplesBodySchema>;
+
+// ---- Resume bullet rewrite schemas ----
+
+export const rewriteBulletSchema = z.object({
+  resumeId: z.uuid(),
+  bullet: z.string().min(1).max(800),
+  roleTitle: z.string().max(200).optional(),
+  roleCompany: z.string().max(200).optional(),
+});
+export type RewriteBulletInput = z.infer<typeof rewriteBulletSchema>;
+
+export const patchResumeBulletSchema = z.object({
+  oldBullet: z.string().min(1).max(800),
+  newBullet: z.string().min(1).max(800),
+});
+export type PatchResumeBulletInput = z.infer<typeof patchResumeBulletSchema>;


### PR DESCRIPTION
## Summary

- Adds `structuredData` JSONB column to `userResumes` via Drizzle migration `0019_public_shatterstar.sql`; stores role/bullet/skills structure parsed by `lib/resume-parser.ts` (OpenAI) on upload and on every bullet edit.
- Adds `PATCH /api/resume/[id]` to replace a single bullet in-place and re-parse structured data, and `POST /api/resume/rewrite-bullet` to generate AI-rewritten bullet variants with per-user rate limiting under the `openai` tier.
- Adds `ImproveBulletDrawer` (Sheet UI) and `StructuredResumeView` components wired to the resume page so users can click any weak bullet (`impact_score < 6`), review three AI rewrites, and accept one — which patches the stored resume, updates the UI, and pushes onto a session-local undo stack.

## Implements

Story #176 — Structured resume coaching (parse + AI bullet rewrite). Not Pro-gated.

## Design notes

- Parse runs inline on upload with graceful fallback — OpenAI/schema failures persist `structured_data: null` and the plaintext view still works.
- Rewrite endpoint returns variants but does **not** persist; only the PATCH accepts writes.
- PATCH does a single string-replace on the first occurrence of `oldBullet` and re-parses. Safe failure mode: 400 if the bullet is not found (no silent no-op).
- 429 rate-limit integration case omitted (shared in-memory limiter would corrupt parallel test state); covered at component level via mocked `fetch → 429` in `ImproveBulletDrawer.test.tsx`.

## Note on inherited test failures

Two pre-existing `PersonaPicker` component tests fail in the suite. They originate from the already-merged PR #179 (`feature/179-personas`) — no `PersonaPicker` file is modified in this diff. Suggested follow-up: file a separate issue against `main` to fix the shadcn `SelectItem` `pointer-events` interaction in jsdom.

## Test plan

- [x] Unit tests pass (18 cases in `lib/resume-parser.test.ts`)
- [x] Component tests pass (`StructuredResumeView` — 9 cases; `ImproveBulletDrawer` — 5 cases including 429 banner; `resume` page — 11 cases)
- [x] Integration tests pass (PATCH `/api/resume/[id]` — 7 cases; POST `/api/resume/rewrite-bullet` — 7 cases; upload parser path — 2 new cases; 415 total passing)
- [x] Lint + typecheck clean
- [x] Drizzle migration committed as full directory (SQL + snapshot + `_journal.json`)
- [x] All routes: `auth()` + 401, ownership check, Zod-validated input, `createRequestLogger` (no `console.log`)
- [x] Accept button meets 44px touch target (`min-h-[44px]`)
- [x] PATCH DB errors bubble to 500 (no masking try/catch)
- [ ] Reviewer approves
- [ ] Manual sanity check by author (upload resume, open drawer, accept a rewrite, confirm content persisted, confirm undo works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)