### PR TITLE
fix(hints): use max_completion_tokens for gpt-5.x compatibility

### DIFF
--- a/apps/web/app/api/sessions/[id]/hints/route.ts
+++ b/apps/web/app/api/sessions/[id]/hints/route.ts
@@ -125,7 +125,7 @@ export async function POST(
         { role: "system", content: systemPrompt },
         { role: "user", content: userMessage },
       ],
-      max_tokens: 300,
+      max_completion_tokens: 300,
       temperature: 0.4,
     });
     hintText = completion.choices[0]?.message?.content ?? "";


### PR DESCRIPTION
## Summary

Production hotfix for the hint generation endpoint shipped in PR #203.

OpenAI rejects `max_tokens` on gpt-5.x models (`HINT_MODEL` defaults to `gpt-5.4-mini`):

```
400 Unsupported parameter: 'max_tokens' is not supported with this model.
Use 'max_completion_tokens' instead.
```

One-line rename in `apps/web/app/api/sessions/[id]/hints/route.ts:128`:
- `max_tokens: 300` → `max_completion_tokens: 300`

Grepped the rest of `apps/web/` — this was the only remaining `max_tokens` usage.

## Test plan

- [x] `eslint` clean on the touched file
- [x] 9 integration tests for `/api/sessions/[id]/hints` pass (the test did not assert on the param name)
- [ ] Reviewer approves
- [ ] Deploy and confirm the prod log stops showing `unsupported_parameter` on hint requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)