### PR TITLE
feat(interview): dynamic coaching hints for technical sessions (#196)

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -214,6 +214,7 @@ task definition / secrets manager.
 | `RESEND_FROM_ADDRESS`        | RUNTIME_ONLY       | Override the FROM address for transactional emails. Defaults to `Preploy <onboarding@resend.dev>`. Switch to your verified domain (e.g. `Preploy <noreply@preploy.tech>`) after DNS verification in Resend. |
 | `PRO_ANALYSIS_MODEL`       | RUNTIME_ONLY       | Override model used for Pro users' session feedback analysis (default: `gpt-5`). Set per environment; point at an available model (e.g. `gpt-4o`) until `gpt-5` is GA. |
 | `PRO_ANALYSIS_MONTHLY_LIMIT` | RUNTIME_ONLY     | Monthly cap on Pro-tier analysis per user. Default `10`. Consumed by `/api/users/pro-analysis-usage` and the feedback tier resolver in `/api/sessions/[id]/feedback`. |
+| `HINT_MODEL`               | RUNTIME_ONLY       | Model used for per-session coaching hints in technical interviews (default: `gpt-5.4-mini`). Free = 1 hint/session, Pro = 3. |
 
 Server-only secrets (`SUPABASE_DB_URL`, `OPENAI_API_KEY`, `GOOGLE_CLIENT_SECRET`,
 `SENTRY_DSN`) must never be referenced from a file marked `"use client"` and

--- a/apps/web/app/api/sessions/[id]/hints/route.integration.test.ts
+++ b/apps/web/app/api/sessions/[id]/hints/route.integration.test.ts
@@ -1,0 +1,330 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  afterEach,
+} from "vitest";
+import { NextRequest } from "next/server";
+import {
+  cleanupTestDb,
+  teardownTestDb,
+  getTestDb,
+} from "../../../../../tests/setup-db";
+import { users, interviewSessions } from "@/lib/schema";
+import { eq } from "drizzle-orm";
+
+// Mock auth
+const mockAuth = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+// Point db import to the test database
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return getTestDb();
+  },
+}));
+
+// Mock OpenAI — same pattern as feedback route integration tests
+const mockChatCreate = vi.fn();
+vi.mock("openai", () => ({
+  default: class MockOpenAI {
+    chat = { completions: { create: mockChatCreate } };
+  },
+}));
+
+vi.stubEnv("OPENAI_API_KEY", "sk-integration-test");
+
+import { POST } from "./route";
+
+const TEST_USER = {
+  id: "00000000-0000-0000-0000-000000000010",
+  email: "hint-test@example.com",
+  name: "Hint Test User",
+};
+
+const OTHER_USER = {
+  id: "00000000-0000-0000-0000-000000000011",
+  email: "hint-other@example.com",
+  name: "Other User",
+};
+
+const PRO_USER = {
+  id: "00000000-0000-0000-0000-000000000012",
+  email: "hint-pro@example.com",
+  name: "Pro User",
+  plan: "pro" as const,
+};
+
+const VALID_BODY = {
+  problemTitle: "Two Sum",
+  problemDescription: "Return indices of two numbers that add up to a target.",
+  code: "def two_sum(nums, target):\n    pass",
+  language: "python",
+};
+
+function makePostRequest(sessionId: string, body: unknown = VALID_BODY): NextRequest {
+  return new NextRequest(
+    `http://localhost:3000/api/sessions/${sessionId}/hints`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+describe("API /api/sessions/[id]/hints (integration)", () => {
+  beforeAll(async () => {
+    vi.stubEnv("HINT_MODEL", "gpt-4o-mini");
+    const db = getTestDb();
+    await db.insert(users).values(TEST_USER).onConflictDoNothing();
+    await db.insert(users).values(OTHER_USER).onConflictDoNothing();
+    await db.insert(users).values(PRO_USER).onConflictDoNothing();
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const db = getTestDb();
+    await db.delete(interviewSessions);
+  });
+
+  afterEach(() => {
+    // don't unstub HINT_MODEL since we set it in beforeAll
+  });
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    await cleanupTestDb();
+    await teardownTestDb();
+  });
+
+  // 1. Unauth → 401
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const db = getTestDb();
+    const [session] = await db
+      .insert(interviewSessions)
+      .values({ userId: TEST_USER.id, type: "technical", config: {} })
+      .returning();
+
+    const res = await POST(makePostRequest(session.id), makeParams(session.id));
+    expect(res.status).toBe(401);
+  });
+
+  // 2. Foreign session → 404
+  it("returns 404 for a session belonging to another user", async () => {
+    const db = getTestDb();
+    const [session] = await db
+      .insert(interviewSessions)
+      .values({ userId: OTHER_USER.id, type: "technical", config: {} })
+      .returning();
+
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const res = await POST(makePostRequest(session.id), makeParams(session.id));
+    expect(res.status).toBe(404);
+  });
+
+  // 3. Behavioral session → 400
+  it("returns 400 for a behavioral session", async () => {
+    const db = getTestDb();
+    const [session] = await db
+      .insert(interviewSessions)
+      .values({ userId: TEST_USER.id, type: "behavioral", config: {} })
+      .returning();
+
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const res = await POST(makePostRequest(session.id), makeParams(session.id));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/technical/i);
+  });
+
+  // 4. Free user, 0 hints used → 201, hintsUsed=1, hintsRemaining=0; DB persisted
+  it("returns 201 for free user first hint, persists DB update", async () => {
+    const db = getTestDb();
+    const [session] = await db
+      .insert(interviewSessions)
+      .values({
+        userId: TEST_USER.id,
+        type: "technical",
+        config: {},
+        hintsUsed: 0,
+        hintsGiven: [],
+      })
+      .returning();
+
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: "Think about using a hash map." } }],
+    });
+
+    const res = await POST(makePostRequest(session.id), makeParams(session.id));
+    expect(res.status).toBe(201);
+
+    const responseBody = await res.json();
+    expect(responseBody.hint).toBe("Think about using a hash map.");
+    expect(responseBody.hintsUsed).toBe(1);
+    expect(responseBody.hintsRemaining).toBe(0);
+
+    // Verify DB persisted
+    const [row] = await db
+      .select()
+      .from(interviewSessions)
+      .where(eq(interviewSessions.id, session.id));
+    expect(row.hintsUsed).toBe(1);
+    const hintsGiven = row.hintsGiven as Array<{ text: string }>;
+    expect(hintsGiven).toHaveLength(1);
+    expect(hintsGiven[0].text).toBe("Think about using a hash map.");
+  });
+
+  // 5. Free user, 1 hint already used → 429
+  it("returns 429 when free user has exhausted hint quota (1/1)", async () => {
+    const db = getTestDb();
+    const [session] = await db
+      .insert(interviewSessions)
+      .values({
+        userId: TEST_USER.id,
+        type: "technical",
+        config: {},
+        hintsUsed: 1,
+        hintsGiven: [{ text: "Already given hint." }],
+      })
+      .returning();
+
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const res = await POST(makePostRequest(session.id), makeParams(session.id));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.hintsUsed).toBe(1);
+    expect(body.hintsRemaining).toBe(0);
+
+    // OpenAI should NOT have been called
+    expect(mockChatCreate).not.toHaveBeenCalled();
+  });
+
+  // 6. Pro user, 2 hints used → 201; hintsUsed=3, hintsRemaining=0; DB correct
+  it("returns 201 for pro user third hint (2/3 used), persists DB update", async () => {
+    const db = getTestDb();
+    const [session] = await db
+      .insert(interviewSessions)
+      .values({
+        userId: PRO_USER.id,
+        type: "technical",
+        config: {},
+        hintsUsed: 2,
+        hintsGiven: [{ text: "Hint 1." }, { text: "Hint 2." }],
+      })
+      .returning();
+
+    mockAuth.mockResolvedValue({ user: { id: PRO_USER.id } });
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: "Focus on the specific step where the pointer stops." } }],
+    });
+
+    const res = await POST(makePostRequest(session.id), makeParams(session.id));
+    expect(res.status).toBe(201);
+
+    const responseBody = await res.json();
+    expect(responseBody.hintsUsed).toBe(3);
+    expect(responseBody.hintsRemaining).toBe(0);
+
+    // Verify DB persisted
+    const [row] = await db
+      .select()
+      .from(interviewSessions)
+      .where(eq(interviewSessions.id, session.id));
+    expect(row.hintsUsed).toBe(3);
+    const hintsGiven = row.hintsGiven as Array<{ text: string }>;
+    expect(hintsGiven).toHaveLength(3);
+    expect(hintsGiven[2].text).toBe("Focus on the specific step where the pointer stops.");
+  });
+
+  // 7. Pro user, 3 hints used → 429
+  it("returns 429 when pro user has exhausted hint quota (3/3)", async () => {
+    const db = getTestDb();
+    const [session] = await db
+      .insert(interviewSessions)
+      .values({
+        userId: PRO_USER.id,
+        type: "technical",
+        config: {},
+        hintsUsed: 3,
+        hintsGiven: [{ text: "H1" }, { text: "H2" }, { text: "H3" }],
+      })
+      .returning();
+
+    mockAuth.mockResolvedValue({ user: { id: PRO_USER.id } });
+
+    const res = await POST(makePostRequest(session.id), makeParams(session.id));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.hintsUsed).toBe(3);
+    expect(body.hintsRemaining).toBe(0);
+
+    expect(mockChatCreate).not.toHaveBeenCalled();
+  });
+
+  // 8. Hint #2 payload includes hint #1 text in the prompt
+  it("includes prior hints in the OpenAI prompt when requesting hint #2", async () => {
+    const db = getTestDb();
+    const [session] = await db
+      .insert(interviewSessions)
+      .values({
+        userId: PRO_USER.id,
+        type: "technical",
+        config: {},
+        hintsUsed: 1,
+        hintsGiven: [{ text: "Think about hash maps." }],
+      })
+      .returning();
+
+    mockAuth.mockResolvedValue({ user: { id: PRO_USER.id } });
+    mockChatCreate.mockResolvedValue({
+      choices: [{ message: { content: "Consider the key you would use." } }],
+    });
+
+    const res = await POST(makePostRequest(session.id), makeParams(session.id));
+    expect(res.status).toBe(201);
+
+    // Assert that the OpenAI call included the prior hint in the user message
+    expect(mockChatCreate).toHaveBeenCalledOnce();
+    const call = mockChatCreate.mock.calls[0][0];
+    const userContent = call.messages.find(
+      (m: { role: string }) => m.role === "user"
+    )?.content as string;
+    expect(userContent).toContain("Think about hash maps.");
+  });
+
+  // 9. Invalid body (missing required field) → 400
+  it("returns 400 for invalid body (missing code field)", async () => {
+    const db = getTestDb();
+    const [session] = await db
+      .insert(interviewSessions)
+      .values({ userId: TEST_USER.id, type: "technical", config: {} })
+      .returning();
+
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    const invalidBody = {
+      problemTitle: "Two Sum",
+      // missing problemDescription, code, language
+    };
+
+    const res = await POST(makePostRequest(session.id, invalidBody), makeParams(session.id));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/app/api/sessions/[id]/hints/route.ts
+++ b/apps/web/app/api/sessions/[id]/hints/route.ts
@@ -1,0 +1,198 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { interviewSessions } from "@/lib/schema";
+import { eq, and, sql } from "drizzle-orm";
+import { createRequestLogger } from "@/lib/logger";
+import { checkRateLimit } from "@/lib/api-utils";
+import { getCurrentUserPlan } from "@/lib/user-plan";
+import { getHintLimit } from "@/lib/plans";
+import { buildHintPrompt } from "@/lib/hint-prompt";
+import OpenAI from "openai";
+
+const HintRequestSchema = z.object({
+  problemTitle: z.string().min(1),
+  problemDescription: z.string().min(1),
+  code: z.string().min(0),
+  language: z.string().min(1),
+});
+
+// POST /api/sessions/[id]/hints — request a coaching hint for a technical session
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const log = createRequestLogger({
+    route: "POST /api/sessions/[id]/hints",
+    userId: session.user.id,
+  });
+
+  // Verify session ownership and existence
+  const [found] = await db
+    .select()
+    .from(interviewSessions)
+    .where(
+      and(
+        eq(interviewSessions.id, id),
+        eq(interviewSessions.userId, session.user.id)
+      )
+    );
+
+  if (!found) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+
+  // Guard: hints are only for technical sessions
+  if (found.type !== "technical") {
+    return NextResponse.json(
+      { error: "Hints are only available for technical interview sessions" },
+      { status: 400 }
+    );
+  }
+
+  // Validate request body
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = HintRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request body", details: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  const { problemTitle, problemDescription, code, language } = parsed.data;
+
+  // Resolve plan and quota
+  const plan = await getCurrentUserPlan(session.user.id);
+  const limit = getHintLimit(plan);
+  const currentHintsUsed = found.hintsUsed ?? 0;
+
+  if (currentHintsUsed >= limit) {
+    log.info(
+      { sessionId: id, hintsUsed: currentHintsUsed, limit, plan },
+      "hint quota exhausted"
+    );
+    return NextResponse.json(
+      {
+        error: "Hint quota exhausted for this session",
+        hintsUsed: currentHintsUsed,
+        hintsRemaining: 0,
+        limit,
+      },
+      { status: 429 }
+    );
+  }
+
+  // Rate-limit check (burst protection, independent of per-session quota)
+  const rateLimitResponse = await checkRateLimit(session.user.id, "openai");
+  if (rateLimitResponse) return rateLimitResponse;
+
+  // Read prior hints from DB (server-authoritative for dedup)
+  const priorHints = ((found.hintsGiven ?? []) as Array<{ text: string }>).map(
+    (h) => h.text
+  );
+
+  // Build prompt
+  const { systemPrompt, userMessage } = buildHintPrompt({
+    problemTitle,
+    problemDescription,
+    code,
+    language,
+    priorHints,
+  });
+
+  // Call OpenAI — construct inside the handler (never at module scope)
+  const model = process.env.HINT_MODEL ?? "gpt-5.4-mini";
+  let hintText: string;
+  try {
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const completion = await openai.chat.completions.create({
+      model,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userMessage },
+      ],
+      max_tokens: 300,
+      temperature: 0.4,
+    });
+    hintText = completion.choices[0]?.message?.content ?? "";
+    if (!hintText) {
+      throw new Error("Empty response from OpenAI");
+    }
+  } catch (err) {
+    log.error({ err, sessionId: id }, "OpenAI hint generation failed");
+    return NextResponse.json(
+      { error: "Hint generation failed. Please try again." },
+      { status: 500 }
+    );
+  }
+
+  // Atomically increment hints_used and append hint to hints_given
+  // Optimistic lock on hints_used to prevent double-submit races.
+  const newHintsUsed = currentHintsUsed + 1;
+  const newHint = { text: hintText };
+  const updatedRows = await db
+    .update(interviewSessions)
+    .set({
+      hintsUsed: sql`${interviewSessions.hintsUsed} + 1`,
+      hintsGiven: sql`${interviewSessions.hintsGiven} || ${JSON.stringify([newHint])}::jsonb`,
+    })
+    .where(
+      and(
+        eq(interviewSessions.id, id),
+        eq(interviewSessions.hintsUsed, currentHintsUsed)
+      )
+    )
+    .returning({ hintsUsed: interviewSessions.hintsUsed });
+
+  // If 0 rows updated, a concurrent request beat us — re-read and return 429
+  if (updatedRows.length === 0) {
+    const [refetched] = await db
+      .select({ hintsUsed: interviewSessions.hintsUsed })
+      .from(interviewSessions)
+      .where(eq(interviewSessions.id, id));
+    const actualUsed = refetched?.hintsUsed ?? limit;
+    log.warn(
+      { sessionId: id, actualUsed, limit },
+      "optimistic lock conflict — concurrent hint request"
+    );
+    return NextResponse.json(
+      {
+        error: "Hint quota exhausted for this session",
+        hintsUsed: actualUsed,
+        hintsRemaining: Math.max(0, limit - actualUsed),
+        limit,
+      },
+      { status: 429 }
+    );
+  }
+
+  const hintsRemaining = Math.max(0, limit - newHintsUsed);
+
+  log.info(
+    { sessionId: id, hintsUsed: newHintsUsed, hintsRemaining, plan, model },
+    "hint generated"
+  );
+
+  return NextResponse.json(
+    {
+      hint: hintText,
+      hintsUsed: newHintsUsed,
+      hintsRemaining,
+    },
+    { status: 201 }
+  );
+}

--- a/apps/web/app/interview/technical/session/page.tsx
+++ b/apps/web/app/interview/technical/session/page.tsx
@@ -41,6 +41,7 @@ export default function TechnicalSessionPage() {
   const [hintsUsed, setHintsUsed] = useState(0);
   const [isHintLoading, setIsHintLoading] = useState(false);
   const [showHintPanel, setShowHintPanel] = useState(false);
+  const [hintError, setHintError] = useState<string | null>(null);
 
   // Regeneration: users can regenerate the question up to 5 times per
   // session so they don't get stuck on a duplicate or an unfamiliar topic.
@@ -191,6 +192,7 @@ export default function TechnicalSessionPage() {
     if (!sessionId || !problem || isHintLoading) return;
     setIsHintLoading(true);
     setShowHintPanel(true);
+    setHintError(null);
     try {
       const res = await fetch(`/api/sessions/${sessionId}/hints`, {
         method: "POST",
@@ -206,9 +208,16 @@ export default function TechnicalSessionPage() {
         const data = await res.json();
         setHints((prev) => [...prev, data.hint]);
         setHintsUsed(data.hintsUsed);
+      } else {
+        const data = await res.json().catch(() => ({}));
+        if (typeof data.hintsUsed === "number") {
+          setHintsUsed(data.hintsUsed);
+        }
+        setHintError(data.error ?? "Failed to get hint. Please try again.");
       }
     } catch (err) {
       console.error("Failed to request hint:", err);
+      setHintError("Failed to get hint. Please try again.");
     } finally {
       setIsHintLoading(false);
     }
@@ -418,13 +427,24 @@ export default function TechnicalSessionPage() {
       isProcessing={isProcessing}
       processingStep={processingStep}
       hintButton={
-        <HintButton
-          hintsUsed={hintsUsed}
-          hintsLimit={hintsLimit}
-          isLoading={isHintLoading}
-          onClick={handleRequestHint}
-          plan={resolvedPlan}
-        />
+        <>
+          <HintButton
+            hintsUsed={hintsUsed}
+            hintsLimit={hintsLimit}
+            isLoading={isHintLoading}
+            onClick={handleRequestHint}
+            plan={resolvedPlan}
+          />
+          {hintError && (
+            <p
+              role="status"
+              aria-live="polite"
+              className="text-xs text-destructive"
+            >
+              {hintError}
+            </p>
+          )}
+        </>
       }
       hintPanel={
         showHintPanel ? (

--- a/apps/web/app/interview/technical/session/page.tsx
+++ b/apps/web/app/interview/technical/session/page.tsx
@@ -15,12 +15,18 @@ import { CodeEditor } from "@/components/editor/CodeEditor";
 import { EditorToolbar } from "@/components/editor/EditorToolbar";
 import { MicIndicator } from "@/components/interview/MicIndicator";
 import { RefreshCw, Loader2 } from "lucide-react";
+import { HintButton } from "@/components/interview/HintButton";
+import { HintPanel } from "@/components/interview/HintPanel";
+import { usePlan } from "@/hooks/usePlan";
+import { getHintLimit } from "@/lib/plans";
 
 export default function TechnicalSessionPage() {
   const router = useRouter();
 
   const { sessionId, config, type, status, startSession, endSession } =
     useInterviewStore();
+
+  const { plan } = usePlan();
 
   const techConfig = config as TechnicalSessionConfig;
 
@@ -29,6 +35,12 @@ export default function TechnicalSessionPage() {
   const [problemError, setProblemError] = useState<string | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const [processingStep, setProcessingStep] = useState("");
+
+  // Hint state
+  const [hints, setHints] = useState<string[]>([]);
+  const [hintsUsed, setHintsUsed] = useState(0);
+  const [isHintLoading, setIsHintLoading] = useState(false);
+  const [showHintPanel, setShowHintPanel] = useState(false);
 
   // Regeneration: users can regenerate the question up to 5 times per
   // session so they don't get stuck on a duplicate or an unfamiliar topic.
@@ -174,6 +186,34 @@ export default function TechnicalSessionPage() {
     }
   }, [regenerationsLeft, isRegenerating, problem, previousProblems, techConfig]);
 
+  // Hint request handler
+  const handleRequestHint = useCallback(async () => {
+    if (!sessionId || !problem || isHintLoading) return;
+    setIsHintLoading(true);
+    setShowHintPanel(true);
+    try {
+      const res = await fetch(`/api/sessions/${sessionId}/hints`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          problemTitle: problem.title,
+          problemDescription: problem.description,
+          code,
+          language,
+        }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setHints((prev) => [...prev, data.hint]);
+        setHintsUsed(data.hintsUsed);
+      }
+    } catch (err) {
+      console.error("Failed to request hint:", err);
+    } finally {
+      setIsHintLoading(false);
+    }
+  }, [sessionId, problem, isHintLoading, code, language]);
+
   // End session handler
   const handleEndSession = useCallback(async () => {
     if (!sessionId) return;
@@ -272,6 +312,10 @@ export default function TechnicalSessionPage() {
 
   // Don't render until we have a session
   if (!sessionId || type !== "technical") return null;
+
+  // Derive hint limit from plan (undefined plan → free limit)
+  const resolvedPlan = plan ?? "free";
+  const hintsLimit = getHintLimit(resolvedPlan);
 
   // Problem panel content
   const problemPanel = problemLoading ? (
@@ -373,6 +417,24 @@ export default function TechnicalSessionPage() {
       onEndSession={handleEndSession}
       isProcessing={isProcessing}
       processingStep={processingStep}
+      hintButton={
+        <HintButton
+          hintsUsed={hintsUsed}
+          hintsLimit={hintsLimit}
+          isLoading={isHintLoading}
+          onClick={handleRequestHint}
+          plan={resolvedPlan}
+        />
+      }
+      hintPanel={
+        showHintPanel ? (
+          <HintPanel
+            hints={hints}
+            isHintLoading={isHintLoading}
+            onClose={() => setShowHintPanel(false)}
+          />
+        ) : undefined
+      }
     />
   );
 }

--- a/apps/web/components/interview/HintButton.test.tsx
+++ b/apps/web/components/interview/HintButton.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { HintButton } from "./HintButton";
+
+// Mock next/link
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode; [key: string]: unknown }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("HintButton", () => {
+  it("is disabled when hintsUsed >= hintsLimit", () => {
+    render(
+      <HintButton
+        hintsUsed={1}
+        hintsLimit={1}
+        isLoading={false}
+        onClick={vi.fn()}
+        plan="free"
+      />
+    );
+    const button = screen.getByRole("button", { name: /hint/i });
+    expect(button).toBeDisabled();
+  });
+
+  it("shows correct remaining count for free user with 0 used", () => {
+    render(
+      <HintButton
+        hintsUsed={0}
+        hintsLimit={1}
+        isLoading={false}
+        onClick={vi.fn()}
+        plan="free"
+      />
+    );
+    // Use getAllByText since shadcn may render multiple
+    const elements = screen.getAllByText(/Hint \(1 left\)/i);
+    expect(elements.length).toBeGreaterThan(0);
+  });
+
+  it("shows correct remaining count for pro user with 0 used", () => {
+    render(
+      <HintButton
+        hintsUsed={0}
+        hintsLimit={3}
+        isLoading={false}
+        onClick={vi.fn()}
+        plan="pro"
+      />
+    );
+    const elements = screen.getAllByText(/Hint \(3 left\)/i);
+    expect(elements.length).toBeGreaterThan(0);
+  });
+
+  it("does not call onClick when disabled (exhausted)", () => {
+    const onClick = vi.fn();
+    render(
+      <HintButton
+        hintsUsed={1}
+        hintsLimit={1}
+        isLoading={false}
+        onClick={onClick}
+        plan="free"
+      />
+    );
+    const button = screen.getByRole("button", { name: /hint/i });
+    fireEvent.click(button);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("renders spinner and loading text when isLoading is true", () => {
+    render(
+      <HintButton
+        hintsUsed={0}
+        hintsLimit={3}
+        isLoading={true}
+        onClick={vi.fn()}
+        plan="pro"
+      />
+    );
+    expect(screen.getByText(/Getting hint/i)).toBeDefined();
+  });
+
+  it("shows upgrade nudge for free user with exhausted hints", () => {
+    render(
+      <HintButton
+        hintsUsed={1}
+        hintsLimit={1}
+        isLoading={false}
+        onClick={vi.fn()}
+        plan="free"
+      />
+    );
+    const link = screen.getByRole("link", { name: /upgrade/i });
+    expect(link).toBeDefined();
+    expect(link.getAttribute("href")).toBe("/pricing");
+  });
+
+  it("does not show upgrade nudge for pro user even when exhausted", () => {
+    render(
+      <HintButton
+        hintsUsed={3}
+        hintsLimit={3}
+        isLoading={false}
+        onClick={vi.fn()}
+        plan="pro"
+      />
+    );
+    expect(screen.queryByRole("link", { name: /upgrade/i })).toBeNull();
+  });
+});

--- a/apps/web/components/interview/HintButton.tsx
+++ b/apps/web/components/interview/HintButton.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { Sparkles, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { PRO_HINTS_PER_SESSION, FREE_HINTS_PER_SESSION } from "@/lib/plans";
 import type { Plan } from "@/lib/plans";
 
 interface HintButtonProps {
@@ -60,7 +61,7 @@ export function HintButton({
           href="/pricing"
           className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline motion-safe:transition-colors"
         >
-          Upgrade for {2} more hints
+          Upgrade for {PRO_HINTS_PER_SESSION - FREE_HINTS_PER_SESSION} more hints
         </Link>
       )}
     </div>

--- a/apps/web/components/interview/HintButton.tsx
+++ b/apps/web/components/interview/HintButton.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Link from "next/link";
+import { Sparkles, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { Plan } from "@/lib/plans";
+
+interface HintButtonProps {
+  hintsUsed: number;
+  hintsLimit: number;
+  isLoading: boolean;
+  onClick: () => void;
+  plan: Plan | undefined;
+}
+
+/**
+ * Coaching hint request button.
+ *
+ * - Shows remaining count in the label.
+ * - Disabled when quota is exhausted or while a hint is loading.
+ * - Cedar Sparkles icon for Pro users with hints remaining (matches ProAnalysisToggle convention).
+ * - Free + exhausted: inline upgrade nudge linking to /pricing.
+ */
+export function HintButton({
+  hintsUsed,
+  hintsLimit,
+  isLoading,
+  onClick,
+  plan,
+}: HintButtonProps) {
+  const hintsRemaining = Math.max(0, hintsLimit - hintsUsed);
+  const isExhausted = hintsRemaining <= 0;
+  const isDisabled = isExhausted || isLoading;
+  const isProWithHints = plan === "pro" && !isExhausted;
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onClick}
+        disabled={isDisabled}
+        aria-label="Request coaching hint"
+        aria-disabled={isDisabled}
+      >
+        {isLoading ? (
+          <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+        ) : isProWithHints ? (
+          <Sparkles
+            className="mr-1.5 h-3.5 w-3.5 text-[color:var(--primary)]"
+            aria-hidden="true"
+          />
+        ) : null}
+        {isLoading ? "Getting hint…" : `Hint (${hintsRemaining} left)`}
+      </Button>
+
+      {/* Upgrade nudge for free users who have exhausted their hint quota */}
+      {isExhausted && plan !== "pro" && (
+        <Link
+          href="/pricing"
+          className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline motion-safe:transition-colors"
+        >
+          Upgrade for {2} more hints
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/interview/HintPanel.test.tsx
+++ b/apps/web/components/interview/HintPanel.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { HintPanel } from "./HintPanel";
+
+describe("HintPanel", () => {
+  it("renders nothing when hints is empty and isHintLoading is false", () => {
+    const { container } = render(
+      <HintPanel hints={[]} isHintLoading={false} onClose={vi.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders both hint texts when two hints are provided", () => {
+    render(
+      <HintPanel
+        hints={["first hint", "second hint"]}
+        isHintLoading={false}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.getByText("first hint")).toBeDefined();
+    expect(screen.getByText("second hint")).toBeDefined();
+  });
+
+  it("labels hints with 'Hint 1', 'Hint 2' numbering", () => {
+    render(
+      <HintPanel
+        hints={["first hint", "second hint"]}
+        isHintLoading={false}
+        onClose={vi.fn()}
+      />
+    );
+    const labels = screen.getAllByText(/Hint \d+/);
+    expect(labels.length).toBeGreaterThanOrEqual(2);
+    const labelTexts = labels.map((el) => el.textContent);
+    expect(labelTexts).toContain("Hint 1");
+    expect(labelTexts).toContain("Hint 2");
+  });
+
+  it("renders the loading skeleton when isHintLoading is true", () => {
+    const { container } = render(
+      <HintPanel hints={[]} isHintLoading={true} onClose={vi.fn()} />
+    );
+    // The skeleton wrapper carries animate-pulse
+    const skeletonBlock = container.querySelector(".animate-pulse");
+    expect(skeletonBlock).not.toBeNull();
+  });
+
+  it("renders three skeleton line divs inside the animate-pulse block", () => {
+    const { container } = render(
+      <HintPanel hints={[]} isHintLoading={true} onClose={vi.fn()} />
+    );
+    const skeletonBlock = container.querySelector(".animate-pulse");
+    // Inner space-y container holds the three line divs
+    const spaceContainer = skeletonBlock?.querySelector(".space-y-1\\.5");
+    const lines = spaceContainer?.querySelectorAll("div") ?? [];
+    expect(lines.length).toBe(3);
+  });
+
+  it("calls onClose exactly once when the close button is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <HintPanel hints={["a hint"]} isHintLoading={false} onClose={onClose} />
+    );
+    const closeButton = screen.getByRole("button", { name: "Close hint panel" });
+    fireEvent.click(closeButton);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the panel when only isHintLoading is true (no existing hints)", () => {
+    render(
+      <HintPanel hints={[]} isHintLoading={true} onClose={vi.fn()} />
+    );
+    // The complementary landmark is present
+    expect(screen.getByRole("complementary", { name: "Coaching hints" })).toBeDefined();
+  });
+
+  it("renders both existing hints and loading skeleton simultaneously", () => {
+    const { container } = render(
+      <HintPanel hints={["existing hint"]} isHintLoading={true} onClose={vi.fn()} />
+    );
+    expect(screen.getByText("existing hint")).toBeDefined();
+    expect(container.querySelector(".animate-pulse")).not.toBeNull();
+  });
+});

--- a/apps/web/components/interview/HintPanel.tsx
+++ b/apps/web/components/interview/HintPanel.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { X, Lightbulb } from "lucide-react";
+
+interface HintPanelProps {
+  hints: string[];
+  isHintLoading: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Overlay panel listing coaching hints received during a technical session.
+ *
+ * - Absolutely positioned inside the right (editor) panel — parent must have `relative`.
+ * - Empty state: not rendered (caller gates on hints.length + isHintLoading).
+ * - Loading skeleton at the end of the list while a hint is in-flight.
+ * - Dismiss X button closes the panel without ending the session.
+ */
+export function HintPanel({ hints, isHintLoading, onClose }: HintPanelProps) {
+  // Don't render if there's nothing to show
+  if (hints.length === 0 && !isHintLoading) return null;
+
+  return (
+    <div
+      className="absolute top-0 right-0 z-10 flex h-full w-80 flex-col border-l bg-background shadow-[var(--shadow-lg)]"
+      role="complementary"
+      aria-label="Coaching hints"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Lightbulb className="h-4 w-4 text-[color:var(--primary)]" aria-hidden="true" />
+          <span className="text-sm font-medium">Coaching Hints</span>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onClose}
+          aria-label="Close hint panel"
+          className="h-7 w-7"
+        >
+          <X className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      </div>
+
+      {/* Hints list */}
+      <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
+        {hints.map((hint, index) => (
+          <div
+            key={index}
+            className="rounded-lg border bg-card p-3 motion-safe:animate-in motion-safe:fade-in motion-safe:duration-200"
+          >
+            <div className="mb-1.5 flex items-center gap-1.5">
+              <span className="text-xs font-medium text-muted-foreground">
+                Hint {index + 1}
+              </span>
+            </div>
+            <p className="text-sm leading-relaxed">{hint}</p>
+          </div>
+        ))}
+
+        {/* Loading skeleton for in-flight hint */}
+        {isHintLoading && (
+          <div className="rounded-lg border bg-card p-3 animate-pulse">
+            <div className="mb-1.5 h-3 w-12 rounded bg-muted" />
+            <div className="space-y-1.5">
+              <div className="h-4 w-[95%] rounded bg-muted" />
+              <div className="h-4 w-[80%] rounded bg-muted" />
+              <div className="h-4 w-[60%] rounded bg-muted" />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/interview/HintPanel.tsx
+++ b/apps/web/components/interview/HintPanel.tsx
@@ -45,7 +45,11 @@ export function HintPanel({ hints, isHintLoading, onClose }: HintPanelProps) {
       </div>
 
       {/* Hints list */}
-      <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
+      <div
+        className="flex-1 overflow-y-auto px-4 py-3 space-y-3"
+        aria-live="polite"
+        aria-atomic="false"
+      >
         {hints.map((hint, index) => (
           <div
             key={index}

--- a/apps/web/components/interview/TechnicalSessionLayout.tsx
+++ b/apps/web/components/interview/TechnicalSessionLayout.tsx
@@ -16,6 +16,10 @@ interface TechnicalSessionLayoutProps {
   isProcessing: boolean;
   /** Current processing step label (e.g., "Transcribing audio...") */
   processingStep?: string;
+  /** Optional hint request button — placed in the bottom bar left cluster */
+  hintButton?: ReactNode;
+  /** Optional hint panel overlay — rendered inside the right (editor) panel */
+  hintPanel?: ReactNode;
 }
 
 export function TechnicalSessionLayout({
@@ -25,6 +29,8 @@ export function TechnicalSessionLayout({
   onEndSession,
   isProcessing,
   processingStep,
+  hintButton,
+  hintPanel,
 }: TechnicalSessionLayoutProps) {
   const [elapsed, setElapsed] = useState(0);
   const [showConfirm, setShowConfirm] = useState(false);
@@ -65,18 +71,22 @@ export function TechnicalSessionLayout({
         {/* Left panel — Problem description (40%) */}
         <div className="w-[40%] overflow-y-auto border-r">{problemPanel}</div>
 
-        {/* Right panel — Editor (60%) */}
-        <div className="flex w-[60%] flex-col">{editorPanel}</div>
+        {/* Right panel — Editor (60%); relative so the hint overlay positions correctly */}
+        <div className="relative flex w-[60%] flex-col">
+          {editorPanel}
+          {hintPanel}
+        </div>
       </div>
 
       {/* Bottom bar — Timer + Mic + End Session */}
       <div className="flex items-center justify-between border-t bg-background px-6 py-3">
-        {/* Timer + Mic indicator */}
+        {/* Timer + Mic indicator + Hint button */}
         <div className="flex items-center gap-4">
           <span className="font-mono text-lg font-medium tabular-nums">
             {formatTime(elapsed)}
           </span>
           {micIndicator}
+          {hintButton}
         </div>
 
         {/* End Session */}

--- a/apps/web/drizzle/0020_outgoing_apocalypse.sql
+++ b/apps/web/drizzle/0020_outgoing_apocalypse.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "interview_sessions" ADD COLUMN "hints_used" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "interview_sessions" ADD COLUMN "hints_given" jsonb DEFAULT '[]'::jsonb NOT NULL;

--- a/apps/web/drizzle/meta/0020_snapshot.json
+++ b/apps/web/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,1462 @@
+{
+  "id": "5a766b04-f993-42cf-8c56-96cb135828a6",
+  "prevId": "d1a487eb-d77c-4317-a346-6b3a56c87a52",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_provider_provider_account_id_pk": {
+          "name": "accounts_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.code_snapshots": {
+      "name": "code_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "code_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_result": {
+          "name": "execution_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "code_snapshots_session_id_interview_sessions_id_fk": {
+          "name": "code_snapshots_session_id_interview_sessions_id_fk",
+          "tableFrom": "code_snapshots",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_questions": {
+      "name": "company_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_questions_user_id_users_id_fk": {
+          "name": "company_questions_user_id_users_id_fk",
+          "tableFrom": "company_questions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deleted_usage": {
+      "name": "deleted_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deleted_usage_hash_month_unique": {
+          "name": "deleted_usage_hash_month_unique",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gaze_samples": {
+      "name": "gaze_samples",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "samples": {
+          "name": "samples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gaze_samples_session_id_interview_sessions_id_fk": {
+          "name": "gaze_samples_session_id_interview_sessions_id_fk",
+          "tableFrom": "gaze_samples",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_plans": {
+      "name": "interview_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interview_date": {
+          "name": "interview_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_data": {
+          "name": "plan_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_plans_user_id_users_id_fk": {
+          "name": "interview_plans_user_id_users_id_fk",
+          "tableFrom": "interview_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_sessions": {
+      "name": "interview_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'configuring'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_star_story_id": {
+          "name": "source_star_story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_pro_analysis": {
+          "name": "use_pro_analysis",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hints_used": {
+          "name": "hints_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hints_given": {
+          "name": "hints_given",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "interview_sessions_user_id_users_id_fk": {
+          "name": "interview_sessions_user_id_users_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "interview_sessions_source_star_story_id_star_stories_id_fk": {
+          "name": "interview_sessions_source_star_story_id_star_stories_id_fk",
+          "tableFrom": "interview_sessions",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "source_star_story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.interview_usage": {
+      "name": "interview_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "interview_usage_user_period_unique": {
+          "name": "interview_usage_user_period_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "interview_usage_user_id_users_id_fk": {
+          "name": "interview_usage_user_id_users_id_fk",
+          "tableFrom": "interview_usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.openai_usage": {
+      "name": "openai_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd_millis": {
+          "name": "cost_usd_millis",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "openai_usage_user_date_model_unique": {
+          "name": "openai_usage_user_date_model_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_feedback": {
+      "name": "session_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_score": {
+          "name": "overall_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strengths": {
+          "name": "strengths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "weaknesses": {
+          "name": "weaknesses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "answer_analyses": {
+          "name": "answer_analyses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "code_quality_score": {
+          "name": "code_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation_quality_score": {
+          "name": "explanation_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeline_analysis": {
+          "name": "timeline_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_consistency_score": {
+          "name": "gaze_consistency_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_distribution": {
+          "name": "gaze_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_coverage": {
+          "name": "gaze_coverage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_timeline": {
+          "name": "gaze_timeline",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drift_analysis": {
+          "name": "drift_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_tier": {
+          "name": "analysis_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_feedback_session_id_interview_sessions_id_fk": {
+          "name": "session_feedback_session_id_interview_sessions_id_fk",
+          "tableFrom": "session_feedback",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_templates": {
+      "name": "session_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "interview_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_templates_user_id_users_id_fk": {
+          "name": "session_templates_user_id_users_id_fk",
+          "tableFrom": "session_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_stories": {
+      "name": "star_stories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_questions": {
+          "name": "expected_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "situation": {
+          "name": "situation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_stories_user_id_users_id_fk": {
+          "name": "star_stories_user_id_users_id_fk",
+          "tableFrom": "star_stories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.star_story_analyses": {
+      "name": "star_story_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "story_id": {
+          "name": "story_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scores": {
+          "name": "scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "star_story_analyses_story_id_star_stories_id_fk": {
+          "name": "star_story_analyses_story_id_star_stories_id_fk",
+          "tableFrom": "star_story_analyses",
+          "tableTo": "star_stories",
+          "columnsFrom": [
+            "story_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transcripts": {
+      "name": "transcripts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entries": {
+          "name": "entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcripts_session_id_interview_sessions_id_fk": {
+          "name": "transcripts_session_id_interview_sessions_id_fk",
+          "tableFrom": "transcripts",
+          "tableTo": "interview_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_badge_unique": {
+          "name": "user_badge_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "badge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_resumes": {
+      "name": "user_resumes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "structured_data": {
+          "name": "structured_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_resumes_user_id_users_id_fk": {
+          "name": "user_resumes_user_id_users_id_fk",
+          "tableFrom": "user_resumes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "user_plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_start": {
+          "name": "plan_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_period_end": {
+          "name": "plan_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "past_due_at": {
+          "name": "past_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gaze_tracking_enabled": {
+          "name": "gaze_tracking_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tour_completed_at": {
+          "name": "tour_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tour_skipped_at": {
+          "name": "tour_skipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.code_event_type": {
+      "name": "code_event_type",
+      "schema": "public",
+      "values": [
+        "edit",
+        "run",
+        "submit"
+      ]
+    },
+    "public.interview_type": {
+      "name": "interview_type",
+      "schema": "public",
+      "values": [
+        "behavioral",
+        "technical"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "configuring",
+        "in_progress",
+        "completed",
+        "cancelled",
+        "failed"
+      ]
+    },
+    "public.user_plan": {
+      "name": "user_plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "max"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1776900010028,
       "tag": "0019_public_shatterstar",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1776931874212,
+      "tag": "0020_outgoing_apocalypse",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/hint-prompt.test.ts
+++ b/apps/web/lib/hint-prompt.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { buildHintPrompt, HINT_SYSTEM_PROMPT } from "./hint-prompt";
+
+describe("buildHintPrompt", () => {
+  const base = {
+    problemTitle: "Two Sum",
+    problemDescription: "Given an array of integers, return indices of two numbers that add up to a target.",
+    code: "def two_sum(nums, target):\n    pass",
+    language: "python",
+    priorHints: [] as string[],
+  };
+
+  it("system prompt contains NEVER and code in prohibition context", () => {
+    const { systemPrompt } = buildHintPrompt(base);
+    expect(systemPrompt).toContain("NEVER");
+    // "NEVER write code" — check both words appear in the prompt
+    expect(systemPrompt.toLowerCase()).toContain("code");
+  });
+
+  it("system prompt prohibits code fences/blocks", () => {
+    const { systemPrompt } = buildHintPrompt(base);
+    expect(systemPrompt).toMatch(/code fences|code blocks/i);
+  });
+
+  it("user message includes problem title", () => {
+    const { userMessage } = buildHintPrompt(base);
+    expect(userMessage).toContain("Two Sum");
+  });
+
+  it("user message includes problem description", () => {
+    const { userMessage } = buildHintPrompt(base);
+    expect(userMessage).toContain("Given an array of integers");
+  });
+
+  it("user message includes current code and language", () => {
+    const { userMessage } = buildHintPrompt(base);
+    expect(userMessage).toContain("python");
+    expect(userMessage).toContain("def two_sum(nums, target):");
+  });
+
+  it("user message has no 'Prior hints' section when priorHints is empty", () => {
+    const { userMessage } = buildHintPrompt({ ...base, priorHints: [] });
+    expect(userMessage).not.toContain("Prior hints given");
+  });
+
+  it("user message includes numbered prior hints when priorHints is non-empty", () => {
+    const { userMessage } = buildHintPrompt({
+      ...base,
+      priorHints: ["Think about hash maps.", "Consider time complexity."],
+    });
+    expect(userMessage).toContain("Prior hints given");
+    expect(userMessage).toContain("1. Think about hash maps.");
+    expect(userMessage).toContain("2. Consider time complexity.");
+  });
+
+  it("returns the canonical HINT_SYSTEM_PROMPT constant", () => {
+    const { systemPrompt } = buildHintPrompt(base);
+    expect(systemPrompt).toBe(HINT_SYSTEM_PROMPT);
+  });
+});

--- a/apps/web/lib/hint-prompt.ts
+++ b/apps/web/lib/hint-prompt.ts
@@ -1,0 +1,58 @@
+/**
+ * Hint prompt builder for technical interview coaching.
+ *
+ * Builds the system + user messages for a per-session LLM hint request.
+ * Pure function — no side effects, no I/O.
+ */
+
+export interface HintPromptInput {
+  /** Problem title shown to the candidate */
+  problemTitle: string;
+  /** Full problem description */
+  problemDescription: string;
+  /** Current code in the editor */
+  code: string;
+  /** Programming language label (e.g. "python", "javascript") */
+  language: string;
+  /** Hints already given this session, in order */
+  priorHints: string[];
+}
+
+export interface HintPromptResult {
+  systemPrompt: string;
+  userMessage: string;
+}
+
+export const HINT_SYSTEM_PROMPT =
+  "You are a senior software engineer coaching a candidate through a technical interview. " +
+  "Your role is strictly coaching — you must NEVER write code for the candidate, never provide " +
+  "near-complete implementations, and never include inline code fences or code blocks in your response. " +
+  "Hints should guide thinking, not give answers. Escalate specificity across hints: hint 1 is " +
+  "conceptual, hint 2 names a relevant pattern or data structure, hint 3 points at the specific " +
+  "step the candidate is stuck on — still without code.";
+
+export function buildHintPrompt({
+  problemTitle,
+  problemDescription,
+  code,
+  language,
+  priorHints,
+}: HintPromptInput): HintPromptResult {
+  const priorHintsSection =
+    priorHints.length > 0
+      ? "\n\nPrior hints given:\n" +
+        priorHints.map((h, i) => `${i + 1}. ${h}`).join("\n")
+      : "";
+
+  const userMessage =
+    `Problem: ${problemTitle}\n\n` +
+    `Description: ${problemDescription}\n\n` +
+    `Current code (${language}):\n${code}` +
+    priorHintsSection +
+    "\n\nPlease provide the next coaching hint.";
+
+  return {
+    systemPrompt: HINT_SYSTEM_PROMPT,
+    userMessage,
+  };
+}

--- a/apps/web/lib/plans.ts
+++ b/apps/web/lib/plans.ts
@@ -61,6 +61,8 @@ export interface PlanLimits {
   dailySessions: number;
   /** Maximum Pro-tier analysis runs per billing period. 0 = not available on this plan. */
   proAnalysisMonthly: number;
+  /** Maximum LLM-generated hints per technical session. */
+  hintsPerSession: number;
 }
 
 export interface PlanDefinition {
@@ -83,6 +85,16 @@ export const FREE_PLAN_MONTHLY_INTERVIEW_LIMIT = 3;
 export const PRO_PLAN_MONTHLY_INTERVIEW_LIMIT = 40;
 export const PRO_ANALYSIS_MONTHLY_LIMIT = 10;
 
+export const FREE_HINTS_PER_SESSION = 1;
+export const PRO_HINTS_PER_SESSION = 3;
+
+/**
+ * Returns the number of LLM-generated hints allowed per technical session for the given plan.
+ */
+export function getHintLimit(plan: Plan): number {
+  return plan === "pro" ? PRO_HINTS_PER_SESSION : FREE_HINTS_PER_SESSION;
+}
+
 export const PLAN_DEFINITIONS: Record<Plan, PlanDefinition> = {
   free: {
     id: "free",
@@ -96,6 +108,7 @@ export const PLAN_DEFINITIONS: Record<Plan, PlanDefinition> = {
       monthlyInterviews: FREE_PLAN_MONTHLY_INTERVIEW_LIMIT,
       dailySessions: 3,
       proAnalysisMonthly: 0,
+      hintsPerSession: FREE_HINTS_PER_SESSION,
     },
   },
   pro: {
@@ -114,6 +127,7 @@ export const PLAN_DEFINITIONS: Record<Plan, PlanDefinition> = {
       monthlyInterviews: PRO_PLAN_MONTHLY_INTERVIEW_LIMIT,
       dailySessions: 40,
       proAnalysisMonthly: PRO_ANALYSIS_MONTHLY_LIMIT,
+      hintsPerSession: PRO_HINTS_PER_SESSION,
     },
   },
 };

--- a/apps/web/lib/schema.ts
+++ b/apps/web/lib/schema.ts
@@ -142,6 +142,8 @@ export const interviewSessions = pgTable("interview_sessions", {
     { onDelete: "set null" }
   ),
   useProAnalysis: boolean("use_pro_analysis").notNull().default(false),
+  hintsUsed: integer("hints_used").notNull().default(0),
+  hintsGiven: jsonb("hints_given").$type<Array<{ text: string }>>().notNull().default([]),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),


### PR DESCRIPTION
## Summary

- Adds a per-session coaching hint system for technical interviews: Free users get 1 hint, Pro users get 3, enforced server-side with an optimistic-lock race guard.
- New `POST /api/sessions/[id]/hints` route calls OpenAI (configurable via `HINT_MODEL` env var, default `gpt-5.4-mini`) and atomically persists each hint to `hints_used` / `hints_given` columns (migration `0020_outgoing_apocalypse.sql`).
- `HintButton` and `HintPanel` components integrate into `TechnicalSessionLayout` via render-prop slots. The client syncs `hintsUsed` from 429 error bodies to handle concurrent-request races gracefully.
- Pro users get MORE hints, not a BETTER model — dedicated `HINT_MODEL` env var keeps hints fast and cheap regardless of plan. Cedar `<Sparkles>` affordance on the button for Pro users with hints remaining.
- Prompt design explicitly forbids code snippets; prior hints are included so the agent escalates rather than repeats. Optimistic-lock UPDATE (`WHERE hints_used = <old>`) prevents double-submit races from burning multiple quota slots.

## Implements

Story #196 — Dynamic coaching hints for technical sessions.

## Note on pre-existing test failure

The `PersonaPicker.test.tsx` intermittent flake is inherited from PR #179 (`feature/179-personas`). It is **not caused by this branch** — no `PersonaPicker` file is modified in this diff.

## Test plan

- [x] Unit tests pass (`hint-prompt.test.ts`: 8 cases covering prompt design, prior-hints inclusion, no-code-snippets directive)
- [x] Component tests pass (`HintPanel.test.tsx`: 8 cases, `HintButton.test.tsx`: 7 cases)
- [x] Integration tests pass (`hints/route.integration.test.ts`: 9 cases — auth, authz 404, behavioral 400, validation 400, free/pro happy paths with DB persistence, quota exhaustion 429, prior-hints in prompt payload)
- [x] Lint clean + typecheck clean (1083 unit+component + 424 integration all green)
- [x] Additive-only migration (`ALTER TABLE` with `DEFAULT` values; no destructive ops; whole `drizzle/` dir staged)
- [x] All routes: `auth()` + 401, ownership 404, Zod-validated input, `createRequestLogger` (no `console.log` server-side), lazy OpenAI init inside handler
- [x] 429 response carries `{ error, hintsUsed, hintsRemaining }` so the client can sync on race conditions
- [x] `role="status" aria-live="polite"` on error banner; `aria-live="polite"` on hint list for screen-reader announcement
- [ ] Reviewer approves
- [ ] Manual sanity check: request hint mid-session on free account, verify upgrade nudge appears after 1st hint; repeat on pro account up to 3rd hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)