### PR TITLE
feat(resume): thread structured_data into question-gen prompt (#200)

### DIFF
--- a/apps/web/app/api/resume/questions/route.integration.test.ts
+++ b/apps/web/app/api/resume/questions/route.integration.test.ts
@@ -52,6 +52,7 @@ const OTHER_USER = {
 };
 
 let testResumeId: string;
+let structuredResumeId: string;
 
 function makeRequest(body: unknown): NextRequest {
   return new NextRequest("http://localhost:3000/api/resume/questions", {
@@ -89,6 +90,30 @@ describe("API POST /api/resume/questions (integration)", () => {
       })
       .returning();
     testResumeId = resume.id;
+
+    const [structuredResume] = await db
+      .insert(userResumes)
+      .values({
+        userId: TEST_USER.id,
+        filename: "structured.txt",
+        content: "Jane Smith\nStaff Engineer at TechCorp\nBuilt distributed caching layer reducing DB load by 60%",
+        structuredData: {
+          roles: [
+            {
+              company: "TechCorp",
+              title: "Staff Engineer",
+              dates: "2022–2024",
+              bullets: [
+                { text: "Built distributed caching layer reducing DB load by 60%", impact_score: 9, has_quantified_metric: true },
+                { text: "Attended weekly syncs", impact_score: 3, has_quantified_metric: false },
+              ],
+            },
+          ],
+          skills: ["Go", "Redis", "Kubernetes", "Postgres"],
+        },
+      })
+      .returning();
+    structuredResumeId = structuredResume.id;
   });
 
   beforeEach(() => {
@@ -202,6 +227,39 @@ describe("API POST /api/resume/questions (integration)", () => {
     const promptContent = callArgs.messages[0].content;
     expect(promptContent).toContain("Google");
     expect(promptContent).toContain("Senior SWE");
+  });
+
+  it("includes structured context in prompt when resume has structuredData", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(
+      makeRequest({ resume_id: structuredResumeId, question_type: "behavioral" })
+    );
+    expect(res.status).toBe(200);
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const callArgs = mockCreate.mock.calls[0][0];
+    const promptContent = callArgs.messages[0].content as string;
+    expect(promptContent).toContain("--- Candidate background (structured) ---");
+    expect(promptContent).toContain("Staff Engineer at TechCorp");
+    expect(promptContent).toContain("Built distributed caching layer");
+    expect(promptContent).toContain("Top skills:");
+    expect(promptContent).toContain("Go");
+  });
+
+  it("returns non-empty question list when structuredData is null (regression)", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    const res = await POST(
+      makeRequest({ resume_id: testResumeId, question_type: "technical" })
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data.questions)).toBe(true);
+    expect(data.questions.length).toBeGreaterThan(0);
+
+    // Prompt should NOT contain structured block for plain resume
+    const callArgs = mockCreate.mock.calls[0][0];
+    const promptContent = callArgs.messages[0].content as string;
+    expect(promptContent).not.toContain("--- Candidate background (structured) ---");
   });
 
   it("handles GPT error gracefully", async () => {

--- a/apps/web/app/api/resume/questions/route.ts
+++ b/apps/web/app/api/resume/questions/route.ts
@@ -5,6 +5,7 @@ import { userResumes } from "@/lib/schema";
 import { and, eq } from "drizzle-orm";
 import { createRequestLogger } from "@/lib/logger";
 import { buildResumeQuestionsPrompt } from "@/lib/resume-prompt-builder";
+import { structuredResumeSchema } from "@/lib/resume-parser";
 import OpenAI from "openai";
 import { z } from "zod/v4";
 
@@ -47,7 +48,11 @@ export async function POST(request: NextRequest) {
 
   // Fetch resume — scoped to the current user (prevents accessing other users' resumes)
   const [resume] = await db
-    .select({ id: userResumes.id, content: userResumes.content })
+    .select({
+      id: userResumes.id,
+      content: userResumes.content,
+      structuredData: userResumes.structuredData,
+    })
     .from(userResumes)
     .where(and(eq(userResumes.id, resume_id), eq(userResumes.userId, session.user.id)));
 
@@ -55,11 +60,13 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Resume not found" }, { status: 404 });
   }
 
+  const parsedStructured = structuredResumeSchema.safeParse(resume.structuredData);
   const prompt = buildResumeQuestionsPrompt({
     resumeText: resume.content,
     questionType: question_type,
     company,
     role,
+    structuredData: parsedStructured.success ? parsedStructured.data : null,
   });
 
   try {

--- a/apps/web/lib/resume-prompt-builder.test.ts
+++ b/apps/web/lib/resume-prompt-builder.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildResumeQuestionsPrompt } from "./resume-prompt-builder";
+import type { StructuredResume } from "./resume-parser";
 
 const SAMPLE_RESUME = `John Doe
 Software Engineer at Acme Corp
@@ -125,5 +126,91 @@ describe("buildResumeQuestionsPrompt", () => {
     });
     expect(result).toContain("Jane Smith");
     expect(result).toContain("technical interview questions");
+  });
+
+  // --- structuredData tests ---
+
+  const SAMPLE_STRUCTURED: StructuredResume = {
+    roles: [
+      {
+        company: "Acme Corp",
+        title: "Senior Engineer",
+        dates: "2021–2024",
+        bullets: [
+          { text: "Led migration of monolith to microservices", impact_score: 8, has_quantified_metric: false },
+          { text: "Reduced latency by 40%", impact_score: 9, has_quantified_metric: true },
+          { text: "Attended daily standups", impact_score: 2, has_quantified_metric: false },
+        ],
+      },
+      {
+        company: "Beta Inc",
+        title: "Junior Engineer",
+        dates: "2019–2021",
+        bullets: [
+          { text: "Fixed bugs in legacy codebase", impact_score: 4, has_quantified_metric: false },
+          { text: "Shipped payment module saving $200k/yr", impact_score: 7, has_quantified_metric: true },
+        ],
+      },
+    ],
+    skills: ["TypeScript", "Python", "AWS", "Kubernetes", "Kafka", "Flink", "React", "Postgres", "Redis", "Go", "Rust"],
+  };
+
+  it("includes structured role context when structuredData is provided", () => {
+    const result = buildResumeQuestionsPrompt({
+      resumeText: SAMPLE_RESUME,
+      questionType: "behavioral",
+      structuredData: SAMPLE_STRUCTURED,
+    });
+    expect(result).toContain("--- Candidate background (structured) ---");
+    expect(result).toContain("Senior Engineer at Acme Corp (2021–2024)");
+    expect(result).toContain("Junior Engineer at Beta Inc (2019–2021)");
+    expect(result).toContain("--- End structured background ---");
+    // Top 10 skills
+    expect(result).toContain("TypeScript");
+    expect(result).toContain("Top skills:");
+    // Rust is the 11th skill, should be excluded
+    expect(result).not.toContain("Rust");
+  });
+
+  it("only includes bullets with impact_score >= 6", () => {
+    const result = buildResumeQuestionsPrompt({
+      resumeText: SAMPLE_RESUME,
+      questionType: "behavioral",
+      structuredData: SAMPLE_STRUCTURED,
+    });
+    // High-impact bullets should appear
+    expect(result).toContain("Led migration of monolith to microservices");
+    expect(result).toContain("Reduced latency by 40%");
+    expect(result).toContain("Shipped payment module saving $200k/yr");
+    // Low-impact bullets should not appear in structured section
+    expect(result).not.toContain("[impact: 2]");
+    expect(result).not.toContain("[impact: 4]");
+    // Scores for high-impact bullets should be annotated
+    expect(result).toContain("[impact: 8]");
+    expect(result).toContain("[impact: 9]");
+    expect(result).toContain("[impact: 7]");
+  });
+
+  it("falls back to plaintext-only when structuredData is null", () => {
+    const result = buildResumeQuestionsPrompt({
+      resumeText: SAMPLE_RESUME,
+      questionType: "behavioral",
+      structuredData: null,
+    });
+    expect(result).not.toContain("--- Candidate background (structured) ---");
+    expect(result).not.toContain("Top skills:");
+    // Resume text still present
+    expect(result).toContain("Acme Corp");
+  });
+
+  it("falls back to plaintext-only when structuredData is omitted", () => {
+    const result = buildResumeQuestionsPrompt({
+      resumeText: SAMPLE_RESUME,
+      questionType: "technical",
+    });
+    expect(result).not.toContain("--- Candidate background (structured) ---");
+    expect(result).not.toContain("Top skills:");
+    // Resume text still present
+    expect(result).toContain("reducing latency by 40%");
   });
 });

--- a/apps/web/lib/resume-prompt-builder.ts
+++ b/apps/web/lib/resume-prompt-builder.ts
@@ -1,8 +1,11 @@
+import type { StructuredResume } from "@/lib/resume-parser";
+
 export interface ResumeQuestionOptions {
   resumeText: string;
   questionType: "behavioral" | "technical";
   company?: string;
   role?: string;
+  structuredData?: StructuredResume | null;
 }
 
 /**
@@ -10,7 +13,7 @@ export interface ResumeQuestionOptions {
  * candidate's resume content.  Different prompts for behavioral vs technical.
  */
 export function buildResumeQuestionsPrompt(options: ResumeQuestionOptions): string {
-  const { resumeText, questionType, company, role } = options;
+  const { resumeText, questionType, company, role, structuredData } = options;
 
   const sections: string[] = [];
 
@@ -25,6 +28,29 @@ export function buildResumeQuestionsPrompt(options: ResumeQuestionOptions): stri
   }
   if (role?.trim()) {
     sections.push(`The target role is: ${role.trim()}.`);
+  }
+
+  // Structured background block (only when available)
+  if (structuredData) {
+    const roleLines = structuredData.roles.map((r, i) => {
+      const highImpactBullets = r.bullets.filter((b) => b.impact_score >= 6);
+      const bulletLines = highImpactBullets
+        .map((b) => `     - ${b.text}   [impact: ${b.impact_score}]`)
+        .join("\n");
+      return `  ${i + 1}. ${r.title} at ${r.company} (${r.dates})${bulletLines ? `\n     Key achievements:\n${bulletLines}` : ""}`;
+    });
+
+    const topSkills = structuredData.skills.slice(0, 10).join(", ");
+
+    sections.push(
+      [
+        "--- Candidate background (structured) ---",
+        "Roles:",
+        roleLines.join("\n"),
+        `Top skills: ${topSkills}`,
+        "--- End structured background ---",
+      ].join("\n")
+    );
   }
 
   // Resume content


### PR DESCRIPTION
## Summary

- When a resume row has a non-null `structured_data` JSONB column (written by PR #198's parser), a "Candidate background (structured)" block is prepended to the GPT prompt for `POST /api/resume/questions`. The block includes each role with only high-impact bullets (impact_score ≥ 6, annotated with their score) and the top-10 skills.
- When `structured_data` is null, absent, or fails schema validation, behaviour is identical to before: only the raw resume text is sent. `structuredResumeSchema.safeParse` is the sole access point — no unchecked casts.
- Request/response shape, auth/authz logic, rate-limit tier, and schema are all unchanged.

## Implements

Issue #200 — use structured resume data in question generation prompts.

## Test plan

- [x] Unit tests pass (1064 total; 4 new cases in `resume-prompt-builder.test.ts`)
- [x] Integration tests pass (417 total; 2 new cases covering structured-on and structured-off paths)
- [x] Lint + typecheck clean
- [x] All 5 ACs traced to non-skipped assertions (QA verified)
- [ ] Reviewer approves
- [ ] Manual sanity check: generate questions for a resume with parsed structured data and confirm the prompt block appears in server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)