### PR TITLE
fix(session): match End Session disabled-state size to sm button

### DIFF
--- a/apps/web/components/interview/SessionControls.tsx
+++ b/apps/web/components/interview/SessionControls.tsx
@@ -111,14 +111,11 @@ export function SessionControls({
             </Button>
           </div>
         ) : !sessionInitialized ? (
-          /* Disabled state — session still initializing. Rendered as a styled
-             span (not a button) so the browser never fires a click event, but
-             with aria-disabled + role="button" so screen readers still announce
-             it as a disabled button. min-h/min-w keep the 44×44 touch target. */
+          // Styled to match Button size="sm" so the control doesn't visibly shrink when the session finishes initializing.
           <span
             role="button"
             aria-disabled="true"
-            className="inline-flex min-h-[44px] min-w-[44px] cursor-not-allowed items-center gap-1.5 rounded-md border border-destructive/30 bg-destructive/5 px-3 text-sm font-medium text-destructive/50 opacity-60 motion-safe:transition-opacity motion-safe:duration-[var(--duration-base)]"
+            className="inline-flex h-7 cursor-not-allowed items-center gap-1 rounded-[min(var(--radius-md),12px)] border border-destructive/30 bg-destructive/5 px-2.5 text-[0.8rem] font-medium text-destructive/50 opacity-60 motion-safe:transition-opacity motion-safe:duration-[var(--duration-base)]"
           >
             Starting session…
           </span>

--- a/apps/web/components/interview/TechnicalSessionLayout.tsx
+++ b/apps/web/components/interview/TechnicalSessionLayout.tsx
@@ -124,15 +124,11 @@ export function TechnicalSessionLayout({
               </Button>
             </div>
           ) : !sessionInitialized ? (
-            /* Disabled state — session still initializing. Rendered as a
-               styled span (not a button) so the browser never fires a click
-               event, but with aria-disabled + role="button" so screen readers
-               still announce it as a button that is disabled. min-h/min-w
-               keep the 44×44 touch target even in the disabled state. */
+            // Styled to match Button size="sm" so the control doesn't visibly shrink when the session finishes initializing.
             <span
               role="button"
               aria-disabled="true"
-              className="inline-flex min-h-[44px] min-w-[44px] cursor-not-allowed items-center gap-1.5 rounded-md border border-destructive/30 bg-destructive/5 px-3 text-sm font-medium text-destructive/50 opacity-60 motion-safe:transition-opacity motion-safe:duration-[var(--duration-base)]"
+              className="inline-flex h-7 cursor-not-allowed items-center gap-1 rounded-[min(var(--radius-md),12px)] border border-destructive/30 bg-destructive/5 px-2.5 text-[0.8rem] font-medium text-destructive/50 opacity-60 motion-safe:transition-opacity motion-safe:duration-[var(--duration-base)]"
             >
               Starting session…
             </span>


### PR DESCRIPTION
## Summary
Follow-up to #207. The "Starting session…" disabled span shipped with `min-h-[44px] min-w-[44px] gap-1.5 rounded-md px-3 text-sm` (~44px tall), but the real `<Button size="sm">` it replaces is `h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem]` (~28px). When the session finished initializing, the control shrank by ~60%, which read as a jarring layout jump.

This aligns the span's sizing to `Button size="sm"` exactly on both `SessionControls.tsx` and `TechnicalSessionLayout.tsx`. The state is transient and non-interactive (aria-disabled), so the 44×44 touch-target minimum isn't load-bearing here.

## Test plan
- [x] `npx turbo lint typecheck test` passes (1126 unit tests)
- [ ] Reviewer visually confirms: open a session, observe "Starting session…" at the same dimensions as "End Session" once init completes (no size jump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)