### PR TITLE
fix(resume): move structured view to right column + button polish

### DIFF
--- a/apps/web/app/resume/components/ImproveBulletDrawer.tsx
+++ b/apps/web/app/resume/components/ImproveBulletDrawer.tsx
@@ -91,7 +91,7 @@ export function ImproveBulletDrawer({
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side="right"
-        className="w-full sm:max-w-lg overflow-y-auto"
+        className="w-full sm:max-w-lg overflow-y-auto px-6"
       >
         <SheetHeader className="mb-4">
           <SheetTitle className="flex items-center gap-2">
@@ -157,7 +157,7 @@ export function ImproveBulletDrawer({
                   variant="outline"
                   disabled={isAccepting}
                   onClick={() => handleAccept(variant)}
-                  className="gap-1.5 min-h-[44px]"
+                  className="gap-1.5"
                 >
                   <Check className="h-3.5 w-3.5" aria-hidden="true" />
                   Accept

--- a/apps/web/app/resume/components/StructuredResumeView.tsx
+++ b/apps/web/app/resume/components/StructuredResumeView.tsx
@@ -114,7 +114,7 @@ export function StructuredResumeView({
                                 onClick={() =>
                                   onImprove(bullet.text, selectedRole.title, selectedRole.company)
                                 }
-                                className="h-8 min-h-[44px] gap-1.5 motion-safe:transition-opacity"
+                                className="h-8 gap-1.5 motion-safe:transition-opacity"
                               >
                                 <Sparkles
                                   className="h-4 w-4 text-[color:var(--primary)]"

--- a/apps/web/app/resume/page.tsx
+++ b/apps/web/app/resume/page.tsx
@@ -516,35 +516,6 @@ export default function ResumePage() {
             </Card>
           )}
 
-          {/* Structured view — only when structuredData present */}
-          {selectedResume?.structuredData && (
-            <Card>
-              <CardHeader>
-                <div className="flex items-center justify-between">
-                  <CardTitle>Structured View</CardTitle>
-                  {undoStack.length > 0 && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={handleUndo}
-                      className="gap-1.5 text-sm"
-                    >
-                      <Undo2 className="h-4 w-4" aria-hidden="true" />
-                      Undo last rewrite
-                    </Button>
-                  )}
-                </div>
-              </CardHeader>
-              <CardContent>
-                <StructuredResumeView
-                  structuredData={selectedResume.structuredData}
-                  resumeId={selectedResume.id}
-                  onImprove={handleImprove}
-                  improvingBullet={improvingBullet}
-                />
-              </CardContent>
-            </Card>
-          )}
         </div>
 
         {/* Right column — Generate Questions */}
@@ -683,6 +654,36 @@ export default function ResumePage() {
                     Use in Behavioral Setup
                   </Button>
                 )}
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Structured view — only when structuredData present */}
+          {selectedResume?.structuredData && (
+            <Card>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <CardTitle>Structured View</CardTitle>
+                  {undoStack.length > 0 && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleUndo}
+                      className="gap-1.5 text-sm"
+                    >
+                      <Undo2 className="h-4 w-4" aria-hidden="true" />
+                      Undo last rewrite
+                    </Button>
+                  )}
+                </div>
+              </CardHeader>
+              <CardContent>
+                <StructuredResumeView
+                  structuredData={selectedResume.structuredData}
+                  resumeId={selectedResume.id}
+                  onImprove={handleImprove}
+                  improvingBullet={improvingBullet}
+                />
               </CardContent>
             </Card>
           )}

--- a/apps/web/app/resume/page.tsx
+++ b/apps/web/app/resume/page.tsx
@@ -344,7 +344,7 @@ export default function ResumePage() {
         <div
           className={`mb-6 rounded-md border px-4 py-3 text-sm ${
             message.type === "success"
-              ? "border-green-500/50 bg-green-500/10 text-green-700 dark:text-green-400"
+              ? "border-[color:var(--chart-1)]/50 bg-[color:var(--chart-1)]/10 text-[color:var(--chart-1)]"
               : "border-destructive/50 bg-destructive/10 text-destructive"
           }`}
         >


### PR DESCRIPTION
## Summary

- Moves the **Structured View** card (+ Undo button + drawer) from the left column to the right column, below Generate Questions. The left column (upload / paste / list / preview) was substantially taller than the right — users missed the structured view entirely during smoke testing.
- Removes `min-h-[44px]` from the **Improve** and **Accept** buttons. Per `apps/web/CLAUDE.md:207`, the 44px touch-target rule targets **icon-only** and chip-sized controls; both of these buttons have a text label alongside the icon, so the softer rule applies. The forced min-height made them look unnaturally tall.
- Adds `px-6` to `SheetContent` in `ImproveBulletDrawer` for a 24px gutter — variant cards were hugging the right edge of the sheet.
- Swaps hardcoded green tokens (`border-green-500/50 bg-green-500/10 text-green-700 dark:text-green-400`) on the success toast for the semantic `var(--chart-1)` (cedar) token — matches the editorial palette and adapts correctly across light/dark modes without a manual `dark:` override. Mirrors the pattern the error branch already uses with `text-destructive`.

## Implements

Post-smoke-test polish on PR #198 (Issue #176 — structured resume coaching).

## Note on inherited flake

Local QA flagged `PersonaPicker.test.tsx` failing in isolation — this test is **pre-existing on main** (inherited from PR #197 / #179, jsdom `pointer-events: none` on shadcn `SelectItem`). It is not touched by this diff and passes when run as part of the full turbo suite. Not blocking this PR; worth a standalone fix on a separate branch.

## Test plan

- [x] Lint + typecheck clean
- [x] 415 integration tests pass
- [x] Resume component tests green (30/30 in `app/resume`)
- [x] Scope: only 3 files under `apps/web/app/resume/` modified (and `page.tsx` for the token swap) — confirmed via `git diff main --stat`
- [ ] Reviewer approves
- [ ] Author verifies in browser: Structured View renders on the right below Generate Questions; Improve and Accept buttons no longer look fat; drawer has visible right gutter; success toast colour matches cedar palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)