### PR TITLE
fix(session): prevent infinite load when End Session clicked before init

### DIFF
--- a/apps/web/app/api/sessions/[id]/feedback/route.integration.test.ts
+++ b/apps/web/app/api/sessions/[id]/feedback/route.integration.test.ts
@@ -305,10 +305,10 @@ describe("API /api/sessions/[id]/feedback (integration)", () => {
     expect(res.status).toBe(404);
   });
 
-  it("POST returns 400 when no transcript exists", async () => {
+  it("POST returns 200 { status: 'empty' } when no transcript exists", async () => {
     mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
 
-    // Create a session without a transcript
+    // Create a session without a transcript — simulates ending before init
     const db = getTestDb();
     const [noTranscriptSession] = await db
       .insert(interviewSessions)
@@ -319,9 +319,37 @@ describe("API /api/sessions/[id]/feedback (integration)", () => {
       makePostRequest(noTranscriptSession.id),
       makeParams(noTranscriptSession.id)
     );
-    expect(res.status).toBe(400);
+    // Returns 200 "empty" sentinel so the client polling loop can break and
+    // render a friendly "nothing to score" card instead of spinning forever.
+    expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.error).toMatch(/transcript/i);
+    expect(body.status).toBe("empty");
+  });
+
+  it("POST returns 200 { status: 'empty' } when transcript row has empty entries array", async () => {
+    mockAuth.mockResolvedValue({ user: { id: TEST_USER.id } });
+
+    // Create a session with a transcript row but with zero entries —
+    // this can happen if the transcript row was inserted before any speech
+    // was captured (e.g. via a race condition or partial save).
+    const db = getTestDb();
+    const [emptyEntriesSession] = await db
+      .insert(interviewSessions)
+      .values({ userId: TEST_USER.id, type: "behavioral", config: {} })
+      .returning();
+
+    await db.insert(transcripts).values({
+      sessionId: emptyEntriesSession.id,
+      entries: [],
+    });
+
+    const res = await POST(
+      makePostRequest(emptyEntriesSession.id),
+      makeParams(emptyEntriesSession.id)
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("empty");
   });
 
   it("POST returns existing feedback if already generated (idempotency)", async () => {

--- a/apps/web/app/api/sessions/[id]/feedback/route.ts
+++ b/apps/web/app/api/sessions/[id]/feedback/route.ts
@@ -126,10 +126,13 @@ export async function POST(
     .where(eq(transcripts.sessionId, id));
 
   if (!transcript || !Array.isArray(transcript.entries) || transcript.entries.length === 0) {
-    return NextResponse.json(
-      { error: "No transcript found for this session" },
-      { status: 400 }
-    );
+    // Session ended before any transcript was recorded (e.g. user hit End Session
+    // before the interviewer's first turn). Return a 200 "empty" sentinel so:
+    //   1. The feedback page polling loop can break on a 200 (it only retries on 404).
+    //   2. The client renders a friendly "nothing to score" card rather than spinning.
+    // A 400 would be semantically wrong here — the session just never started.
+    log.info({ sessionId: id }, "session has no transcript entries — returning empty sentinel");
+    return NextResponse.json({ status: "empty" }, { status: 200 });
   }
 
   // For technical sessions, also fetch code snapshots

--- a/apps/web/app/dashboard/sessions/[id]/feedback/page.tsx
+++ b/apps/web/app/dashboard/sessions/[id]/feedback/page.tsx
@@ -6,7 +6,8 @@ import { FeedbackDashboard } from "@/components/feedback/FeedbackDashboard";
 import type { TimelineEvent } from "@/components/feedback/TimelineView";
 import type { GazeDistribution, GazeTimelineBucket } from "@/lib/gaze-metrics";
 import Link from "next/link";
-import { ArrowLeft, Loader2, RefreshCw } from "lucide-react";
+import { ArrowLeft, Loader2, RefreshCw, MessageSquareOff } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
 
 interface DriftAnalysis {
   added: string[];
@@ -51,6 +52,10 @@ export default function FeedbackPage() {
   const [persona, setPersona] = useState<string | undefined>(undefined);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  // True when the server reports { status: "empty" } — session ended before
+  // any transcript was recorded. Renders a friendly empty-state card rather
+  // than the infinite loading spinner.
+  const [emptySession, setEmptySession] = useState(false);
   // Retry nonce — bumped by the Retry button to re-arm the polling effect
   // without a full page reload (which would drop scroll position and any
   // in-progress UI state).
@@ -98,6 +103,15 @@ export default function FeedbackPage() {
 
         const data = await res.json();
         if (cancelled) return;
+
+        // Server signals that the session ended before any transcript was
+        // recorded (e.g. End Session hit before the interviewer's first turn).
+        // Stop polling and show the empty-state card instead of spinning.
+        if (data.status === "empty") {
+          setIsLoading(false);
+          setEmptySession(true);
+          return;
+        }
 
         // Set sessionType and feedback in the same event handler so React 19
         // batches them into a single commit. This guarantees CodeQualityCard
@@ -233,6 +247,38 @@ export default function FeedbackPage() {
           <RefreshCw className="h-4 w-4" aria-hidden="true" />
           Try again
         </button>
+      </div>
+    );
+  }
+
+  if (emptySession) {
+    return (
+      <div className="mx-auto max-w-md py-24">
+        <Card className="text-center">
+          <CardContent className="flex flex-col items-center gap-4 pt-10 pb-8">
+            <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted">
+              <MessageSquareOff
+                className="h-7 w-7 text-muted-foreground"
+                aria-hidden="true"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <h2 className="text-lg font-semibold text-foreground">
+                Session never started
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                The session ended before any conversation was recorded — there&rsquo;s
+                nothing to score.
+              </p>
+            </div>
+            <Link
+              href="/dashboard"
+              className="mt-2 inline-flex h-11 items-center gap-2 rounded-md bg-primary px-5 text-sm font-medium text-primary-foreground motion-safe:transition-colors motion-safe:duration-[var(--duration-base)] hover:bg-primary/90"
+            >
+              Back to Dashboard
+            </Link>
+          </CardContent>
+        </Card>
       </div>
     );
   }

--- a/apps/web/app/interview/behavioral/session/page.tsx
+++ b/apps/web/app/interview/behavioral/session/page.tsx
@@ -312,6 +312,7 @@ export default function BehavioralSessionPage() {
         onMute={voice.mute}
         onUnmute={voice.unmute}
         onEndSession={handleEndSession}
+        sessionInitialized={voice.transcript.length > 0}
       />
     </div>
   );

--- a/apps/web/app/interview/technical/session/page.tsx
+++ b/apps/web/app/interview/technical/session/page.tsx
@@ -416,6 +416,12 @@ export default function TechnicalSessionPage() {
     </>
   );
 
+  // Session is initialized once the problem has been fetched and rendered
+  // (not still loading). While problemLoading is true or problem is null,
+  // the End Session button stays disabled so users can't land on the feedback
+  // page with an empty session — which would cause an infinite loading spinner.
+  const sessionInitialized = !problemLoading && problem !== null;
+
   return (
     <TechnicalSessionLayout
       problemPanel={problemPanel}
@@ -426,6 +432,7 @@ export default function TechnicalSessionPage() {
       onEndSession={handleEndSession}
       isProcessing={isProcessing}
       processingStep={processingStep}
+      sessionInitialized={sessionInitialized}
       hintButton={
         <>
           <HintButton

--- a/apps/web/components/interview/SessionControls.test.tsx
+++ b/apps/web/components/interview/SessionControls.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SessionControls } from "./SessionControls";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/interview/behavioral/session",
+}));
+
+function renderControls(props: Partial<Parameters<typeof SessionControls>[0]> = {}) {
+  return render(
+    <SessionControls
+      isConnected={true}
+      isMuted={false}
+      onMute={vi.fn()}
+      onUnmute={vi.fn()}
+      onEndSession={vi.fn()}
+      {...props}
+    />
+  );
+}
+
+describe("SessionControls — End Session button gate", () => {
+  it("shows 'Starting session…' microcopy when sessionInitialized is false", () => {
+    renderControls({ sessionInitialized: false });
+    const elements = screen.getAllByText(/starting session/i);
+    expect(elements.length).toBeGreaterThan(0);
+  });
+
+  it("marks the element as aria-disabled when sessionInitialized is false", () => {
+    renderControls({ sessionInitialized: false });
+    const btn = screen.getByRole("button", { name: /starting session/i });
+    expect(btn.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("shows 'End Session' button (not disabled) when sessionInitialized is true", () => {
+    renderControls({ sessionInitialized: true });
+    const endBtn = screen.getByRole("button", { name: /end session/i });
+    expect(endBtn.getAttribute("aria-disabled")).toBeNull();
+  });
+
+  it("shows confirm dialog when End Session is clicked and session is initialized", () => {
+    renderControls({ sessionInitialized: true });
+    const endBtn = screen.getByRole("button", { name: /end session/i });
+    fireEvent.click(endBtn);
+    const confirmElements = screen.getAllByText(/end interview\?/i);
+    expect(confirmElements.length).toBeGreaterThan(0);
+  });
+
+  it("does not show confirm dialog when clicking the disabled span (not initialized)", () => {
+    renderControls({ sessionInitialized: false });
+    const disabledEl = screen.getByRole("button", { name: /starting session/i });
+    fireEvent.click(disabledEl);
+    expect(screen.queryByText(/end interview\?/i)).toBeNull();
+  });
+
+  it("defaults sessionInitialized to true (backward compatibility)", () => {
+    renderControls({}); // no sessionInitialized prop
+    const endBtn = screen.getByRole("button", { name: /end session/i });
+    expect(endBtn.getAttribute("aria-disabled")).toBeNull();
+  });
+});

--- a/apps/web/components/interview/SessionControls.tsx
+++ b/apps/web/components/interview/SessionControls.tsx
@@ -9,6 +9,14 @@ interface SessionControlsProps {
   onMute: () => void;
   onUnmute: () => void;
   onEndSession: () => void;
+  /**
+   * Whether the session has fully initialized (first interviewer turn delivered).
+   * Defaults to true for backward compatibility. When false, the End Session
+   * button is visually disabled with "Starting session…" microcopy so users
+   * can't end before the interview kicks off (which would produce an empty
+   * transcript and infinite-load on the feedback page).
+   */
+  sessionInitialized?: boolean;
 }
 
 export function SessionControls({
@@ -17,6 +25,7 @@ export function SessionControls({
   onMute,
   onUnmute,
   onEndSession,
+  sessionInitialized = true,
 }: SessionControlsProps) {
   const [elapsed, setElapsed] = useState(0);
   const [showConfirm, setShowConfirm] = useState(false);
@@ -101,6 +110,18 @@ export function SessionControls({
               Cancel
             </Button>
           </div>
+        ) : !sessionInitialized ? (
+          /* Disabled state — session still initializing. Rendered as a styled
+             span (not a button) so the browser never fires a click event, but
+             with aria-disabled + role="button" so screen readers still announce
+             it as a disabled button. min-h/min-w keep the 44×44 touch target. */
+          <span
+            role="button"
+            aria-disabled="true"
+            className="inline-flex min-h-[44px] min-w-[44px] cursor-not-allowed items-center gap-1.5 rounded-md border border-destructive/30 bg-destructive/5 px-3 text-sm font-medium text-destructive/50 opacity-60 motion-safe:transition-opacity motion-safe:duration-[var(--duration-base)]"
+          >
+            Starting session…
+          </span>
         ) : (
           <Button variant="destructive" size="sm" onClick={handleEndClick}>
             End Session

--- a/apps/web/components/interview/TechnicalSessionLayout.test.tsx
+++ b/apps/web/components/interview/TechnicalSessionLayout.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TechnicalSessionLayout } from "./TechnicalSessionLayout";
+
+// Mock next/navigation — TechnicalSessionLayout itself doesn't use the router
+// but the shared Button component may pull in route context on some versions.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/interview/technical/session",
+}));
+
+function renderLayout(props: Partial<Parameters<typeof TechnicalSessionLayout>[0]> = {}) {
+  return render(
+    <TechnicalSessionLayout
+      problemPanel={<div>Problem content</div>}
+      editorPanel={<div>Editor content</div>}
+      micIndicator={<div>Mic</div>}
+      onEndSession={vi.fn()}
+      isProcessing={false}
+      {...props}
+    />
+  );
+}
+
+describe("TechnicalSessionLayout — End Session button gate", () => {
+  it("shows 'Starting session…' microcopy when sessionInitialized is false", () => {
+    renderLayout({ sessionInitialized: false });
+    const elements = screen.getAllByText(/starting session/i);
+    expect(elements.length).toBeGreaterThan(0);
+  });
+
+  it("marks the button as aria-disabled when sessionInitialized is false", () => {
+    renderLayout({ sessionInitialized: false });
+    const btn = screen.getByRole("button", { name: /starting session/i });
+    expect(btn.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("shows 'End Session' button (not disabled) when sessionInitialized is true", () => {
+    renderLayout({ sessionInitialized: true });
+    const endBtn = screen.getByRole("button", { name: /end session/i });
+    // Should be a real button without aria-disabled
+    expect(endBtn.getAttribute("aria-disabled")).toBeNull();
+  });
+
+  it("shows confirm dialog when End Session is clicked and session is initialized", () => {
+    renderLayout({ sessionInitialized: true });
+    const endBtn = screen.getByRole("button", { name: /end session/i });
+    fireEvent.click(endBtn);
+    const confirmElements = screen.getAllByText(/end interview\?/i);
+    expect(confirmElements.length).toBeGreaterThan(0);
+  });
+
+  it("does not show confirm dialog when clicking the disabled span (not initialized)", () => {
+    renderLayout({ sessionInitialized: false });
+    const disabledEl = screen.getByRole("button", { name: /starting session/i });
+    fireEvent.click(disabledEl);
+    expect(screen.queryByText(/end interview\?/i)).toBeNull();
+  });
+
+  it("defaults sessionInitialized to true (backward compatibility)", () => {
+    // When prop is omitted entirely, End Session button should be enabled
+    renderLayout({}); // no sessionInitialized prop
+    const endBtn = screen.getByRole("button", { name: /end session/i });
+    expect(endBtn.getAttribute("aria-disabled")).toBeNull();
+  });
+});

--- a/apps/web/components/interview/TechnicalSessionLayout.tsx
+++ b/apps/web/components/interview/TechnicalSessionLayout.tsx
@@ -20,6 +20,14 @@ interface TechnicalSessionLayoutProps {
   hintButton?: ReactNode;
   /** Optional hint panel overlay — rendered inside the right (editor) panel */
   hintPanel?: ReactNode;
+  /**
+   * Whether the session has fully initialized (problem fetched and rendered).
+   * Defaults to true for backward compatibility. When false, the End Session
+   * button is visually disabled with "Starting session…" microcopy so users
+   * can't end before a problem is populated (which would produce an empty
+   * transcript and infinite-load on the feedback page).
+   */
+  sessionInitialized?: boolean;
 }
 
 export function TechnicalSessionLayout({
@@ -31,6 +39,7 @@ export function TechnicalSessionLayout({
   processingStep,
   hintButton,
   hintPanel,
+  sessionInitialized = true,
 }: TechnicalSessionLayoutProps) {
   const [elapsed, setElapsed] = useState(0);
   const [showConfirm, setShowConfirm] = useState(false);
@@ -114,6 +123,19 @@ export function TechnicalSessionLayout({
                 Cancel
               </Button>
             </div>
+          ) : !sessionInitialized ? (
+            /* Disabled state — session still initializing. Rendered as a
+               styled span (not a button) so the browser never fires a click
+               event, but with aria-disabled + role="button" so screen readers
+               still announce it as a button that is disabled. min-h/min-w
+               keep the 44×44 touch target even in the disabled state. */
+            <span
+              role="button"
+              aria-disabled="true"
+              className="inline-flex min-h-[44px] min-w-[44px] cursor-not-allowed items-center gap-1.5 rounded-md border border-destructive/30 bg-destructive/5 px-3 text-sm font-medium text-destructive/50 opacity-60 motion-safe:transition-opacity motion-safe:duration-[var(--duration-base)]"
+            >
+              Starting session…
+            </span>
           ) : (
             <Button variant="destructive" size="sm" onClick={handleEndClick}>
               End Session


### PR DESCRIPTION
## Summary
- Gate the End Session button behind a `sessionInitialized` prop on both `SessionControls` and `TechnicalSessionLayout`; while false, renders an `aria-disabled` styled span with "Starting session…" microcopy that preserves the 44×44 touch target and cannot be clicked.
- Change the feedback API route to return `200 { status: "empty" }` instead of `400` when no transcript entries exist, so the client polling loop can break cleanly and render a "Session never started — nothing to score" empty-state card with a Back to Dashboard CTA.
- Add 12 new component tests (6 per layout) and 2 new integration test cases covering the empty-transcript sentinel path, including the edge case of a transcript row with an empty `entries` array.

## Implements
Fixes #205 — End Session before init causes feedback page infinite load

## Test plan
- [x] Unit / component tests pass (1126 + 12 new cases)
- [x] Integration tests pass (436 + 2 new cases)
- [x] E2E smoke suite passes (21 tests)
- [ ] Reviewer approves
- [ ] Author manually verifies: open a session, hit End Session immediately before the first interviewer turn, confirm "Session never started" card appears instead of a spinner

## Reviewer nits (follow-up, non-blocking)
PR-reviewer flagged two test-convention items: the new component tests use `vi.mock("next/navigation", ...)` without `vi.hoisted()`, and use `getByRole` in a couple of places where the codebase convention is `getAllByRole[0]` for shadcn-rendered components. Works today; worth aligning in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)